### PR TITLE
chore: tag-driven releases (GoReleaser v2 + ko + Homebrew cask)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.2"
+          cache: true
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ go.work.sum
 
 # Claude Code per-user settings (skills under .claude/skills/ are shared)
 .claude/settings.local.json
+
+# GoReleaser local snapshot output
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,96 @@
+version: 2
+
+project_name: file-search-on
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: file-search-on
+    main: ./cmd/file-search-on
+    binary: file-search-on
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^test:"
+      - Merge pull request
+      - Merge branch
+  groups:
+    - title: Features
+      regexp: '^feat(\(.+\))?!?:'
+      order: 0
+    - title: Bug fixes
+      regexp: '^fix(\(.+\))?!?:'
+      order: 1
+    - title: Others
+      order: 999
+
+kos:
+  - id: file-search-on
+    build: file-search-on
+    repositories:
+      - ghcr.io/richardwooding/file-search-on
+    base_image: cgr.dev/chainguard/static
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    tags:
+      - "{{.Version}}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+    sbom: spdx
+    bare: true
+    preserve_import_paths: false
+    labels:
+      org.opencontainers.image.source: "https://github.com/richardwooding/file-search-on"
+      org.opencontainers.image.licenses: "MIT"
+      org.opencontainers.image.description: "Content-type aware file search with CEL"
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.revision: "{{.Commit}}"
+
+homebrew_casks:
+  - name: file-search-on
+    binaries:
+      - file-search-on
+    repository:
+      owner: richardwooding
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew cask update for {{ .ProjectName }} {{ .Tag }}"
+    homepage: "https://github.com/richardwooding/file-search-on"
+    description: "Content-type aware file search with CEL attribute filtering"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,39 @@ Three internal packages compose the pipeline. Read them together — they are ti
 
 The CLI (`cmd/file-search-on/main.go`) uses `kong` for argument parsing. The single `search` subcommand is the default. After `Walk` returns, results are sorted by path and printed as `<path>\t[<content-type>]\t<size> bytes`. The match count goes to stderr.
 
+### Releases
+
+Releases are tag-driven. Pushing a tag matching `v*` to `origin` triggers `.github/workflows/release.yml`, which runs **GoReleaser v2** (pinned `~> v2`, currently v2.15.4) and produces three artifacts in one shot:
+
+1. **GitHub Release** with archives for `linux`/`darwin`/`windows` × `amd64`/`arm64` (six total — `.tar.gz` for unix, `.zip` for windows) plus `checksums.txt`. Binaries are stamped with `version`/`commit`/`date` via `-ldflags -X`; `./file-search-on --version` reads them back.
+2. **OCI image** at `ghcr.io/richardwooding/file-search-on:<version>` (and `:latest` for non-prerelease tags), built by `ko` from the same `builds:` block. Linux only — `amd64` + `arm64` manifests. Base image is `cgr.dev/chainguard/static` (no shell). Image labels follow OCI annotation conventions.
+3. **Homebrew cask** committed to [`richardwooding/homebrew-tap`](https://github.com/richardwooding/homebrew-tap) at `Casks/file-search-on.rb`. Install path is `brew install richardwooding/tap/file-search-on`.
+
+Notes for future agents:
+
+- The config uses **`homebrew_casks`**, not `brews`. `brews` was deprecated in GoReleaser v2.10; we deliberately picked the modern key. The cask form handles macOS-intel/macOS-arm/Linux-intel/Linux-arm splits via Homebrew's `on_macos`/`on_linux` DSL — works fine for CLI binaries even though casks were originally for GUI apps.
+- ko publishes via [`go-containerregistry`](https://github.com/google/go-containerregistry); no Docker daemon is required on the runner. The workflow logs into `ghcr.io` with the workflow's auto-issued `GITHUB_TOKEN` (so `permissions: packages: write` is mandatory in the workflow).
+- Pushing the cask to a *different* repo (`richardwooding/homebrew-tap`) requires a Personal Access Token with content write on that tap, exposed as the repo secret `HOMEBREW_TAP_GITHUB_TOKEN`. The default `GITHUB_TOKEN` is scoped to the source repo only.
+- The first-ever release also needs the `ghcr.io/richardwooding/file-search-on` package's visibility flipped to public manually in GitHub package settings — otherwise `docker pull` requires auth.
+
+#### Local dry-run
+
+```sh
+goreleaser check                                          # validate the YAML
+goreleaser release --snapshot --clean --skip=publish      # builds dist/, no push
+```
+
+The snapshot run will *try* to load OCI images into the local Docker daemon and fail if there isn't one — that's expected on a dev machine and irrelevant for CI. Add `--skip=ko` to bypass it. `dist/` is gitignored.
+
+#### Cutting a release
+
+```sh
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Then watch the **Release** workflow in GitHub Actions. To roll back a botched release: delete the tag (`git push origin :refs/tags/vX.Y.Z`), delete the GitHub Release in the UI, untag the ghcr.io image, revert the homebrew-tap commit. Cheaper to cut `vX.Y.Z+1` if the change is non-destructive.
+
 ### Markdown front-matter (primary feature)
 
 `internal/content/frontmatter.go` is the parser. `splitFrontmatter(data []byte) (*Frontmatter, []byte)` is the only entry point — it returns the parsed metadata (or `nil` if absent) and the body bytes that the rest of `markdown.go` should treat as the document.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@
 
 ## Install
 
+### Homebrew (macOS / Linux)
+
+```sh
+brew install richardwooding/tap/file-search-on
+```
+
+The cask is published from this repo on every tagged release to [`richardwooding/homebrew-tap`](https://github.com/richardwooding/homebrew-tap).
+
+### Container (Docker / Podman)
+
+OCI images are published to GitHub Container Registry on every tag, with `linux/amd64` and `linux/arm64` manifests:
+
+```sh
+docker run --rm -v "$PWD:/work" ghcr.io/richardwooding/file-search-on:latest \
+  'is_markdown && draft' -d /work
+```
+
+Pin to a specific version with `:vX.Y.Z`. The base image is [`cgr.dev/chainguard/static`](https://images.chainguard.dev/directory/image/static), so the container has the binary and nothing else (no shell).
+
+### Pre-built binaries
+
+Pre-built archives for Linux, macOS, and Windows on `amd64` and `arm64` are attached to every [GitHub Release](https://github.com/richardwooding/file-search-on/releases), along with a `checksums.txt` you should verify.
+
+### From source
+
 Requires Go 1.26.2 or newer.
 
 ```sh

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -11,8 +11,15 @@ import (
 	"github.com/richardwooding/file-search-on/internal/search"
 )
 
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 var CLI struct {
-	Search SearchCmd `cmd:"" help:"Search for files matching a CEL expression." default:"withargs"`
+	Search  SearchCmd        `cmd:"" help:"Search for files matching a CEL expression." default:"withargs"`
+	Version kong.VersionFlag `short:"V" help:"Print version and exit."`
 }
 
 type SearchCmd struct {
@@ -104,6 +111,7 @@ func main() {
 		kong.Name("file-search-on"),
 		kong.Description("Content-type aware file search with CEL attribute filtering."),
 		kong.UsageOnError(),
+		kong.Vars{"version": fmt.Sprintf("file-search-on %s (commit %s, built %s)", version, commit, date)},
 	)
 	if err := ctx.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)


### PR DESCRIPTION
## Summary

Adds a complete release pipeline. Pushing a tag matching `v*` triggers `.github/workflows/release.yml`, which runs **GoReleaser v2** (pinned `~> v2`, currently v2.15.4) and produces three artifacts in one shot:

1. **GitHub Release** — `linux` / `darwin` / `windows` × `amd64` / `arm64` (six archives total: `.tar.gz` for unix, `.zip` for windows) plus `checksums.txt`. Binaries are stamped with `version` / `commit` / `date` via `-ldflags -X`; `./file-search-on --version` (or `-V`) prints them back.
2. **OCI image** at `ghcr.io/richardwooding/file-search-on:<version>` (and `:latest` for non-prerelease tags), built by `ko` from the same `builds:` block. Linux only — `amd64` + `arm64` manifests. Base image: `cgr.dev/chainguard/static` (no shell). Image labels follow OCI annotation conventions.
3. **Homebrew cask** committed to [`richardwooding/homebrew-tap`](https://github.com/richardwooding/homebrew-tap) at `Casks/file-search-on.rb`. Install: `brew install richardwooding/tap/file-search-on`.

## Key choices

- `version: 2` and `homebrew_casks:` (the modern key — `brews` was deprecated in GoReleaser v2.10). The cask handles macOS-intel / macOS-arm / Linux-intel / Linux-arm splits via Homebrew's `on_macos`/`on_linux` DSL — works fine for CLI binaries.
- `ko` publishes via `go-containerregistry`, so no Docker daemon is required on the runner. The workflow logs into `ghcr.io` with the auto-issued `GITHUB_TOKEN` (hence `permissions: packages: write`).
- Cross-repo push to `richardwooding/homebrew-tap` requires a PAT exposed as `HOMEBREW_TAP_GITHUB_TOKEN`. The default `GITHUB_TOKEN` is scoped to the source repo only.

## Required before the first tag (one-off, GitHub UI only)

- [ ] **Create a fine-grained PAT** scoped to `richardwooding/homebrew-tap` only, with `Contents: Read and write`. Add it as the repo secret `HOMEBREW_TAP_GITHUB_TOKEN`.
- [ ] **After the first release**, flip `ghcr.io/richardwooding/file-search-on` package visibility to **Public** at https://github.com/users/richardwooding/packages/container/file-search-on/settings — otherwise `docker pull` requires auth.

## Files

- `.goreleaser.yaml` — `version: 2`, single `builds:`, `archives:`, `kos:`, `homebrew_casks:`, `changelog:` with feat/fix grouping.
- `.github/workflows/release.yml` — tag-trigger; sets up Go 1.26.2, ghcr login, `goreleaser/goreleaser-action@v6`.
- `cmd/file-search-on/main.go` — `version` / `commit` / `date` ldflag-stamped vars; `kong.VersionFlag` exposed as `-V` / `--version`.
- `README.md` — new **Install** section (Homebrew, Container, Pre-built binaries) before the existing `go install` instructions.
- `CLAUDE.md` — new **Releases** section with artifacts, local dry-run, cutting procedure, rollback notes, and the rationale for `homebrew_casks` over `brews`.
- `.gitignore` — `dist/` (goreleaser snapshot output).

## Verification

- [x] `goreleaser check` validates the config.
- [x] `goreleaser release --snapshot --clean --skip=publish` produces all six binaries, archives, checksums, and a correctly-rendered `Casks/file-search-on.rb`. ko stops only at local-Docker load — expected on a dev machine, irrelevant for CI.
- [x] `./file-search-on --version` and `-V` print the stamped values with `-ldflags -X`.
- [x] `go vet ./...`, `go test -race ./...`, `golangci-lint run ./...` (v2.12.1) — all clean.
- [x] `go fix -diff ./...` empty (idempotent).
- [ ] First tag push (`v0.1.0`) succeeds and produces all three artifacts — to be verified after merge + secret setup.

## Out of scope

`nfpm` (.deb/.rpm), Cosign signing, Scoop / Winget / Chocolatey for Windows. Each is a clean follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)