### PR TITLE
chore(ci): bump actions to Node 24-capable majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.26.2"
           cache: true
@@ -37,12 +37,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.26.2"
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,20 +13,20 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.26.2"
           cache: true
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
## Summary
- GitHub is retiring the Node 20 runtime on Actions runners; this bumps every `uses:` in `ci.yml` and `release.yml` to a major version whose published `action.yml` declares `runs.using: node24`.
- All 9 references cross a major. Most are mechanical, but `golangci-lint-action v8 → v9` and `goreleaser-action v6 → v7` are worth a glance for input/config changes.
- Tag-major pin style preserved (`@v4` → `@v6`, not `@v6.0.2`).

### Bumps
| File | Action | From | To |
| --- | --- | --- | --- |
| ci.yml | actions/checkout | v4 | v6 |
| ci.yml | actions/setup-go | v5 | v6 |
| ci.yml | golangci/golangci-lint-action | v8 | v9 |
| release.yml | actions/checkout | v4 | v6 |
| release.yml | actions/setup-go | v5 | v6 |
| release.yml | docker/login-action | v3 | v4 |
| release.yml | goreleaser/goreleaser-action | v6 | v7 |

## Test plan
- [ ] CI workflow (`build`, `lint`) runs green on this PR
- [ ] Smoke-check golangci-lint v9 picks up the existing `.golangci.yml` (or its absence) without surprises
- [ ] On a follow-up tag push, confirm release.yml goreleaser-action v7 produces the same artifacts (archives, ko image, Homebrew cask)

🤖 Generated with [Claude Code](https://claude.com/claude-code)