### PR TITLE
feat: emit language from markdown front-matter and HTML <html lang>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Then watch the **Release** workflow in GitHub Actions. To roll back a botched re
 
 Detection is purely by the leading bytes: `---\n` ⇒ YAML, `+++\n` ⇒ TOML, `{` at byte 0 ⇒ JSON. There is intentionally no magic-byte fallback — if the first bytes don't match, `frontmatter_format` is `""` and every promoted variable holds its zero value. Malformed input degrades silently (returns nil + the original bytes) so a broken front-matter block doesn't make a file vanish from results.
 
-Six keys are promoted to first-class CEL variables in `markdown.go`'s `Attributes`: `title`, `author`, `tags`, `categories`, `draft`, `date`. Anything else is reachable through `frontmatter.<key>`. Title precedence is *front-matter > H1*. `tags` and `categories` accept either a list or a bare string (which is wrapped) — that coercion lives in `stringListValue`. `date` accepts native `time.Time` (TOML) or several string layouts (`timeValue`); add new layouts there, not at call sites.
+Seven keys are promoted to first-class CEL variables in `markdown.go`'s `Attributes`: `title`, `author`, `language`, `tags`, `categories`, `draft`, `date`. Anything else is reachable through `frontmatter.<key>`. Title precedence is *front-matter > H1*. `tags` and `categories` accept either a list or a bare string (which is wrapped) — that coercion lives in `stringListValue`. `date` accepts native `time.Time` (TOML) or several string layouts (`timeValue`); add new layouts there, not at call sites.
 
 Map values are normalised through `normalizeMap`/`normalizeValue` so cel-go sees `map[string]any` end-to-end. yaml.v3 already does this for the top-level map, but nested maps from generic `any` paths can sometimes be `map[any]any`; the normaliser covers that.
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Type-specific attributes (zero-valued when not applicable):
 | `csv_columns` | `list<string>` | CSV/TSV header field names |
 | `page_count` | int | PDF |
 | `author` | string | Markdown front-matter, PDF, EPUB `<dc:creator>` |
-| `language` | string | EPUB `<dc:language>` |
+| `language` | string | EPUB `<dc:language>`; HTML `<html lang="...">`; markdown front-matter `language` |
 | `root_element` | string | XML |
 | `json_kind` | string | `"object"` or `"array"` |
 | `img_width`, `img_height` | int | Image dimensions in pixels |

--- a/internal/celexpr/schema.go
+++ b/internal/celexpr/schema.go
@@ -44,7 +44,7 @@ func Schema() SchemaDoc {
 			{"csv_columns", "list<str>", "header field names from the first CSV/TSV line"},
 			{"page_count", "int", "page count (PDF)"},
 			{"author", "string", "author (markdown front-matter, PDF, EPUB)"},
-			{"language", "string", "language code (EPUB)"},
+			{"language", "string", "language code (EPUB, HTML <html lang>, markdown front-matter)"},
 			{"root_element", "string", "root element name (XML)"},
 			{"json_kind", "string", "'object' or 'array' (JSON)"},
 			{"img_width", "int", "image width in pixels"},

--- a/internal/content/frontmatter_test.go
+++ b/internal/content/frontmatter_test.go
@@ -167,6 +167,34 @@ tags: [oops
 	}
 }
 
+func TestFrontmatterLanguagePromoted(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"yaml.md", "---\ntitle: x\nlanguage: fr\n---\nbody\n"},
+		{"toml.md", "+++\ntitle = \"x\"\nlanguage = \"fr\"\n+++\nbody\n"},
+		{"json.md", "{\"title\": \"x\", \"language\": \"fr\"}\n\nbody\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTemp(t, tc.name, tc.body)
+			attrs := markdownAttrs(t, path)
+			if got := attrs["language"]; got != "fr" {
+				t.Errorf("language = %v, want fr", got)
+			}
+		})
+	}
+}
+
+func TestFrontmatterLanguageAbsent(t *testing.T) {
+	path := writeTemp(t, "no-lang.md", "---\ntitle: x\n---\nbody\n")
+	attrs := markdownAttrs(t, path)
+	if v, ok := attrs["language"]; ok {
+		t.Errorf("language present when absent in front-matter: %v", v)
+	}
+}
+
 func TestSingleStringTagWrapsAsList(t *testing.T) {
 	path := writeTemp(t, "single.md", `---
 tags: solo

--- a/internal/content/htmltype.go
+++ b/internal/content/htmltype.go
@@ -23,7 +23,10 @@ func (h *htmlType) MagicBytes() [][]byte {
 	}
 }
 
-var titleRe = regexp.MustCompile(`(?i)<title[^>]*>(.*?)</title>`)
+var (
+	titleRe    = regexp.MustCompile(`(?i)<title[^>]*>(.*?)</title>`)
+	htmlLangRe = regexp.MustCompile(`(?i)<html[^>]*\blang\s*=\s*["']?([A-Za-z][\w-]*)`)
+)
 
 func (h *htmlType) Attributes(path string) (Attributes, error) {
 	f, err := os.Open(path)
@@ -46,7 +49,11 @@ func (h *htmlType) Attributes(path string) (Attributes, error) {
 		title = strings.TrimSpace(m[1])
 	}
 
-	return Attributes{
+	attrs := Attributes{
 		"title": title,
-	}, nil
+	}
+	if m := htmlLangRe.FindStringSubmatch(content); len(m) > 1 {
+		attrs["language"] = m[1]
+	}
+	return attrs, nil
 }

--- a/internal/content/htmltype_test.go
+++ b/internal/content/htmltype_test.go
@@ -1,0 +1,89 @@
+package content_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+)
+
+func htmlAttrs(t *testing.T, path string) content.Attributes {
+	t.Helper()
+	for _, ct := range content.DefaultRegistry().Types() {
+		if ct.Name() == "html" {
+			attrs, err := ct.Attributes(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return attrs
+		}
+	}
+	t.Fatal("html content type not registered")
+	return nil
+}
+
+func TestHTMLLanguage(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"simple-en.html",
+			`<!DOCTYPE html><html lang="en"><head><title>x</title></head></html>`,
+			"en",
+		},
+		{
+			"bcp47-en-GB.html",
+			`<!DOCTYPE html><html lang="en-GB"><head><title>x</title></head></html>`,
+			"en-GB",
+		},
+		{
+			"single-quoted.html",
+			`<!DOCTYPE html><html lang='fr'><head><title>x</title></head></html>`,
+			"fr",
+		},
+		{
+			"unquoted.html",
+			`<!DOCTYPE html><html lang=de><head><title>x</title></head></html>`,
+			"de",
+		},
+		{
+			"with-other-attrs.html",
+			`<!DOCTYPE html><html dir="ltr" lang="ja" class="root"><head><title>x</title></head></html>`,
+			"ja",
+		},
+		{
+			"uppercase-tag.html",
+			`<!DOCTYPE html><HTML LANG="es"><head><title>x</title></head></HTML>`,
+			"es",
+		},
+	}
+	dir := t.TempDir()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, tc.name)
+			if err := os.WriteFile(path, []byte(tc.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			attrs := htmlAttrs(t, path)
+			if got := attrs["language"]; got != tc.want {
+				t.Errorf("language = %v, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHTMLLanguageAbsent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "no-lang.html")
+	body := `<!DOCTYPE html><html><head><title>x</title></head><body>y</body></html>`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	attrs := htmlAttrs(t, path)
+	if v, ok := attrs["language"]; ok {
+		t.Errorf("language present when absent in HTML: %v", v)
+	}
+}

--- a/internal/content/markdown.go
+++ b/internal/content/markdown.go
@@ -64,6 +64,9 @@ func (m *markdownType) Attributes(path string) (Attributes, error) {
 		if v, ok := stringValue(fm.Data["author"]); ok {
 			attrs["author"] = v
 		}
+		if v, ok := stringValue(fm.Data["language"]); ok {
+			attrs["language"] = v
+		}
 		if tags, ok := stringListValue(fm.Data["tags"]); ok {
 			attrs["tags"] = tags
 		}


### PR DESCRIPTION
Closes part of #15 (markdown + HTML); see #20 for the PDF follow-up.

## Summary
The `language` CEL attribute existed since v0.3.0 but only EPUB emitted it. This PR makes the same key cross-cutting:

- **Markdown** — `frontmatter.language` promoted to top-level. Joins `title`, `author`, `tags`, `categories`, `draft`, `date` as the seventh promoted key. Handles all three front-matter formats (YAML, TOML, JSON).
- **HTML** — extract `<html lang="…">` via regex. Tolerant of single/double quotes, unquoted values, BCP 47 hyphenated codes (`en-GB`), uppercase tag/attr names, and intermixed attributes.

## Filter examples
```
language == "fr" && (is_markdown || is_html || is_epub)
language.startsWith("en")
is_markdown && language == ""        // markdown without a declared language
```

## Why no schema changes
`language` is already declared in `celexpr.New`, defaulted in `Evaluate`, switched in `attrs.Extra`, and documented in `Schema()`. Adding emitters is purely about populating `attrs["language"]` from each content type's `Attributes()`. The `extend-cel-schema` audit confirms 0 errors — every CEL attribute still appears in all four required places.

## PDF deferred → tracked in #20
pdfcpu v0.12.0 does **not** publicly expose the PDF document-catalog `/Lang` field. `PDFInfo` covers Title/Author/PageCount/Producer/etc., and `Properties` is for the /Info dict's *custom* properties — neither surfaces /Lang. The `model.RootLang` constant exists internally but isn't reachable through `pkg/api`. Filed as #20 with three implementation options.

## Verification
- [x] \`go build ./...\`
- [x] \`go test -race ./...\` (4 markdown front-matter language cases + 8 HTML lang cases pass)
- [x] \`go vet ./...\`
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix -diff ./...\` — empty
- [x] \`python .claude/skills/extend-cel-schema/scripts/audit_attributes.py\` — 0 errors
- [x] CLI smoke: \`language == "fr"\` finds the markdown file; \`language == "en-GB"\` finds the HTML file

🤖 Generated with [Claude Code](https://claude.com/claude-code)