### PR TITLE
chore: gitignore personal linkedin-article skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ go.work.sum
 # Claude Code per-user settings (skills under .claude/skills/ are shared)
 .claude/settings.local.json
 
+# Personal Claude skills kept out of the public repo
+.claude/skills/linkedin-article/
+
 # GoReleaser local snapshot output
 dist/


### PR DESCRIPTION
Adds \`.claude/skills/linkedin-article/\` to \`.gitignore\` so a personal LinkedIn-drafting skill can live alongside the committed skills without ending up in the public repo.

The skill itself isn't part of this PR — just the gitignore line that keeps any local instance out of \`git status\` / \`git add\` output for any contributor.

For context on what such a skill would do: drafts a LinkedIn article in Markdown with inline \`[text](url)\` hyperlinks, then runs a script that converts the Markdown to RTF via \`pandoc\` + \`textutil\` and places it on the macOS clipboard with \`pbcopy\`, so the next paste into LinkedIn's article editor preserves headings, bold, italics, lists, and clickable links. Personal and tool-specific enough that it doesn't belong in this repo's public skill set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)