### PR TITLE
feat: configurable per-line scanner cap (-L / --max-line-bytes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ file-search-on --list
 | `-d`, `--dir` | Directory to search. | `.` |
 | `-w`, `--workers` | Number of parallel workers. | number of CPU cores |
 | `-l`, `--list` | List supported attributes and registered content types. | |
+| `-L`, `--max-line-bytes` | Per-line scanner cap for text/CSV/HTML in bytes. Raise for very long log lines. | 1 MiB |
 
 Each matching file is printed as `<path>\t[<content-type>]\t<size> bytes`. The match count is written to stderr so it doesn't pollute pipelines.
 

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -32,10 +32,11 @@ func (m *MCPCmd) Run() error {
 }
 
 type SearchCmd struct {
-	Expr    string `arg:"" help:"CEL expression to match files (e.g. 'is_json && size > 1024')." optional:""`
-	Dir     string `short:"d" help:"Directory to search in." default:"."`
-	Workers int    `short:"w" help:"Number of parallel workers." default:"0"`
-	List    bool   `short:"l" help:"List supported attributes and content types."`
+	Expr         string `arg:"" help:"CEL expression to match files (e.g. 'is_json && size > 1024')." optional:""`
+	Dir          string `short:"d" help:"Directory to search in." default:"."`
+	Workers      int    `short:"w" help:"Number of parallel workers." default:"0"`
+	List         bool   `short:"l" help:"List supported attributes and content types."`
+	MaxLineBytes int    `short:"L" name:"max-line-bytes" help:"Per-line scanner cap for text/CSV/HTML (bytes). 0 uses the 1 MiB default." default:"0"`
 }
 
 func (s *SearchCmd) Run() error {
@@ -50,9 +51,10 @@ func (s *SearchCmd) Run() error {
 
 	ctx := context.Background()
 	opts := search.Options{
-		Root:    s.Dir,
-		Expr:    s.Expr,
-		Workers: s.Workers,
+		Root:         s.Dir,
+		Expr:         s.Expr,
+		Workers:      s.Workers,
+		MaxLineBytes: s.MaxLineBytes,
 	}
 
 	results, err := search.Walk(ctx, opts, contentpkg.DefaultRegistry())

--- a/internal/content/csv.go
+++ b/internal/content/csv.go
@@ -31,7 +31,7 @@ func (c *csvType) Attributes(path string) (Attributes, error) {
 	}
 
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 64*1024), MaxLineBytes())
 
 	var firstLine string
 	for scanner.Scan() {

--- a/internal/content/htmltype.go
+++ b/internal/content/htmltype.go
@@ -37,7 +37,7 @@ func (h *htmlType) Attributes(path string) (Attributes, error) {
 
 	var sb strings.Builder
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 64*1024), MaxLineBytes())
 	for scanner.Scan() {
 		sb.WriteString(scanner.Text())
 		sb.WriteString("\n")

--- a/internal/content/limits.go
+++ b/internal/content/limits.go
@@ -1,0 +1,33 @@
+package content
+
+import "sync/atomic"
+
+// DefaultMaxLineBytes is the per-line scanner buffer cap when nothing else has
+// been configured. Lines longer than this are silently truncated, which can
+// under-count line_count / word_count / column_count for unusually wide inputs
+// (single-line JSON logs, minified output). Use SetMaxLineBytes to raise it.
+const DefaultMaxLineBytes = 1 << 20 // 1 MiB
+
+var maxLineBytes atomic.Int64
+
+func init() {
+	maxLineBytes.Store(int64(DefaultMaxLineBytes))
+}
+
+// MaxLineBytes is the current per-line buffer cap honoured by content types
+// that read files line-by-line (text, csv, html). Read on every Attributes()
+// call so the knob takes effect mid-walk if reset.
+func MaxLineBytes() int {
+	return int(maxLineBytes.Load())
+}
+
+// SetMaxLineBytes overrides the per-line buffer cap. Values <= 0 are ignored
+// and the previous value is retained, so callers can pass an unset CLI flag
+// without special-casing zero. Process-global; concurrent Walk calls that need
+// different caps will race.
+func SetMaxLineBytes(n int) {
+	if n <= 0 {
+		return
+	}
+	maxLineBytes.Store(int64(n))
+}

--- a/internal/content/limits_test.go
+++ b/internal/content/limits_test.go
@@ -1,0 +1,78 @@
+package content_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+)
+
+func TestMaxLineBytesDefault(t *testing.T) {
+	// SetMaxLineBytes was called by other tests; reset to default for a clean check.
+	content.SetMaxLineBytes(content.DefaultMaxLineBytes)
+	if got := content.MaxLineBytes(); got != content.DefaultMaxLineBytes {
+		t.Fatalf("MaxLineBytes() = %d, want %d", got, content.DefaultMaxLineBytes)
+	}
+}
+
+func TestSetMaxLineBytesIgnoresZeroAndNegative(t *testing.T) {
+	content.SetMaxLineBytes(content.DefaultMaxLineBytes)
+	prev := content.MaxLineBytes()
+
+	content.SetMaxLineBytes(0)
+	if got := content.MaxLineBytes(); got != prev {
+		t.Errorf("after SetMaxLineBytes(0): got %d, want %d unchanged", got, prev)
+	}
+
+	content.SetMaxLineBytes(-1)
+	if got := content.MaxLineBytes(); got != prev {
+		t.Errorf("after SetMaxLineBytes(-1): got %d, want %d unchanged", got, prev)
+	}
+
+	t.Cleanup(func() {
+		content.SetMaxLineBytes(content.DefaultMaxLineBytes)
+	})
+}
+
+// TestTextRespectsLineCap proves the knob actually changes scanner behaviour:
+// a single line longer than the cap fails the scan, leaving line_count at 0.
+// Raising the cap above the line length recovers the count.
+func TestTextRespectsLineCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "long.txt")
+	body := strings.Repeat("x", 200_000) + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		content.SetMaxLineBytes(content.DefaultMaxLineBytes)
+	})
+
+	ct := content.DefaultRegistry().Detect(path)
+	if ct == nil || ct.Name() != "text" {
+		t.Fatalf("Detect: got %v, want text", ct)
+	}
+
+	// 64 KiB cap: scanner can't fit the 200 KB line, returns no records.
+	content.SetMaxLineBytes(64 * 1024)
+	attrs, err := ct.Attributes(path)
+	if err != nil {
+		t.Fatalf("Attributes (low cap): %v", err)
+	}
+	if got := attrs["line_count"]; got != int64(0) {
+		t.Errorf("line_count with low cap = %v, want 0 (line truncated by scanner)", got)
+	}
+
+	// 1 MiB cap: line fits, count is 1.
+	content.SetMaxLineBytes(content.DefaultMaxLineBytes)
+	attrs, err = ct.Attributes(path)
+	if err != nil {
+		t.Fatalf("Attributes (default cap): %v", err)
+	}
+	if got := attrs["line_count"]; got != int64(1) {
+		t.Errorf("line_count with default cap = %v, want 1", got)
+	}
+}

--- a/internal/content/text.go
+++ b/internal/content/text.go
@@ -24,7 +24,7 @@ func (t *textType) Attributes(path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 64*1024), MaxLineBytes())
 
 	var lineCount, wordCount int64
 	for scanner.Scan() {

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -15,9 +15,10 @@ import (
 
 // SearchInput is the JSON-schema input for the `search` tool.
 type SearchInput struct {
-	Expr    string `json:"expr,omitempty" jsonschema:"CEL expression matched against file attributes (e.g. 'is_pdf && page_count > 10'). Empty means match all."`
-	Dir     string `json:"dir,omitempty" jsonschema:"Directory to search in. Defaults to '.'."`
-	Workers int    `json:"workers,omitempty" jsonschema:"Number of parallel workers. Defaults to runtime.NumCPU()."`
+	Expr         string `json:"expr,omitempty" jsonschema:"CEL expression matched against file attributes (e.g. 'is_pdf && page_count > 10'). Empty means match all."`
+	Dir          string `json:"dir,omitempty" jsonschema:"Directory to search in. Defaults to '.'."`
+	Workers      int    `json:"workers,omitempty" jsonschema:"Number of parallel workers. Defaults to runtime.NumCPU()."`
+	MaxLineBytes int    `json:"max_line_bytes,omitempty" jsonschema:"Per-line scanner buffer cap for text/CSV/HTML (bytes). 0 uses the 1 MiB default; raise for very long log lines."`
 }
 
 // SearchMatch is one match returned by the `search` tool.
@@ -85,9 +86,10 @@ func searchHandler(ctx context.Context, _ *mcp.CallToolRequest, in SearchInput) 
 	}
 
 	results, err := search.Walk(ctx, search.Options{
-		Root:    dir,
-		Expr:    expr,
-		Workers: in.Workers,
+		Root:         dir,
+		Expr:         expr,
+		Workers:      in.Workers,
+		MaxLineBytes: in.MaxLineBytes,
 	}, content.DefaultRegistry())
 	if err != nil {
 		return nil, SearchOutput{}, fmt.Errorf("walk: %w", err)

--- a/internal/search/walker.go
+++ b/internal/search/walker.go
@@ -23,6 +23,11 @@ type Options struct {
 	Root    string
 	Expr    string
 	Workers int
+	// MaxLineBytes overrides the per-line scanner buffer cap honoured by the
+	// text, csv, and html content types. Zero means use the package default
+	// (see content.DefaultMaxLineBytes). Process-global; concurrent Walk
+	// calls with different caps will race.
+	MaxLineBytes int
 }
 
 // Walk walks the directory and returns matching files
@@ -30,6 +35,7 @@ func Walk(ctx context.Context, opts Options, registry *content.Registry) ([]Resu
 	if opts.Workers <= 0 {
 		opts.Workers = runtime.NumCPU()
 	}
+	content.SetMaxLineBytes(opts.MaxLineBytes)
 
 	evaluator, err := celexpr.New(opts.Expr)
 	if err != nil {


### PR DESCRIPTION
Closes #16.

## Summary
Replaces the hard-coded 1 MB `bufio.Scanner` cap in `text`, `csv`, and `html` content types with a configurable knob, exposed on both CLI and MCP surfaces. Lines longer than the cap are still silently truncated (scanner semantics), but users with long log lines can now raise the limit.

Three surfaces:

- **Library** — `internal/content/limits.go`: `MaxLineBytes()` / `SetMaxLineBytes()` backed by `atomic.Int64`.
- **CLI** — `-L` / `--max-line-bytes <bytes>` on the `search` subcommand. Default `0` → 1 MiB.
- **MCP** — `max_line_bytes` field on the `search` tool input.

## Implementation choices

- **Atomic int.** The knob is process-global (`atomic.Int64`). Concurrent `Walk` calls with different caps race; documented on the `Options` field. Acceptable for a CLI tool; if MCP grows multi-tenant call patterns we'd revisit.
- **Bigger max, smaller initial.** Switched from `make([]byte, 1MB), 1MB` to `make([]byte, 64KB), MaxLineBytes()`. The scanner grows the buffer on demand up to the cap, so the common case allocates 64 KB per file instead of 1 MB.
- **Markdown left alone.** `markdown.go` has its own `1 MB initial / 8 MB max` (intentional — markdown bodies frequently include long table rows or inline base64). Out of scope for this PR; can become its own knob if anyone needs it.
- **Walk sets the global.** `search.Walk` calls `content.SetMaxLineBytes(opts.MaxLineBytes)` once before walking, so callers that don't go through `Walk` (any future direct content-type users) can also call the setter manually.

## Verification
- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./...` (all existing tests pass; 3 new tests in `limits_test.go` for default value, zero/negative ignored, and end-to-end truncation/recovery via the text content type)
- [x] `golangci-lint run` — 0 issues
- [x] `go fix -diff ./...` — empty
- [x] `python .claude/skills/extend-cel-schema/scripts/audit_attributes.py` — 0 errors (no schema change)
- [x] CLI smoke: `-L 65536` against a 200 KB-line file gives `line_count = 0`; default cap recovers `line_count = 1`. `--help` shows the new flag.

## Filter examples
```sh
file-search-on 'is_text && line_count > 1000' -d ./logs -L 16777216  # 16 MiB cap for big logs
file-search-on 'is_csv && column_count > 5'  -d ./reports             # default 1 MiB is fine
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)