### PR TITLE
chore: add four maintenance skills

### DIFF
--- a/.claude/skills/add-content-type/SKILL.md
+++ b/.claude/skills/add-content-type/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: add-content-type
+description: Registers a new file-format content type in file-search-on by creating a file under `internal/content/` that implements the four-method `ContentType` interface (`Name`, `Extensions`, `MagicBytes`, `Attributes`), self-registers via `init()` calling `content.Register(...)`, and for image variants extends the `BuildAttributes` `image/*` prefix branch in `internal/celexpr/evaluator.go` — covers CSV, YAML, plain-text, EPUB, new audio/image families, and similar formats. Use when adding support for a new file format so the search recognises it and reports a `content_type`; does NOT cover CEL attribute wiring for type-specific attributes, which is the `extend-cel-schema` skill's job.
+---
+
+# Add Content Type
+
+A "content type" is anything `Detect()` can identify and `Walk` can tag. Registering one is mostly mechanical: drop a file in `internal/content/`, implement four methods, register it, done. The wrinkle is the `Attributes(path)` method — if it returns *any* type-specific keys, you also need the `extend-cel-schema` workflow to make those keys CEL-visible.
+
+## What gets registered
+
+A type is identified by its `Name()` (e.g. `"json"`, `"image/png"`) and detected by either:
+
+- **Extension match** — `.json`, `.md`, etc. Tried first.
+- **Magic-byte prefix** — first 512 bytes of the file. Used as a fallback when the extension doesn't match.
+
+Either or both can be empty (extension-only or magic-only types are valid). Registration is a side-effect of `init()` calling `content.Register(...)` — there is no central list to edit.
+
+## Quick start (non-image, no attributes)
+
+For a type like CSV that you want detected but where you don't (yet) care about per-file attributes:
+
+1. **Copy the template:**
+   ```sh
+   cp .claude/skills/add-content-type/templates/content_type.go.tmpl internal/content/csv.go
+   ```
+2. Fill in `csv.go`: replace `<typename>`, `<TypeName>`, `<name>`, `<.ext>`, magic bytes (or `nil`).
+3. Implement `Attributes` — for now, just `return Attributes{}, nil`.
+4. **Run** `go build ./...` and `go test ./...` — no test edits required for a no-attribute type.
+5. **Run** `go run ./cmd/file-search-on --list` — your new type appears under "Registered content types".
+
+## Quick start (with attributes)
+
+If `Attributes(path)` returns type-specific keys (e.g. `csv_columns`, `csv_rows`):
+
+1. Steps 1–3 as above, but make `Attributes` return the keys.
+2. **Then** run the `extend-cel-schema` skill for *each* new key — declare the CEL variable, add to the activation defaults, add a switch case, and document in `Schema()`.
+3. **Run** `python .claude/skills/extend-cel-schema/scripts/audit_attributes.py` — must pass.
+4. **Run** `go test ./...`.
+5. Add a unit test in `internal/content/csv_test.go` exercising the new type.
+
+## The `ContentType` interface
+
+```go
+type ContentType interface {
+    Name() string                                  // stable identifier; image family must use "image/<subtype>"
+    Extensions() []string                          // lowercase, with leading dot, e.g. []string{".csv"}
+    MagicBytes() [][]byte                          // each entry is a prefix to match against the first 512 bytes; nil if not used
+    Attributes(path string) (Attributes, error)    // called per matching file; return a map[string]any, never nil
+}
+```
+
+Semantic notes:
+
+- **`Name()`** — used by `BuildAttributes` to set the `is_*` flag and the `content_type` CEL attribute. For an image family, the name MUST start with `image/` (e.g. `image/avif`); the `BuildAttributes` `image/*` prefix branch turns `is_image` on automatically.
+- **`Extensions()`** — lowercase, dotted. The detector matches case-insensitively against `filepath.Ext(path)` lower-cased.
+- **`MagicBytes()`** — return `nil` (not `[][]byte{}`) if the type is detected by extension only. Each `[]byte` is a prefix; the detector matches if any prefix is a prefix of the first 512 bytes.
+- **`Attributes(path)`** — called *per matching file* during the walk. Avoid expensive parses without bounds (use `bufio.Scanner` with a buffer cap, decode just enough of the file to extract what you need). Return `Attributes{}` (empty) if no type-specific data; never return `nil`.
+
+## Image-family addition
+
+When the new type is an image variant (e.g. `image/avif`):
+
+- `Name()` MUST return `image/<subtype>`.
+- `BuildAttributes` (`internal/celexpr/evaluator.go`) already has a `case strings.HasPrefix(contentTypeName, "image/")` branch — no edit needed there for new image variants. The branch sets `is_image = true` and dispatches to the registered type's `Attributes` for `width` / `height` (which are renamed to `img_width` / `img_height` by the `attrs.Extra` switch).
+- If the new image type emits *additional* attributes beyond `width` / `height` (e.g. `color_space`, `bit_depth`), each one is a CEL-schema extension — use the `extend-cel-schema` skill.
+
+For a non-image type with its own `is_*` flag (e.g. an `audio/*` family):
+
+- Add an `IsAudio bool` field to `FileAttributes`.
+- Add the `is_audio` CEL variable via the four-place invariant (`extend-cel-schema`).
+- Add a `case strings.HasPrefix(contentTypeName, "audio/"):` branch in `BuildAttributes`.
+
+## Templates
+
+- [templates/content_type.go.tmpl](templates/content_type.go.tmpl) — skeleton for a non-image, no-attribute content type. Copy into `internal/content/<name>.go` and fill in.
+
+## References
+
+- [references/detection.md](references/detection.md) — how `Registry.Detect` works (extension-then-magic), magic-byte gotchas, and what `Attributes(path)` should and should not do during a walk.
+
+## Conventions
+
+- File name in `internal/content/` is the type name lowercased: `csv.go`, `epub.go`, `image_avif.go` (use underscores for `image/...` subtypes).
+- The struct type is unexported and has the form `<name>Type` (e.g. `csvType`). Match the existing files in `internal/content/`.
+- Register from `init()`. Never expose a `New<Name>Type()` constructor — registration is a side-effect, not an API.
+- `MagicBytes` returns `nil` for "no magic"; never an empty slice. The detector special-cases `nil` to skip the magic check.
+- Tests for new types live in `internal/content/<name>_test.go` and follow the existing pattern (see `markdown_test.go` for a thorough example, `jsontype_test.go` for a minimal one).
+- After adding the type, **run** `go run ./cmd/file-search-on --list` to confirm the type appears in the registered-types listing. The listing is generated from `content.DefaultRegistry().Types()`, so a missing type means `Register(...)` wasn't called.

--- a/.claude/skills/add-content-type/references/detection.md
+++ b/.claude/skills/add-content-type/references/detection.md
@@ -1,0 +1,88 @@
+# Content-type detection
+
+How `Registry.Detect` decides what a file is, what `Attributes(path)` should and should not do, and the gotchas that bite when adding a new type.
+
+## How `Registry.Detect` works
+
+The detector is in `internal/content/detector.go`. The algorithm:
+
+1. **Extension first.** Lower-case `filepath.Ext(path)` and check it against each registered type's `Extensions()` slice. First match wins.
+2. **Magic-byte fallback.** If no extension matched, read up to 512 bytes from the file. For each registered type, walk its `MagicBytes()` slice; if any entry is a prefix of the read bytes, that type wins.
+3. **No match → `nil`.** `BuildAttributes` treats this as "no content type"; the `content_type` CEL attribute is the empty string and every `is_*` flag is false.
+
+This means:
+
+- Registration order matters when multiple types claim the same extension or the same magic prefix. The detector returns the first match. In practice the existing types don't overlap, but if you register a type whose extensions or magic overlap an existing one, expect a flaky-feeling bug.
+- A type with `Extensions() = nil` and `MagicBytes() = nil` is unreachable. The detector will never return it.
+
+## Worked example: detecting an EPUB
+
+EPUBs are zip files with a specific marker. Detection options:
+
+- **Extension only:** `Extensions() = []string{".epub"}`, `MagicBytes() = nil`. Cheap, but misses files renamed away from `.epub`.
+- **Magic only:** EPUB starts with `PK\x03\x04` (zip header) plus, deeper inside, a `mimetype` entry containing `application/epub+zip`. The first 512 bytes can include the zip header but you'd be detecting "any zip" — too broad.
+- **Both:** Use the extension match for the common case; magic-byte fallback only if you can find a sufficiently specific prefix in the first 512 bytes. EPUBs typically place the `mimetype` entry first (it's an EPUB requirement), so the bytes `application/epub+zip` often appear in the first 512 bytes.
+
+Pragmatic recommendation: start with extension-only. Add magic bytes when you have a real test file proving they appear in the first 512 bytes.
+
+## Magic-byte gotchas
+
+- **`nil` vs. empty slice.** Return `nil` for "no magic". Returning `[][]byte{}` is technically valid but semantically the same — pick one (`nil`) so the codebase is consistent.
+- **First 512 bytes only.** Magic deeper into the file is invisible. PDFs (`%PDF-`) at byte 0 work; EPUB `mimetype` entries usually do, by spec.
+- **Prefix, not substring.** The detector checks `bytes.HasPrefix(read, magic)`. A magic of `"foo"` won't match a file that starts with `"\xef\xbb\xbffoo"` (BOM-prefixed). If you need BOM tolerance, register multiple magic entries: `[]byte("foo"), []byte("\xef\xbb\xbffoo")`.
+- **Avoid super-short or super-common prefixes.** `"{"` matches every JSON file but also every file that happens to start with `{`. JSON gets away with it because almost nothing else does. CSV has no usable magic — leave `MagicBytes` as `nil`.
+
+## What `Attributes(path)` should and should not do
+
+`Attributes(path)` is called *per matching file*. A search across 100k markdown files calls it 100k times. Performance and resource bounds matter.
+
+**Do:**
+
+- Open the file at `path`, decode just enough to extract what you need, close it. Use `defer f.Close()`.
+- Use bounded buffers — `bufio.Scanner` with a sized buffer cap, `io.LimitReader` for streams that could be huge.
+- Return `Attributes{}` (empty map, not `nil`) if there's nothing type-specific to extract. The detector still records `content_type`; you don't need attributes to be useful.
+- Return `(nil, err)` on a real I/O error. The walker silently skips files whose `Attributes` returns an error — by design, since the search shouldn't crash on a single malformed file.
+
+**Don't:**
+
+- Read or parse the entire file when you only need the first chunk. JSON's content type only reads the first token to detect `object` vs `array` — copy that pattern.
+- Make additional file-system calls beyond reading `path`. The walker has already passed you a stat-able path; recomputing stat or scanning siblings is wasted work.
+- Cache anything in a package-level variable. The `Attributes` call is concurrent — content types are stateless by contract. If you need a cache, scope it inside the function with a `sync.Once`-protected init, but think hard about why first.
+- Panic. The walker doesn't recover; a panicking type takes down the whole search.
+
+## Image-family branching
+
+The `BuildAttributes` function in `internal/celexpr/evaluator.go` (around line 189) has a single branch that catches every image variant by name prefix:
+
+```go
+case strings.HasPrefix(contentTypeName, "image/"):
+    isImage = true
+```
+
+Adding a new image variant (e.g. `image/avif`) is therefore additive: register the type with `Name() = "image/avif"` and the `is_image` flag flips on for that variant automatically. No edit to `evaluator.go` is needed.
+
+For a brand-new family (audio, archive, …), you DO need to extend `BuildAttributes`:
+
+1. Add a `case strings.HasPrefix(contentTypeName, "audio/"): isAudio = true` (or whatever family prefix).
+2. Add an `IsAudio bool` field to the `FileAttributes` struct in the same file.
+3. Add `is_audio` to the four-place CEL invariant (use the `extend-cel-schema` skill).
+
+The reason image is different is that it was the first family to need this pattern; if you add audio/archive/video, you're following the same template, not inventing one.
+
+## Verifying a new type
+
+After registering:
+
+```sh
+go build ./...
+go test ./...
+go run ./cmd/file-search-on --list   # your type appears under "Registered content types"
+```
+
+Then point the search at a directory containing a real file of the new type:
+
+```sh
+go run ./cmd/file-search-on 'content_type == "<your-name>"' -d ./path-with-test-files
+```
+
+If the file isn't reported, either the extension or magic-bytes match isn't firing. Run `--list` to confirm registration; if it's listed there, the issue is in `Detect` (extension/magic mismatch). If it's not listed, your `init()` didn't run — make sure the file is in `internal/content/` and the package was actually built (no syntax errors, etc.).

--- a/.claude/skills/add-content-type/templates/content_type.go.tmpl
+++ b/.claude/skills/add-content-type/templates/content_type.go.tmpl
@@ -1,0 +1,44 @@
+package content
+
+// REPLACE: package import this type needs (e.g. "encoding/csv", "io", "os") and remove unused imports.
+import (
+	"os"
+)
+
+func init() {
+	Register(&<typename>Type{})
+}
+
+type <typename>Type struct{}
+
+// Name returns the stable identifier surfaced as the `content_type` CEL attribute.
+// For image families, MUST start with "image/" (e.g. "image/avif").
+func (t *<typename>Type) Name() string { return "<name>" }
+
+// Extensions returns lowercase, leading-dot extensions matched against filepath.Ext(path).
+func (t *<typename>Type) Extensions() []string {
+	return []string{"<.ext>"}
+}
+
+// MagicBytes returns prefixes matched against the first 512 bytes of the file.
+// Return nil (NOT an empty slice) if the type is detected by extension only.
+func (t *<typename>Type) MagicBytes() [][]byte {
+	return nil
+}
+
+// Attributes is called per matching file during the walk. Keep it cheap —
+// decode only what you need to extract the attributes you'll surface to CEL.
+// Return Attributes{} (never nil) if there are no type-specific attributes.
+//
+// REPLACE: open the file, do the minimum work needed, return the keys. If you
+// add any keys, also follow the extend-cel-schema skill so cel-go sees them.
+func (t *<typename>Type) Attributes(path string) (Attributes, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	// REPLACE: read/parse the file and populate the map below.
+	return Attributes{}, nil
+}

--- a/.claude/skills/add-mcp-tool/SKILL.md
+++ b/.claude/skills/add-mcp-tool/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: add-mcp-tool
+description: Adds a new tool to file-search-on's MCP server in `internal/mcpserver/server.go` by defining JSON-tagged input/output structs (with `jsonschema` field tags), writing a handler that matches the SDK's `ToolHandlerFor[In, Out]` generic signature, registering it with `mcp.AddTool` inside `New()`, and adding an in-memory transport test in `server_test.go`. Use when extending the MCP server with a new tool — for example, a `read_attributes` tool that returns attributes for a single file without running a CEL filter, or any other agent-callable capability beyond the existing `search` and `list_attributes` tools.
+---
+
+# Add MCP Tool
+
+The MCP server in `internal/mcpserver/server.go` exposes tools to MCP clients (Claude Desktop, IDE plugins) via the official Go SDK at `github.com/modelcontextprotocol/go-sdk@v1.5.0`. Adding a tool is four small things in one file plus a test in another. The schema is generated from struct tags — you don't write JSON schema by hand.
+
+Prefer **extending the existing `search` tool's input** over forking a new tool when the new capability is "search but with one more filter / option". MCP clients see fewer entry points and the model picks the right one more reliably.
+
+## The four parts of a tool
+
+1. **Input/output structs** with `json` and `jsonschema` tags. The SDK derives the JSON schema from these.
+2. **Handler function** matching `ToolHandlerFor[In, Out]`:
+   ```go
+   func(ctx context.Context, req *mcp.CallToolRequest, in In) (*mcp.CallToolResult, Out, error)
+   ```
+3. **Registration** via `mcp.AddTool(s, &mcp.Tool{...}, handler)` inside `New(version)`.
+4. **Test** in `server_test.go` driving the new tool through `mcp.NewInMemoryTransports()`.
+
+## Quick start
+
+Adding a hypothetical `read_attributes` tool that returns the full attribute set for a single file:
+
+1. **Add the structs** in `internal/mcpserver/server.go`, near the existing `SearchInput` / `SearchOutput`:
+   ```go
+   type ReadAttributesInput struct {
+       Path string `json:"path" jsonschema:"Path to a single file. Required."`
+   }
+
+   type ReadAttributesOutput struct {
+       Path        string         `json:"path"`
+       ContentType string         `json:"content_type"`
+       Size        int64          `json:"size"`
+       Attributes  map[string]any `json:"attributes"`
+   }
+   ```
+
+2. **Write the handler**, near the existing `searchHandler`:
+   ```go
+   func readAttributesHandler(ctx context.Context, _ *mcp.CallToolRequest, in ReadAttributesInput) (*mcp.CallToolResult, ReadAttributesOutput, error) {
+       attrs, err := celexpr.BuildAttributes(in.Path, content.DefaultRegistry())
+       if err != nil {
+           return nil, ReadAttributesOutput{}, fmt.Errorf("build attributes: %w", err)
+       }
+       return nil, ReadAttributesOutput{
+           Path:        attrs.Path,
+           ContentType: attrs.ContentType,
+           Size:        attrs.Size,
+           Attributes:  attrs.Extra,
+       }, nil
+   }
+   ```
+
+3. **Register** inside `New(version)`, alongside the existing `mcp.AddTool` calls:
+   ```go
+   mcp.AddTool(s, &mcp.Tool{
+       Name:        "read_attributes",
+       Description: "Return the full attribute set for a single file by path, without running a CEL filter.",
+   }, readAttributesHandler)
+   ```
+
+4. **Test** in `internal/mcpserver/server_test.go` — copy `TestSearchTool` as a template; it already wires up the in-memory transport via `newSession(t)`. Decode `StructuredContent` with the existing `mustDecodeStructured(t, res, &out)` helper.
+
+5. **Run** `go test -race ./internal/mcpserver/...` — the test file is the verification. There's no separate audit script for this skill.
+
+## Handler signature, exactly
+
+```go
+func handlerName(
+    ctx context.Context,
+    req *mcp.CallToolRequest,
+    in InputType,
+) (*mcp.CallToolResult, OutputType, error)
+```
+
+Notes:
+
+- The first return value (`*mcp.CallToolResult`) is usually `nil`. The SDK builds one automatically from the structured `Output` value, populating `Content` with a JSON text representation. Return a non-nil `*mcp.CallToolResult` only when you need to attach unstructured `Content` (e.g. plain text or images alongside structured output).
+- Errors returned from the handler become tool errors visible to the client (`res.GetError() != nil`). They are not transport errors and don't tear down the session.
+- `req.Session` gives access to the server session if you need it (for progress notifications, sampling, etc.). Most tools don't.
+
+## Schema tags
+
+```go
+type ToolInput struct {
+    Path    string `json:"path"    jsonschema:"Path to a file. Required."`
+    Verbose bool   `json:"verbose,omitempty" jsonschema:"Include verbose output. Defaults to false."`
+}
+```
+
+- The `json` tag controls the field name on the wire. Use snake_case to match the rest of the file-search-on attribute namespace.
+- The `jsonschema` tag is the human-readable description that surfaces to MCP clients (and to the LLM driving the tool call).
+- For optional fields, add `,omitempty` to the `json` tag and document the default in the `jsonschema` description.
+
+The SDK uses `github.com/google/jsonschema-go` to derive the full JSON schema from the struct, supporting the 2020-12 draft only — don't reach for unusual schema features like `oneOf`/`anyOf`.
+
+## Testing pattern
+
+The existing `TestSearchTool` in `server_test.go` is the canonical pattern. Key points:
+
+- `newSession(t)` builds the server with `mcpserver.New("test")`, wires it to a client through `mcp.NewInMemoryTransports()`, and returns `(ctx, *mcp.ClientSession)`. Reuse this helper for new tool tests.
+- Call `cs.CallTool(ctx, &mcp.CallToolParams{Name: "your_tool", Arguments: YourInputStruct{...}})`.
+- Decode the structured output with `mustDecodeStructured(t, res, &out)` — the helper handles the JSON re-marshal needed because `res.StructuredContent` arrives as `map[string]any`, not your typed struct.
+- Don't try to assert on `res.Content` — the SDK auto-populates it from `StructuredContent` and the format isn't load-bearing for clients that read structured output.
+
+## References
+
+- [references/sdk-cheatsheet.md](references/sdk-cheatsheet.md) — quick map of the SDK's relevant types (`Tool`, `CallToolRequest`, `CallToolResult`, `ToolHandlerFor`, `StdioTransport`, `InMemoryTransport`) with one-liners on what each is for.
+
+## Conventions
+
+- **Tool name** is `snake_case` and a verb or short noun: `search`, `list_attributes`, `read_attributes`. Avoid prefixes like `file_` or `fs_` — clients see the tool name in the context of the server's name (`file-search-on`).
+- **Description** is one sentence, third person, names the inputs and outputs concretely. Bad: "Reads attributes." Good: "Returns the full attribute set for a single file by path, without running a CEL filter."
+- **Reuse existing code.** `search.Walk`, `celexpr.BuildAttributes`, `celexpr.Schema()`, `content.DefaultRegistry()` are the shared building blocks. Don't duplicate them — wire your handler to them and let the existing logic do the work.
+- **Update CLAUDE.md and the README.** Add the new tool to the "MCP server" tables in both. The README's section is short on purpose; one row per tool.
+- **Don't add a CLI flag for the new tool.** The `mcp` subcommand is intentionally flagless — all configuration is per-tool-call from the MCP client.

--- a/.claude/skills/add-mcp-tool/references/sdk-cheatsheet.md
+++ b/.claude/skills/add-mcp-tool/references/sdk-cheatsheet.md
@@ -1,0 +1,77 @@
+# MCP Go SDK cheat-sheet
+
+Quick map of the types and functions in `github.com/modelcontextprotocol/go-sdk@v1.5.0/mcp` that this project uses, with one-liners on what each is for. Read the SDK's own source for full signatures — this file is a navigation aid.
+
+## Server construction
+
+| Symbol | What it is |
+| --- | --- |
+| `mcp.NewServer(impl *Implementation, opts *ServerOptions) *Server` | Builds a server. `Implementation{Name, Version}` identifies the server to clients. `opts` may be `nil`. |
+| `mcp.AddTool[In, Out any](s *Server, t *Tool, h ToolHandlerFor[In, Out])` | Registers a typed tool. The generic types come from your input/output structs; the SDK derives JSON schema from their `json`/`jsonschema` struct tags. |
+| `(*Server).Run(ctx, transport) error` | Blocking; runs the server until the transport closes or `ctx` is cancelled. Used for stdio in production. |
+| `(*Server).Connect(ctx, transport, opts) (*ServerSession, error)` | Returns a session without blocking. Used for in-memory transports in tests. |
+
+## Tool types
+
+| Symbol | What it is |
+| --- | --- |
+| `mcp.Tool` | Metadata: `Name`, `Description`, `InputSchema` (auto-derived by `AddTool`), `Annotations`. |
+| `mcp.CallToolRequest` | Server-side request struct. Has `Session *ServerSession`. The handler receives `*CallToolRequest` plus the typed input. |
+| `mcp.CallToolResult` | Optional unstructured response wrapper. Most handlers return `nil` and let the SDK build it from the typed output. |
+| `mcp.ToolHandlerFor[In, Out any]` | The handler signature: `func(ctx, *CallToolRequest, In) (*CallToolResult, Out, error)`. |
+
+## Transports
+
+| Symbol | What it is |
+| --- | --- |
+| `mcp.StdioTransport` | JSON-RPC over stdin/stdout. Used by `mcpserver.Run` for the `mcp` subcommand. |
+| `mcp.NewInMemoryTransports() (*InMemoryTransport, *InMemoryTransport)` | Returns two paired transports for in-process server↔client. Used by `server_test.go`. |
+| `mcp.CommandTransport` | Drives a server as a subprocess. Useful for end-to-end tests that exercise the binary; this project uses in-memory transports instead. |
+
+## Client (used in tests)
+
+| Symbol | What it is |
+| --- | --- |
+| `mcp.NewClient(impl *Implementation, opts *ClientOptions) *Client` | Builds a client. |
+| `(*Client).Connect(ctx, transport, opts) (*ClientSession, error)` | Returns a session. Closes when `Close()` is called. |
+| `(*ClientSession).CallTool(ctx, *CallToolParams) (*CallToolResult, error)` | Invokes a tool. `CallToolParams.Arguments` is `any` — pass your typed input struct; the SDK marshals it. |
+| `(*ClientSession).ListTools(ctx, *ListToolsParams) (*ListToolsResult, error)` | Lists tools the server registered. Useful for assertions in tests. |
+
+## Decoding `StructuredContent`
+
+Tool results carry structured output in `res.StructuredContent` as `map[string]any` (not your typed struct). The pattern from `server_test.go`:
+
+```go
+func mustDecodeStructured(t *testing.T, res *mcp.CallToolResult, into any) {
+    t.Helper()
+    raw, _ := json.Marshal(res.StructuredContent)
+    if err := json.Unmarshal(raw, into); err != nil { t.Fatal(err) }
+}
+```
+
+The double-marshal is necessary — there is no `mapstructure`-style decode helper in the SDK as of v1.5.0. If/when one ships, this file is the place to update.
+
+## What's NOT here
+
+- Resources (`mcp.Resource`, `mcp.AddResource`) — file-search-on doesn't expose any. If we add one, document it here.
+- Prompts (`mcp.Prompt`, `mcp.AddPrompt`) — same.
+- Sampling / elicitation — server-initiated client calls. Not used here.
+- OAuth — the SDK ships `oauthex/` for client-side OAuth; the README marks it experimental.
+- HTTP/SSE / Streamable transports — the SDK supports them, but the `mcp` subcommand is stdio-only.
+
+## Useful imports for a new tool file
+
+```go
+import (
+    "context"
+    "fmt"
+
+    "github.com/modelcontextprotocol/go-sdk/mcp"
+
+    "github.com/richardwooding/file-search-on/internal/celexpr"
+    "github.com/richardwooding/file-search-on/internal/content"
+    "github.com/richardwooding/file-search-on/internal/search"
+)
+```
+
+`celexpr` for `BuildAttributes` and `Schema()`; `content` for `DefaultRegistry()`; `search` for `Walk` and `Options`. Existing tools wire to these directly — re-use rather than duplicate.

--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: cut-release
+description: Cuts a tag-driven release of file-search-on (GoReleaser v2 + ko + Homebrew tap), watches the GitHub Actions Release workflow, and verifies the three publish targets — GitHub Release archives, ghcr.io OCI image, and the Homebrew tap commit at richardwooding/homebrew-tap — then surfaces the rollback procedure when something goes wrong. Use when the user asks to cut, tag, ship, publish, release, or roll back a version of file-search-on, including phrases like "release v0.3.0" or "the cask is broken, undo the release".
+---
+
+# Cut Release
+
+A release publishes to three independent targets in one shot. Pushing a tag matching `v*` to `origin` triggers `.github/workflows/release.yml`, which runs **GoReleaser v2** and produces:
+
+1. **GitHub Release** — six archives (linux/darwin/windows × amd64/arm64) + `checksums.txt`.
+2. **OCI image** — `ghcr.io/richardwooding/file-search-on:<version>` (and `:latest` for non-prerelease).
+3. **Homebrew cask** — auto-commit on `richardwooding/homebrew-tap`, installable via `brew install richardwooding/tap/file-search-on`.
+
+This skill encodes the pre-flight, the tag-and-push, the verification, and the rollback. Tag pushes are public and hard to reverse — confirm version with the user before pushing if there's any ambiguity.
+
+## Quick start
+
+```sh
+# 1. Pre-flight (all of these must be clean)
+git checkout main
+git pull --ff-only origin main
+git status                          # clean working tree
+gh run list --branch main --limit 1 # latest CI run on main is green
+git tag --sort=-v:refname | head -1 # current latest tag
+goreleaser check                    # validates .goreleaser.yaml
+
+# 2. Pick the new version using semver
+#    feat: → minor bump (v0.X.0)
+#    fix:/chore: → patch bump (v0.X.Y+1)
+#    breaking change → major bump (vX+1.0.0) — until 1.0.0, breaking ⇒ minor
+
+# 3. Tag and push
+git tag -a v0.X.Y -m "v0.X.Y — <one-line summary>"
+git push origin v0.X.Y
+
+# 4. Watch the workflow
+gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId -q '.[0].databaseId')" --exit-status
+
+# 5. Verify all three publish targets
+bash .claude/skills/cut-release/scripts/verify_release.sh v0.X.Y
+```
+
+## Pre-flight checklist (in order)
+
+Skip any step at your peril — tag pushes are not free to undo.
+
+- [ ] On `main`, fast-forwarded to `origin/main`, working tree clean (`git status`).
+- [ ] `gh run list --branch main --limit 1` shows the latest CI run as `success`.
+- [ ] `goreleaser check` validates `.goreleaser.yaml` with no errors.
+- [ ] `git tag --sort=-v:refname | head -1` to read the current latest tag.
+- [ ] Pick the new version from semver: feat → minor, fix/chore → patch, breaking → minor (pre-1.0).
+- [ ] If anything other than feat/fix/chore is in the diff since the last tag (`git log <last-tag>..HEAD --oneline`), pause and confirm the bump kind with the user.
+
+Optional but recommended for risky releases:
+
+```sh
+goreleaser release --snapshot --clean --skip=publish --skip=ko
+```
+
+This builds `dist/` locally without pushing. `--skip=ko` avoids the OCI image step, which fails locally without Docker. `dist/` is gitignored.
+
+## Tag and push
+
+```sh
+git tag -a v0.X.Y -m "v0.X.Y — <one-line summary>"
+git push origin v0.X.Y
+```
+
+Use `git tag -a` (annotated), not lightweight tags. The release workflow does not care, but the annotation lands in `git show v0.X.Y` for future reference.
+
+## Watch the workflow
+
+```sh
+gh run watch <run-id> --exit-status
+```
+
+To find the run-id of the just-triggered release run:
+
+```sh
+gh run list --workflow=release.yml --limit 1 --json databaseId,status -q '.[0]'
+```
+
+Typical duration: 2–3 minutes. If it fails, the tag is already pushed — see the rollback section.
+
+## Verify
+
+**Run** `bash .claude/skills/cut-release/scripts/verify_release.sh v0.X.Y` from the repo root — checks the GitHub Release has the six expected archives + checksums.txt, the Homebrew tap got an auto-commit referencing the version, and (if Docker is installed) the OCI image manifest is published. Exits non-zero on any failure.
+
+If a target fails verification, jump to rollback before the user reports it.
+
+## Rollback
+
+Short version, in order. Detailed commands in [references/rollback.md](references/rollback.md).
+
+1. **Delete the tag remotely and locally.**
+2. **Delete the GitHub Release** in the UI or via `gh release delete`.
+3. **Untag the ghcr.io image** (`gh api -X DELETE` against the package version).
+4. **Revert the Homebrew tap commit** in the separate `richardwooding/homebrew-tap` repo.
+
+If the change shipped is non-destructive (binaries usable, image works, cask resolves), it is **almost always cheaper to cut `vX.Y.Z+1` with the fix** than to roll back. Roll back only when something is broken enough that users shouldn't install it.
+
+## Scripts
+
+- **Run** `bash scripts/verify_release.sh <version>` — verifies all three publish targets for the given version (e.g. `v0.2.0`). Exits non-zero on any failure. Requires `gh`; `docker` is optional (skipped with a warning if missing).
+
+## References
+
+- [references/rollback.md](references/rollback.md) — exact commands for unwinding a botched release across all three targets.
+
+## Conventions
+
+- **Tag format is `v<major>.<minor>.<patch>`.** No prefix beyond `v`. The release workflow is gated on `tags: ['v*']`.
+- **Annotated tags only** (`git tag -a`). The annotation is a one-line summary of the release.
+- **Never force-push a tag.** If a tag was pushed wrong, delete it and cut the next version. Force-pushing tags can confuse caches (Homebrew, ghcr) and is hard to recover from.
+- **Pre-1.0, breaking changes bump the minor.** This is the SemVer convention for `0.x.y` — major stays at 0 until the project commits to API stability.
+- **Don't tag from a feature branch.** Always from `main`, after the PRs that contributed to the release have been merged.

--- a/.claude/skills/cut-release/references/rollback.md
+++ b/.claude/skills/cut-release/references/rollback.md
@@ -1,0 +1,94 @@
+# Release rollback
+
+Exact commands for unwinding a botched release. Read this before doing anything destructive — and consider whether cutting `vX.Y.Z+1` instead is the cheaper move.
+
+## When to roll back vs. roll forward
+
+**Roll forward (cut the next version):** the binaries / image / cask exist and are *usable*, but ship the wrong code. Users who already installed are fine; the next install picks up the fix. This is the default for ~90% of botched releases.
+
+**Roll back:** something is broken enough that any user who installs is harmed — segfault on startup, broken `--help`, missing critical files, security regression. Now you actually need to remove the artifacts.
+
+A release that fails *during* the workflow (red GitHub Actions run) often only created some artifacts. Check each target before deciding what to clean up.
+
+## The four cleanup targets
+
+In order — do them top-down, since downstream caches reference upstream artifacts.
+
+### 1. Delete the git tag
+
+```sh
+# Local
+git tag -d v0.X.Y
+
+# Remote — this is the one users see
+git push origin :refs/tags/v0.X.Y
+```
+
+After this, the GitHub Release UI will still show the release (it's a separate object). The Homebrew tap and ghcr image still exist too — keep going.
+
+### 2. Delete the GitHub Release
+
+```sh
+gh release delete v0.X.Y --repo richardwooding/file-search-on --yes
+```
+
+This removes the archives and the release page. Users who downloaded the tarball already have it; you can't recall those.
+
+### 3. Untag the ghcr.io image
+
+The image lives at `ghcr.io/richardwooding/file-search-on:<numeric-version>` (e.g. `0.2.0`, no `v`). Delete the package version via the GitHub API:
+
+```sh
+# List versions to find the version-id
+gh api -X GET /user/packages/container/file-search-on/versions \
+  --jq '.[] | {id, name, tags: .metadata.container.tags}'
+
+# Delete the specific version-id (replace VERSION_ID)
+gh api -X DELETE /user/packages/container/file-search-on/versions/VERSION_ID
+```
+
+If the release was the most recent and tagged `:latest`, the new most-recent version on the registry will inherit `:latest` once the tag is gone — verify with `docker manifest inspect ghcr.io/richardwooding/file-search-on:latest` if Docker is installed.
+
+### 4. Revert the Homebrew tap commit
+
+The tap is a separate repo: `richardwooding/homebrew-tap`. The release workflow auto-commits a cask update there using the `HOMEBREW_TAP_GITHUB_TOKEN` secret. To revert:
+
+```sh
+# Clone if needed
+git clone https://github.com/richardwooding/homebrew-tap.git
+cd homebrew-tap
+
+# Find the auto-commit (usually most recent, message: "Brew cask update for file-search-on v0.X.Y")
+git log --oneline -5
+
+# Revert it (creates a new commit; do not force-push)
+git revert <commit-sha>
+git push origin main
+```
+
+Revert rather than force-push — keeps history honest and avoids breaking anyone with a checkout. After the revert lands, `brew install richardwooding/tap/file-search-on` resolves to the previous version again.
+
+## After rollback
+
+Run the verifier on the *previous* good version to confirm the world is consistent:
+
+```sh
+bash .claude/skills/cut-release/scripts/verify_release.sh v0.X.Y-1
+```
+
+It should still pass — none of the previous version's artifacts were touched.
+
+## Failure modes during rollback
+
+- **`gh release delete` succeeds but the tag won't push-delete** — usually a stale local tag. Re-run `git fetch --prune --prune-tags origin` and retry.
+- **ghcr.io API call returns 404** — the package may not exist (workflow failed early) or you don't have admin scope on the package. Visit the package settings page in the GitHub UI as a fallback.
+- **Tap revert blocked by branch protection** — open a PR against the tap with the revert commit. The tap is small enough that a human review is fine.
+
+## Cheaper alternative
+
+```sh
+git tag -a v0.X.Y+1 -m "v0.X.Y+1 — fix <regression>"
+git push origin v0.X.Y+1
+```
+
+If the broken release shipped non-destructive code, this is one tag-push and a 3-minute workflow run, versus four cleanup steps across three repos and the public registry. The downside: the broken version still exists in the user-facing release list. That's almost always an acceptable cost.

--- a/.claude/skills/cut-release/scripts/verify_release.sh
+++ b/.claude/skills/cut-release/scripts/verify_release.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Verify a file-search-on release across all three publish targets.
+#
+# Usage: verify_release.sh <version>          (e.g. v0.2.0)
+#
+# Checks:
+#   1. GitHub Release for <version> has the six expected archives + checksums.txt.
+#   2. Homebrew tap (richardwooding/homebrew-tap) has a commit referencing <version>.
+#   3. (Optional) The ghcr.io OCI image manifest is published. Requires docker; warns otherwise.
+#
+# Exits 0 if every required check passes. Exits 1 on any required failure.
+# `gh` must be installed and authenticated.
+
+set -u
+
+readonly OWNER="richardwooding"
+readonly REPO="file-search-on"
+readonly TAP_REPO="richardwooding/homebrew-tap"
+readonly IMAGE="ghcr.io/${OWNER}/${REPO}"
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <version>" >&2
+  exit 2
+fi
+readonly VERSION="$1"
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+  echo "ERROR: version must look like v0.2.0 (got: $VERSION)" >&2
+  exit 2
+fi
+readonly NUMERIC="${VERSION#v}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not installed" >&2
+  exit 1
+fi
+
+errors=0
+warns=0
+
+check() {  # check <label> <command...>
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    printf "  \xe2\x9c\x93 %s\n" "$label"
+    return 0
+  fi
+  printf "  \xe2\x9c\x97 %s\n" "$label"
+  errors=$((errors + 1))
+  return 1
+}
+
+warn_only() {  # warn_only <label>
+  printf "  \xe2\x9a\xa0  %s\n" "$1"
+  warns=$((warns + 1))
+}
+
+echo "Verifying $VERSION..."
+
+# 1. GitHub Release
+echo "GitHub Release"
+release_assets="$(gh release view "$VERSION" --repo "${OWNER}/${REPO}" --json assets -q '[.assets[].name] | join("\n")' 2>/dev/null || true)"
+if [[ -z "$release_assets" ]]; then
+  echo "  \xe2\x9c\x97 release not found"
+  errors=$((errors + 1))
+else
+  expected=(
+    "checksums.txt"
+    "${REPO}_${NUMERIC}_darwin_amd64.tar.gz"
+    "${REPO}_${NUMERIC}_darwin_arm64.tar.gz"
+    "${REPO}_${NUMERIC}_linux_amd64.tar.gz"
+    "${REPO}_${NUMERIC}_linux_arm64.tar.gz"
+    "${REPO}_${NUMERIC}_windows_amd64.zip"
+    "${REPO}_${NUMERIC}_windows_arm64.zip"
+  )
+  for asset in "${expected[@]}"; do
+    if grep -Fxq "$asset" <<<"$release_assets"; then
+      printf "  \xe2\x9c\x93 %s\n" "$asset"
+    else
+      printf "  \xe2\x9c\x97 missing: %s\n" "$asset"
+      errors=$((errors + 1))
+    fi
+  done
+fi
+
+# 2. Homebrew tap commit
+echo "Homebrew tap (${TAP_REPO})"
+top_commit="$(gh api "repos/${TAP_REPO}/commits" --jq '.[0].commit.message' 2>/dev/null || true)"
+if [[ -z "$top_commit" ]]; then
+  printf "  \xe2\x9c\x97 could not read tap commits (private? auth?)\n"
+  errors=$((errors + 1))
+elif grep -qF "$VERSION" <<<"$top_commit"; then
+  printf "  \xe2\x9c\x93 top commit references %s: %s\n" "$VERSION" "$(head -1 <<<"$top_commit")"
+else
+  printf "  \xe2\x9c\x97 top commit does NOT reference %s: %s\n" "$VERSION" "$(head -1 <<<"$top_commit")"
+  errors=$((errors + 1))
+fi
+
+# 3. OCI image (optional)
+echo "OCI image (${IMAGE}:${NUMERIC})"
+if ! command -v docker >/dev/null 2>&1; then
+  warn_only "docker not installed; skipping image manifest check"
+elif docker manifest inspect "${IMAGE}:${NUMERIC}" >/dev/null 2>&1; then
+  printf "  \xe2\x9c\x93 manifest published\n"
+else
+  printf "  \xe2\x9c\x97 manifest not reachable for %s:%s\n" "$IMAGE" "$NUMERIC"
+  errors=$((errors + 1))
+fi
+
+echo
+if [[ $errors -eq 0 ]]; then
+  echo "OK: $VERSION verified ($warns warning(s))"
+  exit 0
+fi
+echo "FAIL: $errors error(s), $warns warning(s)"
+exit 1

--- a/.claude/skills/extend-cel-schema/SKILL.md
+++ b/.claude/skills/extend-cel-schema/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: extend-cel-schema
+description: Extends file-search-on's CEL attribute schema by editing the four call sites that must move together — `cel.Variable(...)` declarations in `celexpr.New`, the activation defaults map in `Evaluate`, the `attrs.Extra` switch in `Evaluate`, and `celexpr.Schema()` — then runs an audit script that catches drift between them. Use when adding a new content-type attribute, promoting a new front-matter key like `summary` or `slug`, or extending an existing content type's attribute set; cel-go errors at runtime (not compile time) when these fall out of sync, so the audit script is the only deterministic guard.
+---
+
+# Extend CEL Schema
+
+Every CEL-visible attribute in file-search-on must appear in **four** places. Drift between them produces a runtime error (`no such attribute: foo`) the moment a CEL expression references the missing piece — `go build` will not catch it. This skill makes the four-place invariant explicit and ships an audit script that reports drift.
+
+## The four-place invariant
+
+| # | Where | What goes there | Failure mode if missing |
+| - | --- | --- | --- |
+| 1 | `internal/celexpr/evaluator.go` — `cel.Variable("foo", cel.<Type>Type)` inside `New` | Declares the variable to cel-go | Compile error: `undeclared reference to 'foo'` |
+| 2 | `internal/celexpr/evaluator.go` — activation defaults map literal in `Evaluate` | Zero value used when the matched type didn't emit this attribute | Runtime error: `no such attribute: foo` |
+| 3 | `internal/celexpr/evaluator.go` — `attrs.Extra` switch in `Evaluate` | Maps the content-type's emitted key to the CEL variable name (often a rename, e.g. `kind` → `json_kind`) | Attribute is always its zero value — silently wrong, no error |
+| 4 | `internal/celexpr/schema.go` — entry in the right `AttributeDoc` slice | Drives both `--list` output and the MCP `list_attributes` tool | Attribute is invisible to humans and to MCP clients |
+
+Place 3 only applies to **type-specific** attributes (anything that comes from a `ContentType.Attributes()` map). The "common" attributes (`name`, `path`, `size`, `is_markdown`, …) are populated directly from the `FileAttributes` struct fields and don't go through the switch. Schema slot:
+
+- `schema.Common` → places 1, 2 (no switch entry)
+- `schema.TypeSpecific` → places 1, 2, 3, 4
+- `schema.Frontmatter` → places 1, 2, 3, 4
+
+## Quick start
+
+1. Decide the CEL variable name (snake_case) and type. Decide whether it's `Common`, `TypeSpecific`, or `Frontmatter`.
+2. Add `cel.Variable("foo", cel.<Type>Type)` in `celexpr.New` (place 1).
+3. Add `"foo": <zero-value>` to the activation defaults map in `Evaluate` (place 2).
+4. If the value comes from a `ContentType.Attributes()` map, add a `case "<source-key>": activation["foo"] = v` to the `attrs.Extra` switch (place 3).
+5. Add `{"foo", "<celtype>", "<description>"}` to the right slice in `celexpr.Schema()` (place 4).
+6. **Run** the audit (see Scripts).
+7. Update the README front-matter table if the new attribute is front-matter-related.
+8. Add a test in `internal/content/frontmatter_test.go` (front-matter case) or the relevant content-type test file.
+
+For a new content type's *registration mechanics* (creating the file in `internal/content/`, implementing `ContentType`), see the `add-content-type` skill — this skill only covers the CEL plumbing.
+
+## Scripts
+
+- **Run** `python scripts/audit_attributes.py` from the repo root — parses `internal/celexpr/evaluator.go` and `internal/celexpr/schema.go`, prints a markdown table of every CEL attribute name with which of the four places it appears in, and exits non-zero on drift. Run before committing any change to those files.
+
+## References
+
+- [references/foot-guns.md](references/foot-guns.md) — the renames in the `attrs.Extra` switch (`kind` → `json_kind`, `width` → `img_width`, …), the cel-go runtime error text, and the image-family branch in `BuildAttributes`.
+
+## Conventions
+
+- CEL variable names are `snake_case`. Match the existing style (`json_kind`, `img_width`, `frontmatter_format`).
+- The CEL type for collections is exact: `cel.ListType(cel.StringType)` for `[]string`, `cel.MapType(cel.StringType, cel.DynType)` for `map[string]any`. cel-go errors loudly on type mismatch.
+- Zero values in the activation map must match the declared CEL type (e.g. `int64(0)` for `cel.IntType`, never plain `0`).
+- Do not edit `cmd/file-search-on/main.go:printHelp` — it's data-driven from `celexpr.Schema()`. Editing place 4 is sufficient.
+- If the new attribute crosses content types (e.g. `description` could come from PDF metadata *and* HTML `<meta>` *and* markdown front-matter), document each emitting site in the schema description so callers know what they're filtering on.

--- a/.claude/skills/extend-cel-schema/references/foot-guns.md
+++ b/.claude/skills/extend-cel-schema/references/foot-guns.md
@@ -1,0 +1,81 @@
+# CEL schema foot-guns
+
+Specific things that catch authors off-guard when extending the CEL attribute schema. Read this before you touch `evaluator.go`.
+
+## The cel-go runtime error
+
+When a CEL variable is referenced by a compiled expression but missing from the activation map, cel-go errors at evaluation time, not compile time. The user sees:
+
+```
+search failed: walk: ...: evaluating CEL expression: no such attribute(s): foo
+```
+
+This is the failure mode for forgetting place 2 (the activation defaults map) or place 3 (the `attrs.Extra` switch — when the expression explicitly references the attribute and no content type emits it). Compile-only smoke tests don't catch this; the test that catches it is one that actually `Walk`s a real directory.
+
+The guard against this is the activation defaults map: every `cel.Variable(...)` declared in `New` MUST have a key in the activation map literal in `Evaluate`, with a zero value of the right type. The audit script enforces this.
+
+## The renames in the Extra switch
+
+The keys content types emit in their `Attributes()` map are NOT always the same as the CEL variable names. The `attrs.Extra` switch in `Evaluate` is a translation layer.
+
+Current renames (in `internal/celexpr/evaluator.go`):
+
+| Source key (from `Attributes()`) | CEL variable |
+| --- | --- |
+| `kind` | `json_kind` |
+| `width` | `img_width` |
+| `height` | `img_height` |
+
+All other keys pass through unchanged (`title` → `title`, `word_count` → `word_count`, etc.).
+
+When adding a new attribute, you can either keep the same name on both sides (preferred) or introduce a rename. Renames are warranted when the source key is a generic word that would clash across content types — `kind` makes sense locally inside `jsonType.Attributes` but `json_kind` is clearer in CEL.
+
+## Type mismatches between zero value and `cel.Variable` type
+
+The zero value in the activation map must match the declared CEL type:
+
+| `cel.Variable` type | Zero value |
+| --- | --- |
+| `cel.StringType` | `""` |
+| `cel.IntType` | `int64(0)` (NOT plain `0`) |
+| `cel.BoolType` | `false` |
+| `cel.TimestampType` | `time.Time{}` |
+| `cel.ListType(cel.StringType)` | `[]string{}` |
+| `cel.MapType(cel.StringType, cel.DynType)` | `map[string]any{}` |
+
+cel-go errors with a confusing "unsupported type conversion" message on mismatch. The audit script does not check zero-value types — `go vet` and the existing test suite do.
+
+## Image-family branching
+
+Image content types use a name prefix (`image/jpeg`, `image/png`, …). The `BuildAttributes` function in `evaluator.go` (around line 189) maps any name starting with `image/` to `is_image = true` via:
+
+```go
+case strings.HasPrefix(contentTypeName, "image/"):
+    isImage = true
+```
+
+When adding a new image variant (e.g. `image/avif`):
+
+1. Register it like any other content type — name MUST start with `image/`.
+2. The `BuildAttributes` branch picks it up automatically; no edit needed there.
+
+When adding a NEW family with its own `is_*` boolean (e.g. an audio family with `is_audio`), you DO need to edit `BuildAttributes`: add a `case strings.HasPrefix(contentTypeName, "audio/"): isAudio = true` and follow the four-place invariant for the `is_audio` CEL variable.
+
+## When to update the README front-matter table
+
+The README has a hand-maintained front-matter table at the bottom of "Markdown front-matter search". Update it when:
+
+- Adding a new front-matter promoted variable (place 4 row in `schema.Frontmatter`).
+- Changing the precedence note (e.g. front-matter > H1 for `title`).
+
+The README does NOT list common attributes (`name`, `size`, …) or type-specific attributes (`page_count`, `img_width`, …) — those live only in `--list` and the MCP `list_attributes` tool. Don't add them to the README.
+
+## What the audit script does NOT catch
+
+The audit script enforces the four-place invariant for CEL attribute *names*. It does not check:
+
+- Whether the CEL variable type matches the zero value's Go type.
+- Whether the source key in the Extra switch matches what content types actually emit.
+- Whether the `AttributeDoc.Type` string in `Schema()` matches the declared `cel.Variable` type.
+
+Those checks are the job of `go build`, `go vet`, and the existing test suite. The audit catches the one class of error that no compiler will.

--- a/.claude/skills/extend-cel-schema/scripts/audit_attributes.py
+++ b/.claude/skills/extend-cel-schema/scripts/audit_attributes.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Audit file-search-on's CEL attribute schema for drift between the four call sites.
+
+Usage: python audit_attributes.py [--repo-root .]
+
+Exits 0 if every CEL attribute appears in every place it must, non-zero on drift.
+Prints a markdown table summarising the state of each attribute.
+
+The four places (see extend-cel-schema/SKILL.md):
+  1. cel.Variable("foo", ...) declarations in celexpr.New             (-> declared)
+  2. activation defaults map literal in celexpr.Evaluate              (-> defaulted)
+  3. attrs.Extra switch case assignments in celexpr.Evaluate          (-> assigned)
+  4. AttributeDoc{...} entries in celexpr.Schema()                    (-> documented)
+
+Invariants:
+  declared == defaulted                                          (sanity, hard error on drift)
+  documented (any slice) ⊆ declared                              (hard error)
+  documented (TypeSpecific ∪ Frontmatter) ⊆ assigned             (hard error)
+  declared - documented                                          (warn — undocumented attribute)
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+CEL_VARIABLE_RE = re.compile(r'cel\.Variable\(\s*"([^"]+)"')
+ACTIVATION_KEY_RE = re.compile(r'^\s*"([^"]+)"\s*:')
+ASSIGN_RE = re.compile(r'activation\[\s*"([^"]+)"\s*\]\s*=')
+DOC_ENTRY_RE = re.compile(r'\{\s*"([^"]+)"\s*,\s*"([^"]*)"\s*,\s*"[^"]*"\s*\}')
+
+
+def parse_evaluator(text: str) -> tuple[set[str], set[str], set[str]]:
+    """Return (declared, defaulted, assigned) sets parsed from evaluator.go."""
+    declared = set(CEL_VARIABLE_RE.findall(text))
+
+    # Locate the activation map literal: starts at `activation := map[string]any{`
+    # ends at the matching closing brace at the same indentation level.
+    start_marker = "activation := map[string]any{"
+    start = text.find(start_marker)
+    if start < 0:
+        raise SystemExit("ERROR: could not find `activation := map[string]any{` in evaluator.go")
+    # Track brace depth from the opening { in the marker
+    open_brace = start + len(start_marker) - 1
+    depth = 1
+    i = open_brace + 1
+    while i < len(text) and depth > 0:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    activation_block = text[open_brace + 1 : i - 1]
+    defaulted = set()
+    for line in activation_block.splitlines():
+        m = ACTIVATION_KEY_RE.match(line)
+        if m:
+            defaulted.add(m.group(1))
+
+    assigned = set(ASSIGN_RE.findall(text))
+    return declared, defaulted, assigned
+
+
+def parse_schema(text: str) -> dict[str, list[tuple[str, str]]]:
+    """Return mapping of slice name (Common / TypeSpecific / Frontmatter) to a list
+    of (attribute_name, attribute_type) tuples in source order."""
+    result: dict[str, list[tuple[str, str]]] = {}
+    # Find each `Common: []AttributeDoc{` / `TypeSpecific: []AttributeDoc{` / `Frontmatter: []AttributeDoc{`
+    for slice_name in ("Common", "TypeSpecific", "Frontmatter"):
+        marker = f"{slice_name}: []AttributeDoc{{"
+        start = text.find(marker)
+        if start < 0:
+            raise SystemExit(f"ERROR: could not find `{marker}` in schema.go")
+        # Find matching closing brace
+        open_brace = start + len(marker) - 1
+        depth = 1
+        i = open_brace + 1
+        while i < len(text) and depth > 0:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+            i += 1
+        block = text[open_brace + 1 : i - 1]
+        result[slice_name] = [(m.group(1), m.group(2)) for m in DOC_ENTRY_RE.finditer(block)]
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo-root", type=Path, default=Path("."), help="Repo root (default: cwd)")
+    args = ap.parse_args()
+
+    root = args.repo_root.resolve()
+    evaluator_path = root / "internal" / "celexpr" / "evaluator.go"
+    schema_path = root / "internal" / "celexpr" / "schema.go"
+    for p in (evaluator_path, schema_path):
+        if not p.exists():
+            print(f"ERROR: {p} not found (run from the repo root, or pass --repo-root)", file=sys.stderr)
+            return 1
+
+    declared, defaulted, assigned = parse_evaluator(evaluator_path.read_text(encoding="utf-8"))
+    schema = parse_schema(schema_path.read_text(encoding="utf-8"))
+
+    documented_common = {n for n, _ in schema["Common"]}
+    documented_typespec = {n for n, _ in schema["TypeSpecific"]}
+    documented_frontmatter = {n for n, _ in schema["Frontmatter"]}
+    documented_all = documented_common | documented_typespec | documented_frontmatter
+    must_be_assigned = documented_typespec | documented_frontmatter
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # Invariant 1: declared == defaulted
+    only_declared = declared - defaulted
+    only_defaulted = defaulted - declared
+    if only_declared:
+        errors.append(
+            f"declared but missing zero-value default in activation map: {sorted(only_declared)}"
+        )
+    if only_defaulted:
+        errors.append(
+            f"defaulted in activation map but not declared via cel.Variable: {sorted(only_defaulted)}"
+        )
+
+    # Invariant 2: documented ⊆ declared
+    documented_not_declared = documented_all - declared
+    if documented_not_declared:
+        errors.append(
+            f"documented in schema.go but not declared via cel.Variable: {sorted(documented_not_declared)}"
+        )
+
+    # Invariant 3: type-specific & front-matter docs ⊆ assigned
+    must_assign_missing = must_be_assigned - assigned
+    if must_assign_missing:
+        errors.append(
+            f"documented as type-specific/front-matter but no `activation[\"foo\"] = v` "
+            f"assignment in the attrs.Extra switch: {sorted(must_assign_missing)}"
+        )
+
+    # Sanity: assignments should target declared variables (unless they are common — but
+    # common attrs are populated from struct fields, never via the switch, so any switch
+    # assignment is to a type-specific or front-matter slot).
+    assigned_not_declared = assigned - declared
+    if assigned_not_declared:
+        errors.append(
+            f"attrs.Extra switch assigns to undeclared CEL variable: {sorted(assigned_not_declared)}"
+        )
+
+    # Warning: declared but undocumented (the `--list` view will hide it).
+    declared_not_documented = declared - documented_all
+    if declared_not_documented:
+        warnings.append(
+            f"declared via cel.Variable but not documented in schema.go (won't show "
+            f"in --list or list_attributes): {sorted(declared_not_documented)}"
+        )
+
+    # Build the markdown report.
+    print("| Attribute | Declared | Defaulted | Assigned | Documented |")
+    print("| --- | --- | --- | --- | --- |")
+    every = sorted(declared | defaulted | assigned | documented_all)
+    for name in every:
+        slot = ""
+        if name in documented_common:
+            slot = "Common"
+        elif name in documented_typespec:
+            slot = "TypeSpecific"
+        elif name in documented_frontmatter:
+            slot = "Frontmatter"
+        d = "✓" if name in declared else "—"
+        f_ = "✓" if name in defaulted else "—"
+        a = "✓" if name in assigned else ("·" if slot == "Common" else "—")
+        doc = slot if slot else "—"
+        print(f"| `{name}` | {d} | {f_} | {a} | {doc} |")
+    print()
+    print("Legend: ✓ = present, — = missing, · = N/A (common attrs are not assigned via the switch)")
+    print()
+
+    for w in warnings:
+        print(f"WARN  {w}")
+    for e in errors:
+        print(f"ERROR {e}")
+
+    print(f"\n{len(errors)} error(s), {len(warnings)} warning(s)")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Codifies recurring file-search-on maintenance workflows as agent skills. Each skill ships a deterministic check (script) where one exists, and references for the foot-guns prose alone can't catch.

| Skill | Trigger | Verification |
| --- | --- | --- |
| `extend-cel-schema` | Adding a CEL attribute (content-type or front-matter) | `scripts/audit_attributes.py` compares the four call sites in `evaluator.go` and `schema.go`, reports drift |
| `cut-release` | Cutting/tagging/publishing a version | `scripts/verify_release.sh <version>` checks all three publish targets (GH release archives, ghcr.io image, Homebrew tap commit) |
| `add-content-type` | Adding a new file-format content type | `templates/content_type.go.tmpl` skeleton + `references/detection.md` foot-guns |
| `add-mcp-tool` | Adding a tool to the MCP server | `references/sdk-cheatsheet.md` for the SDK type map; the in-memory transport test pattern is the verification |

## Why skills, not just CLAUDE.md prose
- The existing CLAUDE.md prose tells the agent *what* to edit. The audit script tells the agent *whether the edit is consistent* — cel-go errors at runtime, not compile time, on undeclared variables, so a script is the only reliable guard.
- Same logic for the release verifier: the workflow either runs or doesn't, but the three targets (GH release / ghcr / Homebrew tap) are independent and one can silently fail.

## Verification
- [x] `python .claude/skills/skill-authoring/scripts/lint_skill.py` against each new skill — 0 errors, 0 warnings on all four.
- [x] `python .claude/skills/extend-cel-schema/scripts/audit_attributes.py` — clean on `main` (every CEL attribute appears in all four required places).
- [x] `bash .claude/skills/cut-release/scripts/verify_release.sh v0.2.0` — passes (six archives, checksums.txt, Homebrew tap commit referencing v0.2.0; OCI image check skipped, Docker not installed locally).
- [ ] Trigger smoke-test in a fresh agent session: prompts like "add a new content type for plain text", "promote `summary` from front-matter", "release v0.3.0", "add a `read_attributes` MCP tool" should each pick the right skill from frontmatter alone.

## Out of scope
- A `bump-go-toolchain` skill — low frequency, well-covered by existing CLAUDE.md `go fix` docs.
- CI integration for the audit script — could wire into the `lint` job, but that's a follow-up after the skill is in real use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)