### PR TITLE
fix(release): strip macOS quarantine xattr in cask postflight

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -94,3 +94,17 @@ homebrew_casks:
     commit_msg_template: "Brew cask update for {{ .ProjectName }} {{ .Tag }}"
     homepage: "https://github.com/richardwooding/file-search-on"
     description: "Content-type aware file search with CEL attribute filtering"
+    # Strip the quarantine xattr so macOS Gatekeeper doesn't block the
+    # unsigned binary on first run. See issue tracking real
+    # signing+notarization for the long-term fix.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/file-search-on"]
+          end
+    caveats: |
+      file-search-on is not yet signed/notarized with an Apple Developer ID.
+      The cask removes the quarantine attribute on install so Gatekeeper
+      lets it run. If macOS still blocks it, run:
+        sudo xattr -dr com.apple.quarantine $(brew --prefix)/bin/file-search-on

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ brew install richardwooding/tap/file-search-on
 
 The cask is published from this repo on every tagged release to [`richardwooding/homebrew-tap`](https://github.com/richardwooding/homebrew-tap).
 
+> **macOS Gatekeeper:** the binary isn't yet signed with an Apple Developer ID, so macOS may block it on first run. The cask's post-install hook strips the quarantine xattr automatically. If macOS still blocks it, run:
+>
+> ```sh
+> sudo xattr -dr com.apple.quarantine $(brew --prefix)/bin/file-search-on
+> ```
+
 ### Container (Docker / Podman)
 
 OCI images are published to GitHub Container Registry on every tag, with `linux/amd64` and `linux/arm64` manifests:


### PR DESCRIPTION
## Summary

`v0.1.0` binaries are unsigned, so macOS Gatekeeper blocks them on first run even after `brew install richardwooding/tap/file-search-on` — Homebrew's automatic quarantine removal doesn't always run for `binary` casks on modern macOS (Sequoia / Apple Silicon).

Adds an explicit `hooks.post.install` block to the goreleaser `homebrew_casks:` config, which goreleaser renders as a `postflight do` block in the generated `Casks/file-search-on.rb`. The block runs `xattr -dr com.apple.quarantine` against the staged binary on every install. Also adds a `caveats` string showing the manual fallback for anyone still blocked, and a matching note in README's Homebrew install section.

This is a workaround. The real fix is signing + notarization with an Apple Developer ID — tracked as a separate follow-up issue.

## Generated cask diff (relevant parts)

```ruby
binary "file-search-on"

postflight do
  if OS.mac?
    system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/file-search-on"]
  end
end

caveats <<~EOS
  file-search-on is not yet signed/notarized with an Apple Developer ID.
  The cask removes the quarantine attribute on install so Gatekeeper
  lets it run. If macOS still blocks it, run:
    sudo xattr -dr com.apple.quarantine $(brew --prefix)/bin/file-search-on
EOS
```

## Verification

- [x] `goreleaser check` validates the new `hooks.post.install` field.
- [x] `goreleaser release --snapshot --clean --skip=publish --skip=ko` succeeds; rendered cask contains both `postflight` and `caveats` blocks correctly.
- [ ] After merge: cut `v0.1.1`, then `brew upgrade richardwooding/tap/file-search-on` and confirm Gatekeeper no longer blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)