### PR TITLE
docs: add CLAUDE.md and expand README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@ go.work.sum
 .env
 
 # Editor/IDE
-# .idea/
-# .vscode/
+.idea/
+.vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+`file-search-on` is a Go CLI that recursively searches a directory and matches files against a [CEL](https://github.com/google/cel-spec) expression evaluated over file metadata and content-type-specific attributes (e.g. `is_pdf && page_count > 10`, `is_markdown && word_count > 500`).
+
+Module: `github.com/richardwooding/file-search-on`. Toolchain: Go 1.25.
+
+## Commands
+
+```sh
+go build ./...                                  # build all packages
+go build -o file-search-on ./cmd/file-search-on # build the CLI binary
+go test ./...                                   # run all tests
+go test -race -coverprofile=coverage.out ./...  # what CI runs
+go test ./internal/celexpr -run TestEvaluator   # run a single test (regex match)
+go vet ./...
+golangci-lint run                               # CI uses `latest` version
+```
+
+Run the CLI:
+
+```sh
+./file-search-on 'is_markdown && word_count > 100' -d ./docs
+./file-search-on --list   # list supported attributes & registered content types
+```
+
+If `Expr` is empty it defaults to `"true"` (matches all files). Worker count defaults to `runtime.NumCPU()` when `-w` is 0 or unset.
+
+## Architecture
+
+Three internal packages compose the pipeline. Read them together — they are tightly coupled by the `FileAttributes` shape:
+
+- **`internal/content`** — pluggable content-type detection. Each type (markdown, json, xml, html, pdf, image variants) implements the `ContentType` interface (`Name`, `Extensions`, `MagicBytes`, `Attributes(path)`) and self-registers via `init()` calling `content.Register(...)` on a package-global `defaultRegistry`. `Registry.Detect(path)` tries extension match first, then falls back to magic-byte sniffing on the first 512 bytes. `Attributes(path)` is called *per matching file* during the walk and returns a `map[string]interface{}` of type-specific fields.
+- **`internal/celexpr`** — wraps `cel-go`. `New(expr)` declares a fixed schema of CEL variables (the union of common file attributes + every type-specific attribute any content type might emit) and compiles the program once. `BuildAttributes(path, registry)` runs `os.Stat`, calls `registry.Detect`, then calls the matched type's `Attributes`, and packs everything into `FileAttributes`. `Evaluate` flattens that into a CEL activation, supplying zero values for type-specific vars when the matched type didn't produce them — this is required because cel-go errors on undeclared/unbound variables.
+- **`internal/search`** — `Walk` is the orchestrator. It compiles the CEL expression once, then fans out: a `filepath.WalkDir` producer feeds paths into a buffered channel; N workers (`Workers`, default `NumCPU`) pull paths, call `BuildAttributes` + `Evaluate`, and append matches under a single `sync.Mutex`. Directory traversal errors are swallowed (returning `nil` from the WalkDir func). `ctx` cancellation is checked only at the producer.
+
+The CLI (`cmd/file-search-on/main.go`) uses `kong` for argument parsing. The single `search` subcommand is the default. After `Walk` returns, results are sorted by path and printed as `<path>\t[<content-type>]\t<size> bytes`. The match count goes to stderr.
+
+### Adding a new content type
+
+1. Create a new file in `internal/content/` implementing the `ContentType` interface and call `Register(&yourType{})` from `init()`.
+2. If it introduces new attributes, declare matching `cel.Variable(...)` entries in `celexpr.New` **and** wire them in both the activation defaults map and the `attrs.Extra` switch in `Evaluate` (`internal/celexpr/evaluator.go`). Forgetting either side will produce CEL "no such attribute" errors at runtime.
+3. If it's an image-family type, also extend the `strings.HasPrefix(contentTypeName, "image/")` branch logic in `BuildAttributes` and add it to the `--list` output in `cmd/file-search-on/main.go:printHelp`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,119 @@
 # file-search-on
-File content type aware search with attribute and cel support
+
+**Content-type aware file search with CEL-powered attribute filtering.**
+
+`file-search-on` walks a directory tree and returns files matching a [CEL](https://github.com/google/cel-spec) expression evaluated over each file's metadata and content-type-specific attributes. Instead of grepping by name, you can ask things like *"all PDFs with more than 10 pages"* or *"all Markdown files over 500 words whose title starts with 'Draft'"*.
+
+## Features
+
+- **Pluggable content-type detection** — extension-first, with magic-byte fallback. Markdown, JSON, XML, HTML, PDF, and the common image formats (JPEG, PNG, GIF, WebP, SVG, TIFF, BMP) are supported out of the box.
+- **Rich, type-specific attributes** — page count and author for PDFs, title and word count for Markdown, root element for XML, dimensions for images, and more.
+- **CEL expressions** — the full Common Expression Language is available, so you can compose conditions naturally with `&&`, `||`, comparisons, string functions, and so on.
+- **Parallel walking** — files are evaluated across a configurable worker pool (defaults to the number of CPU cores).
+
+## Install
+
+Requires Go 1.25 or newer.
+
+```sh
+go install github.com/richardwooding/file-search-on/cmd/file-search-on@latest
+```
+
+Or build from a clone:
+
+```sh
+git clone https://github.com/richardwooding/file-search-on.git
+cd file-search-on
+go build -o file-search-on ./cmd/file-search-on
+```
+
+## Usage
+
+```sh
+file-search-on [EXPR] [-d DIR] [-w WORKERS]
+file-search-on --list
+```
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `EXPR` | CEL expression to match files against. | `true` (matches everything) |
+| `-d`, `--dir` | Directory to search. | `.` |
+| `-w`, `--workers` | Number of parallel workers. | number of CPU cores |
+| `-l`, `--list` | List supported attributes and registered content types. | |
+
+Each matching file is printed as `<path>\t[<content-type>]\t<size> bytes`. The match count is written to stderr so it doesn't pollute pipelines.
+
+## Examples
+
+Find all Markdown files larger than 500 words:
+
+```sh
+file-search-on 'is_markdown && word_count > 500' -d ./docs
+```
+
+Find PDFs with more than 10 pages, written by a specific author:
+
+```sh
+file-search-on 'is_pdf && page_count > 10 && author == "Jane Doe"'
+```
+
+Find all JSON files whose top-level value is an array:
+
+```sh
+file-search-on 'is_json && json_kind == "array"'
+```
+
+Find images wider than 1920 pixels:
+
+```sh
+file-search-on 'is_image && img_width > 1920' -d ~/Pictures
+```
+
+Combine paths and types — find HTML files inside a `build/` directory:
+
+```sh
+file-search-on 'is_html && dir.contains("build")'
+```
+
+## Available attributes
+
+Common attributes (always present):
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `name` | string | Filename |
+| `path` | string | Full path |
+| `dir` | string | Parent directory |
+| `size` | int | File size in bytes |
+| `ext` | string | File extension, e.g. `.md` |
+| `content_type` | string | Detected content type |
+| `is_markdown`, `is_json`, `is_xml`, `is_html`, `is_pdf`, `is_image` | bool | Type predicates |
+
+Type-specific attributes (zero-valued when not applicable):
+
+| Attribute | Type | Source |
+| --- | --- | --- |
+| `title` | string | Markdown H1, HTML `<title>`, or PDF metadata |
+| `word_count` | int | Markdown |
+| `page_count` | int | PDF |
+| `author` | string | PDF |
+| `root_element` | string | XML |
+| `json_kind` | string | `"object"` or `"array"` |
+| `img_width`, `img_height` | int | Image dimensions in pixels |
+
+Run `file-search-on --list` to see the full, up-to-date list along with the registered content types.
+
+## Development
+
+```sh
+go build ./...                                  # build everything
+go test -race -coverprofile=coverage.out ./...  # run the test suite
+go vet ./...
+golangci-lint run
+```
+
+The codebase has three internal packages: `internal/content` (the pluggable type registry), `internal/celexpr` (the CEL evaluator and attribute builder), and `internal/search` (the parallel walker). See [CLAUDE.md](./CLAUDE.md) for an architecture overview and a step-by-step guide to adding a new content type.
+
+## License
+
+[MIT](./LICENSE)


### PR DESCRIPTION
## Summary

- Replace the two-line README with installation steps, a usage table, an attribute reference, and worked CEL examples (Markdown word count, PDF author, JSON kind, image dimensions, path filtering).
- Add `CLAUDE.md` describing the `internal/content` → `internal/celexpr` → `internal/search` pipeline and a step-by-step checklist for registering a new content type, since that change spans all three packages and the CEL variable schema must be updated in lockstep.

## Test plan

- [ ] Render README on GitHub and confirm tables, code blocks, and links display correctly.
- [ ] Verify the example CEL expressions (\`is_markdown && word_count > 500\`, \`is_pdf && page_count > 10\`, \`is_image && img_width > 1920\`) actually run against a sample directory.
- [ ] Confirm \`file-search-on --list\` output still matches the attributes documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)