### PR TITLE
feat(csv): add csv_columns attribute, adopt encoding/csv parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Type-specific attributes (zero-valued when not applicable):
 | `word_count` | int | Markdown body (front-matter excluded), plain text |
 | `line_count` | int | Plain text |
 | `column_count` | int | CSV/TSV header row |
+| `csv_columns` | `list<string>` | CSV/TSV header field names |
 | `page_count` | int | PDF |
 | `author` | string | Markdown front-matter, PDF, EPUB `<dc:creator>` |
 | `language` | string | EPUB `<dc:language>` |

--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -61,6 +61,7 @@ func New(expr string) (*Evaluator, error) {
 		cel.Variable("word_count", cel.IntType),
 		cel.Variable("line_count", cel.IntType),
 		cel.Variable("column_count", cel.IntType),
+		cel.Variable("csv_columns", cel.ListType(cel.StringType)),
 		cel.Variable("language", cel.StringType),
 		cel.Variable("page_count", cel.IntType),
 		cel.Variable("author", cel.StringType),
@@ -114,6 +115,7 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 		"word_count":         int64(0),
 		"line_count":         int64(0),
 		"column_count":       int64(0),
+		"csv_columns":        []string{},
 		"language":           "",
 		"page_count":         int64(0),
 		"author":             "",
@@ -140,6 +142,8 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 				activation["line_count"] = v
 			case "column_count":
 				activation["column_count"] = v
+			case "csv_columns":
+				activation["csv_columns"] = v
 			case "language":
 				activation["language"] = v
 			case "page_count":

--- a/internal/celexpr/schema.go
+++ b/internal/celexpr/schema.go
@@ -41,6 +41,7 @@ func Schema() SchemaDoc {
 			{"word_count", "int", "word count (markdown body, plain text)"},
 			{"line_count", "int", "line count (plain text)"},
 			{"column_count", "int", "column count from header line (CSV/TSV)"},
+			{"csv_columns", "list<str>", "header field names from the first CSV/TSV line"},
 			{"page_count", "int", "page count (PDF)"},
 			{"author", "string", "author (markdown front-matter, PDF, EPUB)"},
 			{"language", "string", "language code (EPUB)"},

--- a/internal/content/csv.go
+++ b/internal/content/csv.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"bufio"
+	"encoding/csv"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,25 +25,45 @@ func (c *csvType) Attributes(path string) (Attributes, error) {
 	}
 	defer func() { _ = f.Close() }()
 
-	delim := ","
+	delim := ','
 	if strings.EqualFold(filepath.Ext(path), ".tsv") {
-		delim = "\t"
+		delim = '\t'
 	}
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 
-	var columnCount int64
+	var firstLine string
 	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
+		if line := scanner.Text(); line != "" {
+			firstLine = line
+			break
 		}
-		columnCount = int64(strings.Count(line, delim) + 1)
-		break
 	}
 
-	return Attributes{
-		"column_count": columnCount,
-	}, nil
+	attrs := Attributes{
+		"column_count": int64(0),
+		"csv_columns":  []string{},
+	}
+	if firstLine == "" {
+		return attrs, nil
+	}
+
+	r := csv.NewReader(strings.NewReader(firstLine))
+	r.Comma = delim
+	r.LazyQuotes = true
+	r.FieldsPerRecord = -1
+	record, err := r.Read()
+	if err != nil {
+		// Malformed beyond LazyQuotes' tolerance — fall back to a raw split so
+		// column_count still has a non-zero value rather than dropping the file.
+		fields := strings.Split(firstLine, string(delim))
+		attrs["column_count"] = int64(len(fields))
+		attrs["csv_columns"] = fields
+		return attrs, nil
+	}
+
+	attrs["column_count"] = int64(len(record))
+	attrs["csv_columns"] = record
+	return attrs, nil
 }

--- a/internal/content/csv_test.go
+++ b/internal/content/csv_test.go
@@ -3,22 +3,36 @@ package content_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/richardwooding/file-search-on/internal/content"
 )
 
-func TestCSVColumnCount(t *testing.T) {
+func TestCSVAttributes(t *testing.T) {
 	dir := t.TempDir()
 	cases := []struct {
-		file string
-		body string
-		want int64
+		file        string
+		body        string
+		wantCount   int64
+		wantColumns []string
 	}{
-		{"data.csv", "a,b,c,d\n1,2,3,4\n", 4},
-		{"data.tsv", "a\tb\tc\n1\t2\t3\n", 3},
-		{"single.csv", "only_one_column\n1\n2\n", 1},
-		{"leading-empty.csv", "\n\nx,y,z\n", 3},
+		{"data.csv", "a,b,c,d\n1,2,3,4\n", 4, []string{"a", "b", "c", "d"}},
+		{"data.tsv", "a\tb\tc\n1\t2\t3\n", 3, []string{"a", "b", "c"}},
+		{"single.csv", "only_one_column\n1\n2\n", 1, []string{"only_one_column"}},
+		{"leading-empty.csv", "\n\nx,y,z\n", 3, []string{"x", "y", "z"}},
+		{
+			"quoted.csv",
+			`"a,b",c,"d""e",f` + "\n1,2,3,4\n",
+			4,
+			[]string{"a,b", "c", `d"e`, "f"},
+		},
+		{
+			"quoted-tab.tsv",
+			"\"col\twith\ttabs\"\tb\tc\n1\t2\t3\n",
+			3,
+			[]string{"col\twith\ttabs", "b", "c"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.file, func(t *testing.T) {
@@ -34,8 +48,15 @@ func TestCSVColumnCount(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Attributes: %v", err)
 			}
-			if got := attrs["column_count"]; got != tc.want {
-				t.Errorf("column_count = %v, want %d", got, tc.want)
+			if got := attrs["column_count"]; got != tc.wantCount {
+				t.Errorf("column_count = %v, want %d", got, tc.wantCount)
+			}
+			gotCols, ok := attrs["csv_columns"].([]string)
+			if !ok {
+				t.Fatalf("csv_columns wrong type: %T", attrs["csv_columns"])
+			}
+			if !reflect.DeepEqual(gotCols, tc.wantColumns) {
+				t.Errorf("csv_columns = %#v, want %#v", gotCols, tc.wantColumns)
 			}
 		})
 	}
@@ -54,5 +75,12 @@ func TestCSVEmpty(t *testing.T) {
 	}
 	if got := attrs["column_count"]; got != int64(0) {
 		t.Errorf("column_count = %v, want 0", got)
+	}
+	cols, ok := attrs["csv_columns"].([]string)
+	if !ok {
+		t.Fatalf("csv_columns wrong type: %T", attrs["csv_columns"])
+	}
+	if len(cols) != 0 {
+		t.Errorf("csv_columns = %#v, want empty slice", cols)
 	}
 }


### PR DESCRIPTION
Closes #14.

## Summary
- New CEL attribute `csv_columns` (`list<string>`) — the field names from the first non-empty line of a CSV/TSV.
- Migrates `internal/content/csv.go` from naive `strings.Count(line, delim)+1` to `encoding/csv`. As a side-effect this also fixes `column_count` for files with quoted delimiters — `\"a,b\",c,d` is now correctly **3 columns**, not 4.

## Filter examples
```
is_csv && csv_columns.exists(c, c == \"revenue\")
is_csv && csv_columns.size() > 10
is_csv && \"customer_id\" in csv_columns
```

## Design choices
- **`LazyQuotes = true`** on the reader so slightly off-spec CSVs (a single stray quote) don't make a file vanish from results.
- **Hard-parse fallback:** if even `LazyQuotes` rejects the line, fall back to raw split. Keeps `column_count` non-zero rather than dropping the file silently.
- **One-line scope:** still find the first non-empty line via `bufio.Scanner` (1 MB cap), then run `csv.Reader` against just that line. Per-file cost stays well under a millisecond. The 1 MB cap is the existing limitation tracked in #16.

## Verification
- [x] `go build ./...`
- [x] `go test -race ./...` (six new CSV cases pass: simple comma/tab, single-column, leading-empty, quoted commas with escaped quotes, tabs inside quoted TSV fields, empty file)
- [x] `go vet ./...`
- [x] `golangci-lint run` — 0 issues
- [x] `go fix -diff ./...` — empty
- [x] `python .claude/skills/extend-cel-schema/scripts/audit_attributes.py` — 0 errors
- [x] CLI smoke: `file-search-on 'is_csv && csv_columns.exists(c, c == \"summary\")'` resolves correctly against a CSV with quoted fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)