### PR TITLE
chore: bump to Go 1.26.2, apply go fix modernizers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26.2"
           cache: true
       - name: Download dependencies
         run: go mod download
@@ -24,6 +24,10 @@ jobs:
         run: go build ./...
       - name: Vet
         run: go vet ./...
+      - name: Verify go fix is clean
+        run: |
+          go fix ./...
+          git diff --exit-code
       - name: Test
         run: go test -race -coverprofile=coverage.out ./...
 
@@ -36,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26.2"
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 `file-search-on` is a Go CLI that recursively searches a directory and matches files against a [CEL](https://github.com/google/cel-spec) expression evaluated over file metadata and content-type-specific attributes (e.g. `is_pdf && page_count > 10`, `is_markdown && word_count > 500`).
 
-Module: `github.com/richardwooding/file-search-on`. Toolchain: Go 1.25.
+Module: `github.com/richardwooding/file-search-on`. Toolchain: Go 1.26.2.
 
 ## Commands
 
@@ -17,8 +17,22 @@ go test ./...                                   # run all tests
 go test -race -coverprofile=coverage.out ./...  # what CI runs
 go test ./internal/celexpr -run TestEvaluator   # run a single test (regex match)
 go vet ./...
+go fix -diff ./...                              # preview Go 1.26 modernizers (see below)
+go fix ./...                                    # apply them
 golangci-lint run                               # CI uses `latest` version
 ```
+
+### `go fix` (Go 1.26+ modernizers)
+
+Go 1.26 reintroduced `go fix` as a code-modernization tool — it rewrites code to use newer language and stdlib features (e.g. `slices.Contains`, `any`, `min`/`max`, `range` over an integer, `sync.WaitGroup.Go`). See [the announcement](https://go.dev/blog/gofix) for the full set of fixers.
+
+CI runs `go fix ./... && git diff --exit-code` after the build step, so any unapplied modernizer will fail the pipeline. Workflow:
+
+1. Make sure the working tree is clean (`go fix` edits should be a separate commit from feature work).
+2. Run `go fix -diff ./...` to preview, or `go fix ./...` to apply. Re-run until idempotent — applying one fix can unlock another.
+3. `go test ./...` afterwards; semantic conflicts may need a manual touch-up.
+
+Use `go tool fix help` to list fixers and `go tool fix help <name>` for details on a specific one.
 
 Run the CLI:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Install
 
-Requires Go 1.25 or newer.
+Requires Go 1.26.2 or newer.
 
 ```sh
 go install github.com/richardwooding/file-search-on/cmd/file-search-on@latest
@@ -109,10 +109,23 @@ Run `file-search-on --list` to see the full, up-to-date list along with the regi
 go build ./...                                  # build everything
 go test -race -coverprofile=coverage.out ./...  # run the test suite
 go vet ./...
+go fix ./...                                    # apply Go 1.26 modernizers — see below
 golangci-lint run
 ```
 
 The codebase has three internal packages: `internal/content` (the pluggable type registry), `internal/celexpr` (the CEL evaluator and attribute builder), and `internal/search` (the parallel walker). See [CLAUDE.md](./CLAUDE.md) for an architecture overview and a step-by-step guide to adding a new content type.
+
+### Keeping the code modern with `go fix`
+
+Go 1.26 reintroduced [`go fix`](https://go.dev/blog/gofix) as a code-modernization tool that rewrites your sources to use newer language and standard-library features (`slices.Contains`, `any`, `min`/`max`, `range` over integers, `sync.WaitGroup.Go`, and more).
+
+```sh
+go fix -diff ./...   # preview the changes
+go fix ./...         # apply them
+go tool fix help     # list every available fixer
+```
+
+CI runs `go fix ./... && git diff --exit-code` after every build, so the project stays idiomatic for whichever Go release the toolchain is pinned to. After bumping the Go version, run `go fix ./...` from a clean working tree and commit the result on its own.
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/richardwooding/file-search-on
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/alecthomas/kong v1.15.0

--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -79,7 +79,7 @@ func New(expr string) (*Evaluator, error) {
 
 // Evaluate evaluates the expression against the given file attributes
 func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
-	activation := map[string]interface{}{
+	activation := map[string]any{
 		"name":         attrs.Name,
 		"path":         attrs.Path,
 		"dir":          attrs.Dir,

--- a/internal/content/detector.go
+++ b/internal/content/detector.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -16,17 +17,15 @@ func (r *Registry) Detect(path string) ContentType {
 
 	ext := strings.ToLower(filepath.Ext(path))
 	for _, ct := range types {
-		for _, e := range ct.Extensions() {
-			if e == ext {
-				return ct
-			}
+		if slices.Contains(ct.Extensions(), ext) {
+			return ct
 		}
 	}
 	f, err := os.Open(path)
 	if err != nil {
 		return nil
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	buf := make([]byte, 512)
 	n, _ := f.Read(buf)
 	buf = buf[:n]

--- a/internal/content/htmltype.go
+++ b/internal/content/htmltype.go
@@ -30,7 +30,7 @@ func (h *htmlType) Attributes(path string) (Attributes, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var sb strings.Builder
 	scanner := bufio.NewScanner(f)

--- a/internal/content/imagetype.go
+++ b/internal/content/imagetype.go
@@ -48,7 +48,7 @@ func decodeImageConfig(path string) (int, int, error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	cfg, _, err := image.DecodeConfig(f)
 	if err != nil {
 		return 0, 0, err

--- a/internal/content/jsontype.go
+++ b/internal/content/jsontype.go
@@ -27,7 +27,7 @@ func (j *jsonType) Attributes(path string) (Attributes, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	decoder := json.NewDecoder(f)
 	tok, err := decoder.Token()
@@ -36,9 +36,10 @@ func (j *jsonType) Attributes(path string) (Attributes, error) {
 	}
 	kind := "unknown"
 	if d, ok := tok.(json.Delim); ok {
-		if d == '{' {
+		switch d {
+		case '{':
 			kind = "object"
-		} else if d == '[' {
+		case '[':
 			kind = "array"
 		}
 	}

--- a/internal/content/markdown.go
+++ b/internal/content/markdown.go
@@ -23,7 +23,7 @@ func (m *markdownType) Attributes(path string) (Attributes, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var title string
 	var wordCount int

--- a/internal/content/types.go
+++ b/internal/content/types.go
@@ -3,7 +3,7 @@ package content
 import "sync"
 
 // Attributes is a map of attribute name to value for CEL evaluation
-type Attributes map[string]interface{}
+type Attributes map[string]any
 
 // ContentType represents a detectable file content type
 type ContentType interface {

--- a/internal/content/xmltype.go
+++ b/internal/content/xmltype.go
@@ -26,7 +26,7 @@ func (x *xmlType) Attributes(path string) (Attributes, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	decoder := xml.NewDecoder(f)
 	var rootElement string

--- a/internal/search/walker.go
+++ b/internal/search/walker.go
@@ -42,9 +42,7 @@ func Walk(ctx context.Context, opts Options, registry *content.Registry) ([]Resu
 	var wg sync.WaitGroup
 
 	for i := 0; i < opts.Workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for path := range paths {
 				attrs, err := celexpr.BuildAttributes(path, registry)
 				if err != nil {
@@ -62,7 +60,7 @@ func Walk(ctx context.Context, opts Options, registry *content.Registry) ([]Resu
 				})
 				mu.Unlock()
 			}
-		}()
+		})
 	}
 
 	walkErr := filepath.WalkDir(opts.Root, func(path string, d fs.DirEntry, err error) error {


### PR DESCRIPTION
## Summary

- Bumps the toolchain to **Go 1.26.2** in both `go.mod` and the `setup-go` step in CI.
- Applies the Go 1.26 [`go fix`](https://go.dev/blog/gofix) modernizers across `internal/`: `slices.Contains` for the extension lookup in the detector, `interface{}` → `any` in the attribute/activation maps, and `sync.WaitGroup.Go` for the search worker pool.
- Adds a CI step (`go fix ./... && git diff --exit-code`) so future toolchain bumps that introduce new modernizers fail fast instead of drifting.
- Documents the `go fix` workflow in **README.md** and **CLAUDE.md** with a link to https://go.dev/blog/gofix.
- Cleans up the lint issues surfaced by the upgraded **golangci-lint v2.12.1**:
  - `errcheck` on `defer f.Close()` for read-only file handles in `detector.go`, `markdown.go`, `htmltype.go`, `jsontype.go`, `xmltype.go`, `imagetype.go` — wrapped in `defer func() { _ = f.Close() }()` to make the discard explicit.
  - staticcheck `QF1003` if/else chain in the JSON delimiter detection rewritten as a tagged `switch`.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean on Go 1.26.2.
- [x] `go test -race ./...` passes.
- [x] `go fix -diff ./...` is empty (idempotent).
- [x] `golangci-lint run ./...` reports `0 issues` on v2.12.1.
- [ ] CI green on the new `Verify go fix is clean` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)