### PR TITLE
docs: balanced README + per-family recipe files under examples/

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,43 @@
 
 **Content-type aware file search with CEL-powered attribute filtering.**
 
-`file-search-on` walks a directory tree and returns files matching a [CEL](https://github.com/google/cel-spec) expression evaluated over each file's metadata and content-type-specific attributes. Instead of grepping by name, you can ask things like *"all PDFs with more than 10 pages"* or *"all Markdown files over 500 words whose title starts with 'Draft'"*.
+`file-search-on` walks a directory tree and returns files matching a [CEL](https://github.com/google/cel-spec) expression evaluated over each file's metadata and content-type-specific attributes. Instead of grepping by name, ask things like:
+
+```sh
+file-search-on 'is_pdf && page_count > 10 && author == "Jane Doe"'
+file-search-on 'is_image && gps_lat > 51.4 && gps_lat < 51.6'        # photos near home
+file-search-on 'is_audio && artist == "Radiohead" && year < 2000'
+file-search-on 'is_video && video_height >= 2160 && video_codec == "h265"'
+file-search-on 'is_office && language == "fr"'
+file-search-on 'is_markdown && "longread" in tags && word_count > 1000'
+```
+
+Across **24 file formats** organised into eight content-type families (documents, data, images, audio, video, office, ebooks, plain text), with format-specific metadata extraction.
 
 ## Features
 
-- **First-class Markdown front-matter search** — query YAML (`---`), TOML (`+++`), and JSON (`{ ... }`) front-matter directly. Common keys (`title`, `author`, `tags`, `categories`, `draft`, `date`) are promoted to top-level CEL variables, and a generic `frontmatter` map exposes every other key. See the [dedicated section](#markdown-front-matter-search) below.
-- **Pluggable content-type detection** — extension-first, with magic-byte fallback. Markdown, JSON, XML, HTML, PDF, and the common image formats (JPEG, PNG, GIF, WebP, SVG, TIFF, BMP) are supported out of the box.
-- **Rich, type-specific attributes** — page count and author for PDFs, title and word count for Markdown, root element for XML, dimensions for images, and more.
-- **CEL expressions** — the full Common Expression Language is available, so you can compose conditions naturally with `&&`, `||`, comparisons, string functions, and so on.
-- **Parallel walking** — files are evaluated across a configurable worker pool (defaults to the number of CPU cores).
+- **Pluggable content-type detection** — extension-first with magic-byte fallback. New formats are a single registration call.
+- **Eight content-type families**, each with its own metadata extractors:
+
+  | Family | Formats | Bundle of attributes |
+  | --- | --- | --- |
+  | **Documents** | PDF, EPUB | title, author, language, page_count |
+  | **Markup** | Markdown, HTML, XML | title, word_count, frontmatter, language, root_element |
+  | **Data** | JSON, CSV, TSV | json_kind, column_count, csv_columns |
+  | **Plain text** | TXT, log, … | line_count, word_count |
+  | **Images** | JPEG, PNG, GIF, WebP, TIFF, BMP, SVG, HEIC | dimensions + EXIF: camera, lens, GPS, ISO, focal_length, taken_at |
+  | **Audio** | MP3, M4A, FLAC, OGG | tags (artist, album, genre, year, …) + duration, bitrate, sample_rate, channels |
+  | **Video** | MP4, MOV, MKV, WebM, AVI | duration, bitrate, video_codec, audio_codec, video_width/height, frame_rate |
+  | **Office** | DOCX, XLSX, PPTX, ODT | title, author, language (Dublin Core) |
+
+  Type predicates (`is_pdf`, `is_image`, `is_audio`, `is_video`, `is_office`, `is_epub`, …) light up automatically from the registered content type. See [examples/](./examples/) for recipes by family.
+
+- **First-class Markdown front-matter** — YAML (`---`), TOML (`+++`), and JSON (`{ ... }`) are recognised by leading bytes. Common keys (`title`, `author`, `language`, `tags`, `categories`, `draft`, `date`) become top-level CEL variables; everything else lives in a generic `frontmatter` map. See [examples/markdown.md](./examples/markdown.md).
+- **CEL expressions** — the full Common Expression Language: comparisons, `&&`/`||`, string functions, list membership, timestamp arithmetic. Composes naturally with structural attributes.
+- **Multiple output formats** — `bare` (paths only), `default`, `verbose` (multi-line), `json` (NDJSON), or a Go `text/template` via `--format`.
+- **MCP server mode** — same binary doubles as a [Model Context Protocol](https://modelcontextprotocol.io) server (stdio, HTTP, or SSE). LLM agents can invoke `search` and `list_attributes` tools directly.
+- **Pure Go, no CGO** — cross-compiles cleanly to all six release targets. No image/audio/video decoder dependencies.
+- **Parallel walking** — files are evaluated across a worker pool (defaults to `NumCPU`).
 
 ## Install
 
@@ -22,7 +50,7 @@ brew install richardwooding/tap/file-search-on
 
 The cask is published from this repo on every tagged release to [`richardwooding/homebrew-tap`](https://github.com/richardwooding/homebrew-tap).
 
-> **macOS Gatekeeper:** the binary isn't yet signed with an Apple Developer ID, so macOS may block it on first run. The cask's post-install hook strips the quarantine xattr automatically. If macOS still blocks it, run:
+> **macOS Gatekeeper:** the binary isn't yet signed with an Apple Developer ID, so macOS may block it on first run. The cask's post-install hook strips the quarantine xattr automatically. If macOS still blocks it:
 >
 > ```sh
 > sudo xattr -dr com.apple.quarantine $(brew --prefix)/bin/file-search-on
@@ -88,138 +116,44 @@ file-search-on 'is_markdown' -d ./docs -o json       # NDJSON, one object per li
 file-search-on 'is_markdown' -d ./docs --format '{{.Path}}\t{{.Title}}\t{{.WordCount}}'
 ```
 
-`-o bare` and `-o json` and `--format` suppress the `<N> file(s) found` summary on stderr (the count is implicit in the line count). `--format` uses Go [`text/template`](https://pkg.go.dev/text/template); the data context is a flat record — `{{.Path}}`, `{{.Title}}`, `{{.WordCount}}`, `{{.Frontmatter}}`, all the `Is*` booleans, etc. Backslash escapes (`\t`, `\n`) are expanded before parsing.
+`-o bare`, `-o json`, and `--format` suppress the `<N> file(s) found` summary on stderr (the count is implicit in the line count). `--format` uses Go [`text/template`](https://pkg.go.dev/text/template); the data context is a flat record — `{{.Path}}`, `{{.Title}}`, `{{.WordCount}}`, `{{.Frontmatter}}`, all the `Is*` booleans, etc. Backslash escapes (`\t`, `\n`) are expanded before parsing.
 
-## Markdown front-matter search
+## Recipes
 
-Searching across the front-matter of large note collections, blogs, and documentation sites is a primary use case for this tool. Three formats are recognised, detected by the very first bytes of the file:
+Focused recipe collections live under [`examples/`](./examples/):
 
-| Format | Opening | Closing | Common in |
-| --- | --- | --- | --- |
-| YAML | `---` line | `---` line | Jekyll, Obsidian, Hugo, MkDocs |
-| TOML | `+++` line | `+++` line | Hugo, Zola |
-| JSON | `{` at byte 0 | matching `}` | Hugo, Eleventy |
+| Recipe file | What's in it |
+| --- | --- |
+| [`examples/markdown.md`](./examples/markdown.md) | Front-matter (YAML / TOML / JSON), draft flags, tag membership, custom keys |
+| [`examples/images.md`](./examples/images.md) | EXIF camera/lens, GPS bounding boxes, ISO / aperture / focal length, taken-at ranges |
+| [`examples/audio.md`](./examples/audio.md) | Artist / album / genre / year, bitrate, sample rate, hi-res filtering |
+| [`examples/video.md`](./examples/video.md) | Codec, resolution, frame rate, duration, MKV vs MP4 |
+| [`examples/office.md`](./examples/office.md) | DOCX / XLSX / PPTX / ODT — title, author, language |
+| [`examples/epub.md`](./examples/epub.md) | EPUB books — title, author, language; XMP fallback |
+| [`examples/data.md`](./examples/data.md) | JSON arrays vs objects, CSV column membership, XML root elements |
+| [`examples/text.md`](./examples/text.md) | Plain text / log files — line count, word count, big-line caps |
+| [`examples/cookbook.md`](./examples/cookbook.md) | Cross-cutting recipes — dedupe, mixed media filters, pipeline integration |
 
-Parsing is lightweight: the front-matter block is read and decoded directly with [`gopkg.in/yaml.v3`](https://pkg.go.dev/gopkg.in/yaml.v3), [`pelletier/go-toml/v2`](https://pkg.go.dev/github.com/pelletier/go-toml/v2), or `encoding/json`. The Markdown body is not parsed beyond a single pass for `word_count` and an H1 title fallback, so this stays fast across thousands of files.
-
-Six commonly-used keys are promoted to first-class CEL variables; everything else is reachable through the generic `frontmatter` map.
-
-| CEL variable | Type | Notes |
-| --- | --- | --- |
-| `title` | string | Front-matter `title` overrides the H1 fallback. |
-| `author` | string | From front-matter. |
-| `tags` | `list<string>` | A bare string (`tags: solo`) is wrapped as a single-element list. |
-| `categories` | `list<string>` | Same coercion as `tags`. |
-| `draft` | bool | Defaults to `false` when missing. |
-| `date` | timestamp | Native TOML dates and common YAML/JSON string layouts (RFC3339, `YYYY-MM-DD`, etc.) are accepted. |
-| `frontmatter` | `map<string, dyn>` | Full parsed map. Reach any custom key with `frontmatter.your_key`. |
-| `frontmatter_format` | string | `"yaml"`, `"toml"`, `"json"`, or `""` if no front-matter was present. |
-
-### Front-matter examples
-
-Find drafts in your blog:
+A handful of representative one-liners:
 
 ```sh
-file-search-on 'is_markdown && draft' -d ./content
-```
-
-Find Markdown tagged `go` and not draft:
-
-```sh
-file-search-on 'is_markdown && "go" in tags && !draft' -d ./posts
-```
-
-Find published posts from 2024 onward:
-
-```sh
-file-search-on 'is_markdown && date >= timestamp("2024-01-01T00:00:00Z")'
-```
-
-Reach a custom front-matter key (e.g. `category: essay`):
-
-```sh
-file-search-on 'is_markdown && frontmatter.category == "essay"'
-```
-
-Find files in a specific front-matter format:
-
-```sh
-file-search-on 'is_markdown && frontmatter_format == "toml"'
-```
-
-Combine front-matter with structural attributes — long, tagged, non-draft posts:
-
-```sh
-file-search-on 'is_markdown && word_count > 1000 && "longread" in tags && !draft'
-```
-
-## Examples
-
-Find all Markdown files larger than 500 words:
-
-```sh
+# All Markdown files larger than 500 words
 file-search-on 'is_markdown && word_count > 500' -d ./docs
-```
 
-Find PDFs with more than 10 pages, written by a specific author:
+# 4K HEVC videos longer than 30 minutes
+file-search-on 'is_video && video_height >= 2160 && video_codec == "h265" && duration > 1800' -d ~/Videos
 
-```sh
-file-search-on 'is_pdf && page_count > 10 && author == "Jane Doe"'
-```
+# Photos taken in 2024 with a Sony camera at high ISO
+file-search-on 'is_image && camera_make == "SONY" && iso > 1600 && taken_at > timestamp("2024-01-01T00:00:00Z")' -d ~/Pictures
 
-Find all JSON files whose top-level value is an array:
+# CSVs with a "revenue" column
+file-search-on 'is_csv && csv_columns.exists(c, c == "revenue")' -d ./reports
 
-```sh
-file-search-on 'is_json && json_kind == "array"'
-```
+# French-language office documents
+file-search-on 'is_office && language == "fr"' -d ~/Documents
 
-Find images wider than 1920 pixels:
-
-```sh
-file-search-on 'is_image && img_width > 1920' -d ~/Pictures
-```
-
-Find photos shot at high ISO on a specific camera:
-
-```sh
-file-search-on 'is_image && camera_make == "Canon" && iso > 1600' -d ~/Pictures
-```
-
-Find photos taken in a geographic bounding box (London-ish):
-
-```sh
-file-search-on 'is_image && gps_lat > 51.4 && gps_lat < 51.6 && gps_lon > -0.2 && gps_lon < 0.0' -d ~/Pictures
-```
-
-Find photos taken in a date range:
-
-```sh
-file-search-on 'is_image && taken_at > timestamp("2024-01-01T00:00:00Z") && taken_at < timestamp("2025-01-01T00:00:00Z")' -d ~/Pictures
-```
-
-Find audio files by artist, album, or genre:
-
-```sh
-file-search-on 'is_audio && artist == "Radiohead"' -d ~/Music
-file-search-on 'is_audio && genre == "Jazz" && year > 2000' -d ~/Music
-file-search-on 'is_audio && album == "OK Computer"' -d ~/Music --format '{{.Track}}\t{{.Title}}'
-```
-
-Find audio by duration, bitrate, or sample rate (hi-res):
-
-```sh
-file-search-on 'is_audio && duration > 600' -d ~/Music                  # tracks > 10 minutes
-file-search-on 'is_audio && bitrate >= 320' -d ~/Music                  # high-bitrate MP3 / lossless
-file-search-on 'is_audio && sample_rate >= 96000' -d ~/Music            # hi-res audio
-```
-
-Find video by codec, resolution, or duration:
-
-```sh
-file-search-on 'is_video && video_codec == "h265"' -d ~/Videos          # HEVC encodes
-file-search-on 'is_video && video_height >= 2160' -d ~/Videos           # 4K and above
-file-search-on 'is_video && duration > 1800' -d ~/Videos                # over 30 minutes
-file-search-on 'is_video && frame_rate > 30' -d ~/Videos                # high-frame-rate
+# Audio tracks ≥ 96 kHz (hi-res)
+file-search-on 'is_audio && sample_rate >= 96000' -d ~/Music
 ```
 
 Combine paths and types — find HTML files inside a `build/` directory:
@@ -230,55 +164,79 @@ file-search-on 'is_html && dir.contains("build")'
 
 ## Available attributes
 
-Common attributes (always present):
+Run `file-search-on --list` for the canonical, up-to-date listing. The summary tables below are organised by attribute family.
+
+### Common (always present)
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `name` | string | Filename |
-| `path` | string | Full path |
-| `dir` | string | Parent directory |
+| `name`, `path`, `dir` | string | Path components |
 | `size` | int | File size in bytes |
-| `ext` | string | File extension, e.g. `.md` |
+| `ext` | string | File extension (e.g. `.md`) |
 | `content_type` | string | Detected content type |
-| `is_markdown`, `is_json`, `is_xml`, `is_html`, `is_pdf`, `is_image`, `is_text`, `is_csv`, `is_epub`, `is_office`, `is_audio`, `is_video` | bool | Type predicates (`is_office` covers DOCX/XLSX/PPTX/ODT; `is_audio` covers MP3/M4A/FLAC/OGG; `is_video` covers MP4/MOV/MKV/WebM/AVI) |
+| `is_markdown`, `is_json`, `is_xml`, `is_html`, `is_pdf`, `is_image`, `is_text`, `is_csv`, `is_epub`, `is_office`, `is_audio`, `is_video` | bool | Type predicates |
 
-Type-specific attributes (zero-valued when not applicable):
+### Document / markup
 
 | Attribute | Type | Source |
 | --- | --- | --- |
-| `title` | string | Markdown front-matter, then H1; HTML `<title>`; PDF `/Info` dict; EPUB `<dc:title>`; DOCX/XLSX/PPTX/ODT `<dc:title>` |
-| `word_count` | int | Markdown body (front-matter excluded), plain text |
+| `title` | string | Markdown front-matter / H1; HTML `<title>`; PDF `/Info`; EPUB `<dc:title>`; office `<dc:title>`; audio tags |
+| `author` | string | Markdown front-matter, PDF `/Info`, EPUB / office `<dc:creator>` |
+| `language` | string | EPUB / office `<dc:language>`; HTML `<html lang>`; markdown front-matter; PDF `/Lang` (XMP fallback) |
+| `word_count` | int | Markdown body, plain text |
 | `line_count` | int | Plain text |
-| `column_count` | int | CSV/TSV header row |
-| `csv_columns` | `list<string>` | CSV/TSV header field names |
 | `page_count` | int | PDF |
-| `author` | string | Markdown front-matter, PDF `/Info`, EPUB `<dc:creator>`; DOCX/XLSX/PPTX/ODT `<dc:creator>` |
-| `language` | string | EPUB `<dc:language>`; HTML `<html lang="...">`; markdown front-matter `language`; PDF `/Lang` (or XMP `<dc:language>` fallback); DOCX/XLSX/PPTX/ODT `<dc:language>` |
-| `root_element` | string | XML |
-| `json_kind` | string | `"object"` or `"array"` |
-| `img_width`, `img_height` | int | Image dimensions in pixels |
-| `camera_make`, `camera_model`, `lens` | string | EXIF camera/lens identification (JPEG/TIFF/HEIC/PNG) |
-| `taken_at` | timestamp | EXIF capture time (DateTimeOriginal → CreateDate → ModifyDate fallback) |
-| `orientation` | int | EXIF orientation tag (1-8) |
-| `gps_lat`, `gps_lon` | double | GPS coordinates in decimal degrees (north / east positive) |
-| `iso` | int | EXIF ISO sensitivity |
-| `focal_length`, `f_stop`, `exposure_time` | double | EXIF focal length (mm), F-number, exposure (s) |
-| `artist`, `album`, `album_artist`, `composer`, `genre` | string | Audio tags (ID3v1/v2 for MP3, MP4 atoms for M4A, Vorbis comments for FLAC/OGG) |
-| `year`, `track` | int | Audio release year and track number |
-| `duration` | double | Audio or video length in seconds |
-| `bitrate` | int | Audio or video average bitrate in kbps (file_size × 8 / duration / 1000) |
-| `sample_rate` | int | Audio sample rate in Hz |
-| `channels` | int | Audio channel count |
-| `video_codec`, `audio_codec` | string | Codec names (h264, h265, av1, vp9, aac, opus, ...) |
-| `video_width`, `video_height` | int | Video frame dimensions in pixels |
-| `frame_rate` | double | Video frames per second |
-| `frontmatter` | `map<string, dyn>` | Full Markdown front-matter map |
-| `frontmatter_format` | string | `"yaml"`, `"toml"`, `"json"`, or `""` |
-| `tags`, `categories` | `list<string>` | Markdown front-matter |
-| `draft` | bool | Markdown front-matter |
-| `date` | timestamp | Markdown front-matter |
 
-Run `file-search-on --list` to see the full, up-to-date list along with the registered content types.
+### Data / structural
+
+| Attribute | Type | Source |
+| --- | --- | --- |
+| `column_count`, `csv_columns` | int / `list<string>` | CSV/TSV header row |
+| `json_kind` | string | JSON top-level: `"object"` or `"array"` |
+| `root_element` | string | XML |
+
+### Markdown front-matter (promoted)
+
+| Attribute | Type | Notes |
+| --- | --- | --- |
+| `tags`, `categories` | `list<string>` | Bare strings are wrapped to single-element lists |
+| `draft` | bool | Defaults to `false` when missing |
+| `date` | timestamp | Native TOML dates + RFC3339 / `YYYY-MM-DD` strings |
+| `frontmatter` | `map<string, dyn>` | Full parsed map — reach any custom key with `frontmatter.foo` |
+| `frontmatter_format` | string | `"yaml"`, `"toml"`, `"json"`, or `""` |
+
+### Images (EXIF)
+
+| Attribute | Type | Source |
+| --- | --- | --- |
+| `img_width`, `img_height` | int | Pixel dimensions |
+| `camera_make`, `camera_model`, `lens` | string | EXIF |
+| `taken_at` | timestamp | EXIF DateTimeOriginal → CreateDate → ModifyDate fallback |
+| `orientation` | int | EXIF orientation (1-8) |
+| `gps_lat`, `gps_lon` | double | Decimal degrees, north / east positive |
+| `iso` | int | EXIF ISO |
+| `focal_length`, `f_stop`, `exposure_time` | double | mm, F-number, seconds |
+
+### Audio
+
+| Attribute | Type | Source |
+| --- | --- | --- |
+| `artist`, `album`, `album_artist`, `composer`, `genre` | string | Audio tags (ID3v1/v2, MP4 atoms, Vorbis comments) |
+| `year`, `track` | int | Release year, track number |
+| `duration` | double | Seconds |
+| `bitrate` | int | kbps (file_size × 8 / duration / 1000) |
+| `sample_rate` | int | Hz |
+| `channels` | int | 1 = mono, 2 = stereo, … |
+
+### Video
+
+| Attribute | Type | Source |
+| --- | --- | --- |
+| `video_codec`, `audio_codec` | string | h264, h265, av1, vp9, aac, opus, ... |
+| `video_width`, `video_height` | int | Frame pixels |
+| `frame_rate` | double | fps |
+| `duration` | double | Seconds (shared with audio) |
+| `bitrate` | int | Kbps (shared with audio) |
 
 ## MCP server mode
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+# Recipes
+
+CEL expression recipes by content family, plus cross-cutting cookbook patterns.
+
+| File | Topic |
+| --- | --- |
+| [`markdown.md`](./markdown.md) | Markdown front-matter (YAML / TOML / JSON), tag membership, drafts, custom keys |
+| [`images.md`](./images.md) | EXIF — camera, lens, GPS bounding boxes, ISO / aperture, taken_at ranges |
+| [`audio.md`](./audio.md) | Audio tags (artist / album / genre / year), bitrate, sample rate, hi-res filtering |
+| [`video.md`](./video.md) | Codec, resolution, frame rate, duration, MKV vs MP4 |
+| [`office.md`](./office.md) | DOCX / XLSX / PPTX / ODT — title, author, language |
+| [`epub.md`](./epub.md) | EPUB ebooks — title, author, language |
+| [`data.md`](./data.md) | JSON / CSV / TSV / XML — `csv_columns`, `json_kind`, `root_element` |
+| [`text.md`](./text.md) | Plain text and HTML — `line_count`, `word_count`, long-line caps |
+| [`cookbook.md`](./cookbook.md) | Cross-family queries, output-format pipelines, integration with find / jq / ffmpeg / rga |
+
+Every recipe is a complete `file-search-on '<expr>'` invocation that you can paste and run. Most include a few variations and useful output-format snippets.
+
+For the canonical, up-to-date attribute list run `file-search-on --list`. For the full attribute reference see the [README](../README.md#available-attributes).

--- a/examples/audio.md
+++ b/examples/audio.md
@@ -1,0 +1,128 @@
+# Recipes — Audio
+
+Audio content types: `audio/mpeg` (MP3), `audio/mp4` (M4A/AAC), `audio/flac`, `audio/ogg`. Umbrella boolean `is_audio`.
+
+Tags are extracted via [`dhowden/tag`](https://github.com/dhowden/tag) — handles ID3v1/v2 (MP3), MP4 atoms (M4A), and Vorbis comments (FLAC, OGG) under one API. Playback metadata (duration, bitrate, sample rate, channels) is hand-rolled per format.
+
+## Tags
+
+By artist:
+
+```sh
+file-search-on 'is_audio && artist == "Radiohead"' -d ~/Music
+```
+
+By album:
+
+```sh
+file-search-on 'is_audio && album == "OK Computer"' --format '{{.Track}}\t{{.Title}}'
+```
+
+By genre and year:
+
+```sh
+file-search-on 'is_audio && genre == "Jazz" && year > 2000' -d ~/Music
+file-search-on 'is_audio && genre.contains("Electronic")'        # any genre containing "Electronic"
+```
+
+By composer (often used for classical music libraries):
+
+```sh
+file-search-on 'is_audio && composer == "J.S. Bach"' -d ~/Music/Classical
+```
+
+Find compilation albums (where `album_artist` differs from `artist`):
+
+```sh
+file-search-on 'is_audio && album_artist != "" && album_artist != artist'
+```
+
+Untagged audio files — useful for triage:
+
+```sh
+file-search-on 'is_audio && artist == "" && album == ""'
+```
+
+## Duration and bitrate
+
+Long tracks (10+ minutes — typical for jazz, classical, podcasts):
+
+```sh
+file-search-on 'is_audio && duration > 600' -d ~/Music
+```
+
+Short tracks (skits, intros):
+
+```sh
+file-search-on 'is_audio && duration < 60'
+```
+
+By bitrate buckets — find low-quality files in a library:
+
+```sh
+file-search-on 'is_audio && bitrate > 0 && bitrate < 192' -d ~/Music     # below 192 kbps
+file-search-on 'is_audio && bitrate >= 320'                              # 320 kbps+ MP3 / lossless
+```
+
+## Hi-res audio
+
+Sample rate ≥ 96 kHz indicates hi-res content:
+
+```sh
+file-search-on 'is_audio && sample_rate >= 96000' -d ~/Music
+file-search-on 'is_audio && sample_rate >= 192000'   # ultra-hi-res, rare outside studio masters
+```
+
+By channel count — surround mixes:
+
+```sh
+file-search-on 'is_audio && channels > 2'             # 5.1, 7.1, etc.
+file-search-on 'is_audio && channels == 1'            # mono
+```
+
+## Format-specific filters
+
+```sh
+file-search-on 'is_audio && content_type == "audio/flac"'        # lossless only
+file-search-on 'is_audio && content_type == "audio/mpeg"'        # MP3 only
+file-search-on 'is_audio && content_type == "audio/mp4"'         # M4A / AAC only
+```
+
+Combined with bitrate to find lossy hi-res nonsense (high bitrate MP3 isn't *truly* hi-res):
+
+```sh
+file-search-on 'is_audio && content_type == "audio/mpeg" && bitrate > 320'
+```
+
+## Combined queries
+
+A DJ's set-prep query — full-length electronic tracks at 320+:
+
+```sh
+file-search-on 'is_audio && genre.contains("Electronic") && duration > 240 && bitrate >= 320'
+```
+
+A library audit — tracks tagged but lacking dimensions or duration (broken files):
+
+```sh
+file-search-on 'is_audio && artist != "" && duration == 0.0'
+```
+
+Find new additions to a specific artist's catalogue:
+
+```sh
+file-search-on 'is_audio && artist == "Aphex Twin" && year >= 2020'
+```
+
+## Useful output formats
+
+```sh
+# Path + artist + album + track, ready for spreadsheet import
+file-search-on 'is_audio' --format '{{.Path}}\t{{.Artist}}\t{{.Album}}\t{{.Track}}\t{{.Title}}'
+
+# Just paths to all of a band's catalogue
+file-search-on 'is_audio && artist == "Radiohead"' -o bare > radiohead.list
+
+# JSON for analytics — duration histogram
+file-search-on 'is_audio' -o json | jq '.duration | floor / 60 | floor' | sort -n | uniq -c
+```

--- a/examples/cookbook.md
+++ b/examples/cookbook.md
@@ -1,0 +1,145 @@
+# Recipes — Cross-cutting cookbook
+
+Patterns that span multiple content-type families, plus pipeline / output-format tricks.
+
+## Cross-family queries
+
+All media files (image, audio, video) over 100 MB — likely the largest space-eaters in a directory:
+
+```sh
+file-search-on '(is_image || is_audio || is_video) && size > 100000000' -d ~/
+```
+
+All "long" media — videos > 30 min OR audio > 10 min:
+
+```sh
+file-search-on '(is_video && duration > 1800) || (is_audio && duration > 600)'
+```
+
+All authored documents (PDF, EPUB, office, markdown) by a specific author:
+
+```sh
+file-search-on 'author == "Jane Doe" && (is_pdf || is_epub || is_office || is_markdown)'
+```
+
+Foreign-language anything — `language` is cross-cutting across markdown / HTML / PDF / EPUB / office:
+
+```sh
+file-search-on 'language == "fr"'
+file-search-on 'language != "" && language != "en" && !language.startsWith("en")'
+```
+
+Anything titled — useful for inventories:
+
+```sh
+file-search-on 'title != ""' --format '{{.Path}}\t{{.ContentType}}\t{{.Title}}'
+```
+
+## Path-based filters
+
+Inside or outside specific subtrees:
+
+```sh
+file-search-on 'is_pdf && dir.contains("/contracts/")'
+file-search-on 'is_markdown && !dir.contains("/drafts/")'
+file-search-on 'is_image && dir.startsWith("/Volumes/Photo Backup/")'
+```
+
+By filename pattern (CEL has `string.matches(regex)`):
+
+```sh
+file-search-on 'is_image && name.matches("IMG_[0-9]{4}.*")'        # iPhone-style filenames
+file-search-on 'is_text && name.endsWith(".log.1")'                # rotated logs
+```
+
+## Output formats — pipeline patterns
+
+### `bare` for `xargs`
+
+```sh
+# Backup all 4K videos to an external drive
+file-search-on 'is_video && video_height >= 2160' -o bare -d ~/Videos | \
+  xargs -I {} cp {} /Volumes/Backup/4K/
+
+# Re-encode old H.264 to H.265 (ffmpeg required)
+file-search-on 'is_video && video_codec == "h264" && video_height >= 1080' -o bare | \
+  xargs -I {} ffmpeg -i {} -c:v libx265 {}.h265.mp4
+```
+
+### `json` for `jq` and downstream tooling
+
+```sh
+# Histogram of audio bitrates
+file-search-on 'is_audio && bitrate > 0' -o json | jq -r '.bitrate' | sort -n | uniq -c
+
+# Total disk used by 4K HEVC content
+file-search-on 'is_video && video_height >= 2160 && video_codec == "h265"' -o json | \
+  jq -s 'map(.size) | add | . / 1073741824 | "\(.)GB"'
+
+# Everything by content type, frequency-sorted
+file-search-on 'true' -o json | jq -r '.content_type' | sort | uniq -c | sort -rn
+```
+
+### `--format` for spreadsheet imports
+
+```sh
+# Photo metadata as TSV ready for a spreadsheet
+file-search-on 'is_image && taken_at > timestamp("2024-01-01T00:00:00Z")' \
+  --format '{{.Path}}\t{{.CameraModel}}\t{{.ISO}}\t{{printf "%.1f" .FocalLength}}\t{{.TakenAt}}' \
+  > photos-2024.tsv
+```
+
+## Combining with other tools
+
+### `find` for non-content filters
+
+`file-search-on` doesn't know about file mtime / atime. Combine with `find` when you need them:
+
+```sh
+# Recently-modified Markdown files
+find . -name '*.md' -mtime -7 -print0 | \
+  xargs -0 -I {} file-search-on 'is_markdown && draft' -d $(dirname {})
+```
+
+### `ripgrep-all` for full-text inside metadata-matched files
+
+```sh
+# Search inside PDFs by Jane Doe for a specific phrase
+file-search-on 'is_pdf && author == "Jane Doe"' -o bare | \
+  xargs rga 'specific phrase'
+```
+
+### `du` summary by content family
+
+```sh
+# Disk used by audio / video / images, separately
+for fam in is_audio is_video is_image is_office is_epub; do
+  total=$(file-search-on "$fam" -o json -d ~/ 2>/dev/null | jq -s 'map(.size) | add')
+  echo "$fam: $total bytes"
+done
+```
+
+## Programmatic use via MCP
+
+When run as an MCP server (`file-search-on mcp`), the same expressions work. An LLM agent can compose CEL based on the user's intent and call the `search` tool. Example client request:
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "search",
+    "arguments": {
+      "expr": "is_video && video_height >= 2160 && video_codec == \"h265\"",
+      "dir": "/Users/me/Videos"
+    }
+  }
+}
+```
+
+The MCP `search` tool returns the same attribute set as `-o json` — see [`list_attributes`](https://github.com/richardwooding/file-search-on#mcp-server-mode) for the schema.
+
+## When file-search-on isn't the right tool
+
+- **Content search inside files** — use `ripgrep` (text), `rga` (multi-format), or `xsv` (CSV). `file-search-on` does metadata filtering; pipe its output into a content tool.
+- **Filesystem-attribute search** (mtime, atime, owner, mode) — use `find`. Compose with `file-search-on` via shell.
+- **Real-time indexing** — this tool walks directly; for huge repeated searches over the same tree, build an index with another tool and query that.

--- a/examples/data.md
+++ b/examples/data.md
@@ -1,0 +1,128 @@
+# Recipes — Data formats (JSON, CSV, TSV, XML)
+
+Three structural file types with lightweight metadata extraction:
+
+| Type | Predicate | Attributes |
+| --- | --- | --- |
+| JSON | `is_json` | `json_kind` (`"object"` / `"array"`) |
+| CSV / TSV | `is_csv` | `column_count`, `csv_columns` |
+| XML | `is_xml` | `root_element` |
+
+Detection: extension first (`.json`, `.csv`, `.tsv`, `.xml`, `.xsl`, `.xslt`, `.xsd`, `.rss`, `.atom`), then magic bytes (`{`/`[` for JSON, `<?xml` for XML, no magic for CSV).
+
+## JSON
+
+Top-level shape — array vs object:
+
+```sh
+file-search-on 'is_json && json_kind == "array"' -d ./data       # NDJSON-style logs, lists
+file-search-on 'is_json && json_kind == "object"' -d ./config    # config files, single records
+```
+
+Empty / malformed JSON (`json_kind == "unknown"`):
+
+```sh
+file-search-on 'is_json && json_kind == "unknown"'
+```
+
+## CSV / TSV
+
+By column count:
+
+```sh
+file-search-on 'is_csv && column_count > 10'                     # wide tables
+file-search-on 'is_csv && column_count == 1'                     # single-column lists
+file-search-on 'is_csv && column_count >= 50'                    # often spreadsheet exports
+```
+
+By column name (the killer feature):
+
+```sh
+# CSVs that have a "revenue" column
+file-search-on 'is_csv && csv_columns.exists(c, c == "revenue")'
+
+# CSVs with both customer_id and email
+file-search-on 'is_csv && csv_columns.exists(c, c == "customer_id") && csv_columns.exists(c, c == "email")'
+
+# CSVs whose first column is named "id" (case-sensitive)
+file-search-on 'is_csv && size(csv_columns) > 0 && csv_columns[0] == "id"'
+
+# CSVs with a column whose name contains "date"
+file-search-on 'is_csv && csv_columns.exists(c, c.contains("date"))'
+```
+
+The CSV parser uses Go's `encoding/csv` with `LazyQuotes = true`, so files with embedded commas in quoted fields (`"a,b",c,d` → 3 columns) are handled correctly.
+
+By extension — CSV vs TSV:
+
+```sh
+file-search-on 'is_csv && ext == ".tsv"'
+file-search-on 'is_csv && ext == ".csv"'
+```
+
+## XML
+
+By root element — useful for distinguishing format families:
+
+```sh
+file-search-on 'is_xml && root_element == "rss"'                # RSS feeds
+file-search-on 'is_xml && root_element == "feed"'               # Atom feeds
+file-search-on 'is_xml && root_element == "svg"'                # SVG files (also caught by is_image)
+file-search-on 'is_xml && root_element == "config"'             # generic config XML
+file-search-on 'is_xml && root_element == "configuration"'      # Spring / .NET style
+```
+
+Find Atom or RSS together:
+
+```sh
+file-search-on 'is_xml && (root_element == "rss" || root_element == "feed")' -d ./feeds
+```
+
+## Combined queries
+
+A data-quality audit — empty CSVs or tiny JSON files:
+
+```sh
+file-search-on '(is_csv && column_count == 0) || (is_json && size < 10)'
+```
+
+Find all data files in a `dist/` directory:
+
+```sh
+file-search-on '(is_json || is_csv || is_xml) && dir.contains("dist")'
+```
+
+Spreadsheet exports likely to be NDJSON-friendly (one JSON array, plenty of rows — file size as a proxy):
+
+```sh
+file-search-on 'is_json && json_kind == "array" && size > 1000000'
+```
+
+## Useful output formats
+
+```sh
+# All CSV column names, deduplicated
+file-search-on 'is_csv' -o json | jq -r '.csv_columns[]?' | sort -u
+
+# Path + column count, sorted by column count
+file-search-on 'is_csv' --format '{{.ColumnCount}}\t{{.Path}}' | sort -n
+
+# Find which columns appear in which CSVs (inverted index)
+file-search-on 'is_csv' -o json | \
+  jq -r '. as $r | .csv_columns[]? | "\(.)|\($r.path)"' | \
+  sort | awk -F'|' '{c[$1]=c[$1] " " $2} END {for(k in c) print k ":" c[k]}'
+```
+
+## Interplay with full-text search
+
+For content search inside JSON/CSV/XML, this tool's output composes naturally with `jq`, `grep`, `xsv`, etc.:
+
+```sh
+# Find CSVs with "revenue" column then filter for rows above threshold
+file-search-on 'is_csv && csv_columns.exists(c, c == "revenue")' -o bare | \
+  while read f; do xsv search -s revenue '^[5-9][0-9]{4,}' "$f"; done
+
+# JSON arrays containing a specific key in any element
+file-search-on 'is_json && json_kind == "array"' -o bare | \
+  xargs -I {} jq 'map(select(.status == "active"))' {}
+```

--- a/examples/epub.md
+++ b/examples/epub.md
@@ -1,0 +1,86 @@
+# Recipes — EPUB ebooks
+
+EPUB content type: `epub` (extension `.epub`). Predicate: `is_epub`.
+
+EPUBs are zip containers with a manifest at `META-INF/container.xml` pointing to the OPF rootfile, where Dublin Core metadata lives. The same `readDublinCore` scanner that handles DOCX/XLSX/PPTX/ODT also handles EPUB.
+
+## Author and title
+
+```sh
+file-search-on 'is_epub && author == "Ursula K. Le Guin"' -d ~/Books
+file-search-on 'is_epub && title.contains("Earthsea")'
+```
+
+Anonymous or untitled books (rare, but possible from poorly-prepared epubs):
+
+```sh
+file-search-on 'is_epub && author == ""'
+file-search-on 'is_epub && title == ""'
+```
+
+## Language
+
+`language` is cross-cutting. EPUB sets it via `<dc:language>` in the OPF.
+
+```sh
+file-search-on 'is_epub && language == "en"'           # English
+file-search-on 'is_epub && language == "es"'           # Spanish
+file-search-on 'is_epub && language.startsWith("en")'  # en, en-US, en-GB, etc.
+```
+
+Books with no language set:
+
+```sh
+file-search-on 'is_epub && language == ""'
+```
+
+## Combined queries
+
+A reading-list curator's query — French-language sci-fi by a specific author:
+
+```sh
+file-search-on 'is_epub && language == "fr" && author == "Pierre Boulle"'
+```
+
+A library audit — books missing essential metadata:
+
+```sh
+file-search-on 'is_epub && (title == "" || author == "")'
+```
+
+A "find Le Guin's translated works" query:
+
+```sh
+file-search-on 'is_epub && author.contains("Le Guin") && language != "en"'
+```
+
+## File size as a proxy for length
+
+EPUBs don't carry page count or word count metadata, so file size is the best available proxy:
+
+```sh
+file-search-on 'is_epub && size > 5000000'                    # > 5 MB (long novels with images)
+file-search-on 'is_epub && size < 500000'                     # < 500 KB (short stories, novellas)
+```
+
+## Useful output formats
+
+```sh
+# A bibliographic summary
+file-search-on 'is_epub' --format '{{.Title}} — {{.Author}} ({{.Language}})'
+
+# JSON ready for Calibre import or similar
+file-search-on 'is_epub' -o json | jq '{title, author, language, size}'
+
+# All books by language, frequency-sorted
+file-search-on 'is_epub' -o json | jq -r '.language // "(unset)"' | sort | uniq -c | sort -rn
+```
+
+## What's NOT covered
+
+- **Body text search** — out of scope; metadata-only.
+- **Series / volume metadata** (Calibre custom columns) — sometimes in the OPF but not standardised; not parsed.
+- **Cover art** — not extracted (the OPF references it but we don't surface a path).
+- **Reading progress** — that's a reader-side concept, not in the EPUB itself.
+
+For full-text search inside EPUBs, pipe the matched paths to `pandoc` (which can convert EPUB to plain text) and grep the output.

--- a/examples/images.md
+++ b/examples/images.md
@@ -1,0 +1,124 @@
+# Recipes — Images and EXIF
+
+Image content types: `image/jpeg`, `image/png`, `image/gif`, `image/webp`, `image/svg+xml`, `image/tiff`, `image/bmp`, `image/heic`. The umbrella boolean `is_image` matches any of them.
+
+EXIF metadata is extracted from JPEG, TIFF, HEIC, and PNG (eXIf chunk) via [`evanoberholster/imagemeta`](https://github.com/evanoberholster/imagemeta). GIF/WebP/BMP/SVG fall back to stdlib `image.DecodeConfig` for `img_width`/`img_height` only.
+
+## Camera and lens
+
+Find photos shot on a specific camera:
+
+```sh
+file-search-on 'is_image && camera_make == "Canon"' -d ~/Pictures
+file-search-on 'is_image && camera_model == "iPhone 15 Pro"'
+```
+
+Find shots from a specific lens (handy for prime-lens fans):
+
+```sh
+file-search-on 'is_image && lens.contains("50mm")' -d ~/Pictures
+```
+
+Photos with no EXIF camera info (web-stripped, scanned, or screenshots):
+
+```sh
+file-search-on 'is_image && camera_make == ""'
+```
+
+## Resolution
+
+```sh
+file-search-on 'is_image && img_width >= 4000'              # high-res
+file-search-on 'is_image && img_width < 800'                # thumbnails
+file-search-on 'is_image && img_width >= 4000 && img_height >= 3000'   # full-res photos
+```
+
+## Capture date
+
+```sh
+# 2024 photos
+file-search-on 'is_image && taken_at >= timestamp("2024-01-01T00:00:00Z") && taken_at < timestamp("2025-01-01T00:00:00Z")'
+
+# Last-week's shots (computed externally and substituted in)
+file-search-on "is_image && taken_at > timestamp(\"$(date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)\")"
+```
+
+`taken_at` falls back through DateTimeOriginal → CreateDate → ModifyDate, so even scanned or edited images that lack `DateTimeOriginal` will still report a date.
+
+## GPS — geographic bounding boxes
+
+Decimal degrees, north / east positive. To find photos taken in a region, set lat / lon ranges around the centre:
+
+```sh
+# London-ish
+file-search-on 'is_image && gps_lat > 51.4 && gps_lat < 51.6 && gps_lon > -0.2 && gps_lon < 0.0'
+
+# San Francisco
+file-search-on 'is_image && gps_lat > 37.7 && gps_lat < 37.8 && gps_lon > -122.5 && gps_lon < -122.4'
+```
+
+Photos with NO GPS data (privacy review, web-stripped):
+
+```sh
+file-search-on 'is_image && gps_lat == 0.0 && gps_lon == 0.0 && camera_make != ""'
+```
+
+(The `camera_make != ""` filters out non-EXIF images like SVGs and BMPs, which would otherwise match the GPS = 0 condition.)
+
+## Exposure settings
+
+```sh
+file-search-on 'is_image && iso > 1600'                          # high-ISO (low-light, noise)
+file-search-on 'is_image && f_stop < 2.0'                        # wide-aperture / shallow DOF
+file-search-on 'is_image && focal_length >= 200.0'               # telephoto
+file-search-on 'is_image && exposure_time > 1.0'                 # long exposures > 1 sec
+```
+
+## Combined queries
+
+A photographer's review query — high-ISO Sony shots from a specific camera body:
+
+```sh
+file-search-on 'is_image && camera_make == "SONY" && camera_model.contains("A7") && iso > 3200'
+```
+
+Wedding photographer's prime lens portfolio — 35mm or 85mm primes, wide aperture:
+
+```sh
+file-search-on 'is_image && (focal_length == 35.0 || focal_length == 85.0) && f_stop < 2.0'
+```
+
+iPhone photos taken in 2024 in a specific city:
+
+```sh
+file-search-on 'is_image && camera_model.contains("iPhone") && gps_lat > 51.4 && gps_lat < 51.6 && taken_at > timestamp("2024-01-01T00:00:00Z")'
+```
+
+## Orientation
+
+EXIF orientation is 1-8. Common values:
+
+| Value | Meaning |
+| --- | --- |
+| 1 | Normal |
+| 3 | Rotated 180° |
+| 6 | Rotated 90° CW (i.e. portrait phone capture stored as landscape) |
+| 8 | Rotated 90° CCW |
+
+```sh
+file-search-on 'is_image && orientation == 6'        # phone-portraits
+file-search-on 'is_image && orientation != 1 && orientation != 0'   # any non-default rotation
+```
+
+## Useful output formats
+
+```sh
+# Path + camera + ISO, tab-separated
+file-search-on 'is_image && camera_make != ""' --format '{{.Path}}\t{{.CameraModel}}\t{{.ISO}}'
+
+# JSON for jq — sort by ISO descending
+file-search-on 'is_image && iso > 0' -o json | jq -s 'sort_by(-.iso) | .[].path'
+
+# Bare paths for xargs (e.g. copy a year's photos)
+file-search-on 'is_image && taken_at > timestamp("2024-01-01T00:00:00Z")' -o bare | xargs -I {} cp {} ~/photos-2024/
+```

--- a/examples/markdown.md
+++ b/examples/markdown.md
@@ -1,0 +1,139 @@
+# Recipes — Markdown front-matter
+
+Markdown front-matter search is a primary use case. Three formats are recognised, each detected by the very first bytes:
+
+| Format | Opening | Closing | Common in |
+| --- | --- | --- | --- |
+| YAML | `---` line | `---` line | Jekyll, Obsidian, Hugo, MkDocs |
+| TOML | `+++` line | `+++` line | Hugo, Zola |
+| JSON | `{` at byte 0 | matching `}` | Hugo, Eleventy |
+
+Seven keys are promoted to first-class CEL variables: `title`, `author`, `language`, `tags`, `categories`, `draft`, `date`. Anything else is reachable via the generic `frontmatter` map.
+
+## Drafts and publishing state
+
+Find drafts:
+
+```sh
+file-search-on 'is_markdown && draft' -d ./content
+```
+
+Find published posts (note `!draft` covers both `draft: false` and missing `draft`):
+
+```sh
+file-search-on 'is_markdown && !draft' -d ./content
+```
+
+## Tags and categories
+
+Find Markdown tagged `go`:
+
+```sh
+file-search-on 'is_markdown && "go" in tags' -d ./posts
+```
+
+Find non-draft posts tagged `longread`:
+
+```sh
+file-search-on 'is_markdown && "longread" in tags && !draft'
+```
+
+Find posts in either of two categories:
+
+```sh
+file-search-on 'is_markdown && ("essays" in categories || "notes" in categories)'
+```
+
+A bare `tags: solo` is automatically wrapped to a single-element list, so `"solo" in tags` works without authors needing to write `[solo]`.
+
+## Dates
+
+Find posts from 2024 onward:
+
+```sh
+file-search-on 'is_markdown && date >= timestamp("2024-01-01T00:00:00Z")'
+```
+
+Find posts in a date range:
+
+```sh
+file-search-on 'is_markdown && date >= timestamp("2024-06-01T00:00:00Z") && date < timestamp("2024-09-01T00:00:00Z")'
+```
+
+Native TOML dates and common YAML/JSON string layouts (RFC3339, `YYYY-MM-DD`) are accepted.
+
+## Custom front-matter keys
+
+Reach any unpromoted key via `frontmatter.<key>`:
+
+```sh
+file-search-on 'is_markdown && frontmatter.category == "essay"'
+file-search-on 'is_markdown && frontmatter.weight > 50'
+file-search-on 'is_markdown && frontmatter.featured == true'
+```
+
+For nested keys like `seo.description`, use chained lookups:
+
+```sh
+file-search-on 'is_markdown && frontmatter.seo.description != ""'
+```
+
+## Front-matter format
+
+The `frontmatter_format` variable reports which dialect was detected:
+
+```sh
+file-search-on 'is_markdown && frontmatter_format == "toml"'   # Hugo / Zola
+file-search-on 'is_markdown && frontmatter_format == ""'       # No front-matter at all
+```
+
+## Body content
+
+Long-form content thresholds:
+
+```sh
+file-search-on 'is_markdown && word_count > 1000'                          # longreads
+file-search-on 'is_markdown && word_count < 100 && !draft'                 # stub posts
+```
+
+The H1 fallback for `title`: if there's no front-matter `title`, the first `# Heading` line wins. To find posts without an H1 *or* a front-matter title:
+
+```sh
+file-search-on 'is_markdown && title == ""'
+```
+
+## Combining
+
+Long, tagged, non-draft posts (the canonical longread filter):
+
+```sh
+file-search-on 'is_markdown && word_count > 1500 && "longread" in tags && !draft'
+```
+
+Drafts that have been worked on (have a body but unfinished):
+
+```sh
+file-search-on 'is_markdown && draft && word_count > 200'
+```
+
+Foreign-language posts via the cross-cutting `language` variable (works for HTML and EPUB too):
+
+```sh
+file-search-on 'is_markdown && language == "fr"'
+```
+
+## Useful output formats
+
+```sh
+# Just paths, ready to pipe
+file-search-on 'is_markdown && draft' -o bare | xargs $EDITOR
+
+# Multi-line view of all metadata
+file-search-on 'is_markdown && "longread" in tags' -o verbose | head -40
+
+# Custom columns: path, title, word count
+file-search-on 'is_markdown && !draft' --format '{{.Path}}\t{{.Title}}\t{{.WordCount}}'
+
+# Full JSON for jq pipelines
+file-search-on 'is_markdown' -o json | jq 'select(.frontmatter.weight > 50) | .path'
+```

--- a/examples/office.md
+++ b/examples/office.md
@@ -1,0 +1,90 @@
+# Recipes — Office documents
+
+Office content types: `office/docx`, `office/xlsx`, `office/pptx`, `office/odt`. Umbrella boolean `is_office`.
+
+All four are zip-based containers with metadata stored as Dublin Core elements (`dc:title`, `dc:creator`, `dc:language`). DOCX/XLSX/PPTX read from `docProps/core.xml`; ODT reads from `meta.xml`. Same parser handles all four since the inner element names are identical.
+
+## By format
+
+```sh
+file-search-on 'is_office && content_type == "office/docx"' -d ~/Documents
+file-search-on 'is_office && content_type == "office/xlsx"' -d ~/Documents
+file-search-on 'is_office && content_type == "office/pptx"' -d ~/Documents
+file-search-on 'is_office && content_type == "office/odt"' -d ~/Documents
+```
+
+## Title
+
+```sh
+file-search-on 'is_office && title == "Quarterly Report"'
+file-search-on 'is_office && title.contains("Draft")'
+file-search-on 'is_office && title.startsWith("2024")'
+```
+
+Untitled documents (often defaults from templates that nobody filled in):
+
+```sh
+file-search-on 'is_office && title == ""'
+```
+
+## Author
+
+```sh
+file-search-on 'is_office && author == "Jane Doe"'
+file-search-on 'is_office && author.contains("Smith")'
+```
+
+Anonymous documents:
+
+```sh
+file-search-on 'is_office && author == ""'
+```
+
+## Language
+
+`language` is cross-cutting — same variable as Markdown / EPUB / HTML / PDF.
+
+```sh
+file-search-on 'is_office && language == "en-GB"'        # British English
+file-search-on 'is_office && language == "fr"'           # French
+file-search-on 'is_office && language.startsWith("en")'  # any English variant
+```
+
+## Combined queries
+
+A compliance audit — find all DOCX/XLSX without an author:
+
+```sh
+file-search-on 'is_office && (content_type == "office/docx" || content_type == "office/xlsx") && author == ""'
+```
+
+A "draft" cleanup — find office files whose title contains "Draft" or "Copy":
+
+```sh
+file-search-on 'is_office && (title.contains("Draft") || title.contains("Copy"))'
+```
+
+Find documents from a specific author across all office formats:
+
+```sh
+file-search-on 'is_office && author == "Jane Doe"' --format '{{.Path}}\t{{.ContentType}}\t{{.Title}}'
+```
+
+## Useful output formats
+
+```sh
+# Sorted listing of all spreadsheets with title and author
+file-search-on 'is_office && content_type == "office/xlsx"' --format '{{.Path}}\t{{.Title}}\t{{.Author}}' | sort
+
+# JSON for analytics — frequency by author
+file-search-on 'is_office' -o json | jq -r '.author // "(unknown)"' | sort | uniq -c | sort -rn
+```
+
+## What's NOT covered
+
+- **DOCX / PPTX content search** (text inside slides or paragraphs) — out of scope for v1; this is metadata-only.
+- **XLSX cell content** — same.
+- **Track changes / revisions** — not parsed.
+- **Custom document properties** (the `app.xml` / custom properties beyond core.xml) — not surfaced.
+
+For full-text search of office documents, pipe the matched paths to a tool like `ripgrep-all` (`rga`) or `pandoc`.

--- a/examples/text.md
+++ b/examples/text.md
@@ -1,0 +1,99 @@
+# Recipes — Plain text and HTML
+
+`text/plain` covers `.txt`, `.text`, `.log`. Predicate: `is_text`.
+
+`html` covers `.html`, `.htm`, `.xhtml`. Predicate: `is_html`.
+
+Both are loop-bound types: a single `bufio.Scanner` pass per file with a configurable per-line buffer cap (`-L` flag, default 1 MiB).
+
+## Plain text
+
+By line count — useful for log triage:
+
+```sh
+file-search-on 'is_text && line_count > 1000' -d /var/log
+file-search-on 'is_text && line_count == 0'                       # empty files
+file-search-on 'is_text && ext == ".log" && line_count > 100000'  # large logs
+```
+
+By word count:
+
+```sh
+file-search-on 'is_text && word_count > 5000'                     # long-form text
+file-search-on 'is_text && word_count < 100 && size > 1000000'    # huge files with few words (binary garbage in .txt?)
+```
+
+Combined — recently-rotated logs that have content:
+
+```sh
+file-search-on 'is_text && ext == ".log" && line_count > 0 && size < 10485760' -d /var/log
+```
+
+## Long-line files
+
+The default 1 MiB per-line cap silently truncates lines longer than that. For files with very long single lines (minified output, single-line JSON logs), bump the cap:
+
+```sh
+file-search-on 'is_text && line_count > 0' -L 16777216 -d /var/log/json
+```
+
+Or to detect files that *might* have such lines (low line count for their size):
+
+```sh
+file-search-on 'is_text && size > 100000 && line_count < 10'
+```
+
+## HTML
+
+By title (extracted from `<title>` element):
+
+```sh
+file-search-on 'is_html && title.contains("404")' -d ./build
+file-search-on 'is_html && title == ""'                           # untitled pages
+```
+
+By language (`<html lang="...">`):
+
+```sh
+file-search-on 'is_html && language == "en"'
+file-search-on 'is_html && language == ""'                        # missing lang attribute (a11y red flag)
+```
+
+Combined — find untitled HTML in a build directory (broken pages):
+
+```sh
+file-search-on 'is_html && title == "" && dir.contains("build")'
+```
+
+## Combining with paths
+
+Files in a specific directory tree:
+
+```sh
+file-search-on 'is_text && dir.contains("/var/log/nginx/")'
+```
+
+Files NOT in node_modules / vendor:
+
+```sh
+file-search-on 'is_text && !dir.contains("node_modules") && !dir.contains("vendor")'
+```
+
+## Useful output formats
+
+```sh
+# Bare paths to feed grep / awk
+file-search-on 'is_text && line_count > 1000' -o bare | xargs grep -l "ERROR"
+
+# Sorted listing — biggest log files first
+file-search-on 'is_text && ext == ".log"' -o json | jq -s 'sort_by(-.size) | .[].path'
+
+# Line count totals
+file-search-on 'is_text' -o json | jq -s 'map(.line_count) | add'
+```
+
+## What's NOT covered
+
+- **Encoding detection** — the scanner reads UTF-8 / ASCII bytes; UTF-16 / Latin-1 files give correct line counts but `word_count` may be misleading for non-ASCII content.
+- **Binary detection** — files with `.txt` extension but binary content will pass through; line count will reflect byte boundaries.
+- **`.md` detection** — Markdown files are matched by `is_markdown`, not `is_text`. See [`markdown.md`](./markdown.md).

--- a/examples/video.md
+++ b/examples/video.md
@@ -1,0 +1,127 @@
+# Recipes — Video
+
+Video content types: `video/mp4` (.mp4 / .m4v), `video/quicktime` (.mov / .qt), `video/x-matroska` (.mkv), `video/webm`, `video/x-msvideo` (.avi). Umbrella boolean `is_video`.
+
+Hand-rolled binary parsers — no CGO, no `ffmpeg` dependency.
+
+## Codec
+
+Find HEVC encodes (smaller files, modern phones):
+
+```sh
+file-search-on 'is_video && video_codec == "h265"' -d ~/Videos
+```
+
+Find AV1 encodes (newest open codec):
+
+```sh
+file-search-on 'is_video && video_codec == "av1"'
+```
+
+Find legacy H.264:
+
+```sh
+file-search-on 'is_video && video_codec == "h264"'
+```
+
+The codec strings are normalised across containers — `avc1` / `avc3` (MP4) and `V_MPEG4/ISO/AVC` (MKV) both report as `"h264"`.
+
+## Audio track in a video
+
+The audio codec inside a video container is captured as `audio_codec`:
+
+```sh
+file-search-on 'is_video && audio_codec == "aac"'              # most MP4 / phone clips
+file-search-on 'is_video && audio_codec == "opus"'             # WebM / modern MKV
+file-search-on 'is_video && audio_codec == "ac3"'              # Blu-ray rips
+```
+
+## Resolution
+
+```sh
+file-search-on 'is_video && video_height >= 2160'                 # 4K and above
+file-search-on 'is_video && video_height >= 1080'                 # 1080p+
+file-search-on 'is_video && video_width <= 720'                   # SD / low-res
+file-search-on 'is_video && video_width >= 7680'                  # 8K (rare)
+```
+
+Aspect ratio (vertical / portrait):
+
+```sh
+file-search-on 'is_video && video_height > video_width'           # portrait, e.g. phone clips
+```
+
+## Frame rate
+
+```sh
+file-search-on 'is_video && frame_rate > 30'                      # high-FPS (slo-mo, gaming)
+file-search-on 'is_video && frame_rate >= 60'
+file-search-on 'is_video && frame_rate < 25'                      # film transfer / animation
+```
+
+The frame rate is computed from the first stts entry (MP4) or DefaultDuration (MKV) / microSecPerFrame (AVI). For VBR content the first entry is taken as the dominant rate.
+
+## Duration
+
+```sh
+file-search-on 'is_video && duration > 1800'                      # over 30 minutes
+file-search-on 'is_video && duration < 60'                        # short clips
+file-search-on 'is_video && duration > 7200'                      # over 2 hours (films)
+```
+
+## Bitrate
+
+`bitrate` is computed average (file_size × 8 / duration / 1000), shared with audio. Useful for spotting compressed files:
+
+```sh
+file-search-on 'is_video && bitrate < 1000 && video_height >= 1080'   # over-compressed 1080p
+file-search-on 'is_video && bitrate > 50000'                          # uncompressed / RAW captures
+```
+
+## Format-specific filters
+
+```sh
+file-search-on 'is_video && content_type == "video/x-matroska"'   # MKV only
+file-search-on 'is_video && content_type == "video/mp4"'          # MP4 / M4V
+file-search-on 'is_video && content_type == "video/webm"'         # WebM (Vorbis/VP9 typical)
+```
+
+## Combined queries
+
+The "find good archive material" query — high-resolution, modern codec, decent bitrate, longer than a clip:
+
+```sh
+file-search-on 'is_video && video_height >= 1080 && (video_codec == "h265" || video_codec == "av1") && bitrate > 4000 && duration > 300'
+```
+
+The "find space-wasters" query — old codec, big file, low resolution:
+
+```sh
+file-search-on 'is_video && video_codec == "h264" && size > 5000000000 && video_height < 1080'
+```
+
+Phone clips (portrait-rotated MP4 from a phone, > 30 fps):
+
+```sh
+file-search-on 'is_video && content_type == "video/mp4" && frame_rate >= 30 && video_height > video_width'
+```
+
+## Useful output formats
+
+```sh
+# A summary table: path, codec, dims, fps, duration in minutes
+file-search-on 'is_video' --format '{{.Path}}\t{{.VideoCodec}}\t{{.VideoWidth}}x{{.VideoHeight}}\t{{printf "%.1f" .FrameRate}}fps\t{{printf "%.0f" .Duration}}s'
+
+# Total minutes of HEVC content
+file-search-on 'is_video && video_codec == "h265"' -o json | jq -s 'map(.duration) | add / 60'
+
+# All 4K content as a flat list
+file-search-on 'is_video && video_height >= 2160' -o bare
+```
+
+## Known limitations
+
+- **Aspect-ratio rotation**: phone-recorded clips often store portrait video as 1920×1080 with a 90° rotation matrix in `tkhd`. We currently report the stored dimensions, not the displayed dimensions. Tracked in [#36](https://github.com/richardwooding/file-search-on/issues/36).
+- **HDR**: `colr` (MP4) and `Colour` (MKV) elements aren't parsed; `is_hdr` is a follow-up. Tracked in [#38](https://github.com/richardwooding/file-search-on/issues/38).
+- **Subtitle tracks**: presence and language not surfaced. Tracked in [#39](https://github.com/richardwooding/file-search-on/issues/39).
+- **`audio_codec` is video-only** in the current build — for the audio track inside a video container. Audio sample_rate / channels for video files are tracked in [#37](https://github.com/richardwooding/file-search-on/issues/37).


### PR DESCRIPTION
## Summary
The README had drifted markdown-first as the project added eight content-type families. This rebalances it and moves depth into focused recipe files.

## README

- **Polyglot opening**: replaced the markdown-only intro with a taste of CEL queries across PDF, images, audio, video, office, and markdown.
- **Features → content-type families table** showing all 24 formats and the bundle of attributes per family.
- **Markdown front-matter** demoted from its own top-level section to a pointer at \`examples/markdown.md\` (still listed in Features).
- **Recipes section** trimmed to a brief table of links + ~6 representative one-liners.
- **Available attributes** reorganised into thematic subsections (Common / Document / Data / Front-matter / Images / Audio / Video) instead of one long mixed table.
- Net: **353 → 311 lines** despite covering substantially more.

## New \`examples/\` directory (9 files)

| File | Topic |
| --- | --- |
| [\`examples/README.md\`](./examples/README.md) | Index with one-line summaries per file |
| [\`markdown.md\`](./examples/markdown.md) | Front-matter (YAML / TOML / JSON), tags, dates, custom keys |
| [\`images.md\`](./examples/images.md) | EXIF, GPS bounding boxes, ISO / aperture, capture dates |
| [\`audio.md\`](./examples/audio.md) | Tags, duration, bitrate, hi-res filtering, audit queries |
| [\`video.md\`](./examples/video.md) | Codec, resolution, frame rate, container-specific filters |
| [\`office.md\`](./examples/office.md) | DOCX / XLSX / PPTX / ODT — title, author, language |
| [\`epub.md\`](./examples/epub.md) | EPUB ebooks |
| [\`data.md\`](./examples/data.md) | JSON / CSV / TSV / XML — \`csv_columns\`, \`json_kind\`, \`root_element\` |
| [\`text.md\`](./examples/text.md) | Plain text + HTML — line / word counts, long-line caps |
| [\`cookbook.md\`](./examples/cookbook.md) | Cross-family queries; \`xargs\` / \`jq\` / \`ffmpeg\` / \`rga\` / \`find\` integration; MCP usage |

Each file is a complete, paste-and-run reference for one topic. Most include 6-15 recipes plus output-format snippets.

## No code changes
Pure docs. \`go build ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)