### PR TITLE
feat(celexpr): add fuzzy-string CEL functions (levenshtein, soundex, n-grams)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,19 @@ When you change the promoted-variable set:
 3. If it's an image-family type, also extend the `strings.HasPrefix(contentTypeName, "image/")` branch logic in `BuildAttributes`. The registered-types listing in `--list` is generated from `content.DefaultRegistry().Types()`, so the new type appears there automatically.
 4. For office documents, register the type with name `office/<format>` (e.g. `office/docx`); the `strings.HasPrefix(contentTypeName, "office/")` branch in `BuildAttributes` will set `is_office = true` automatically. DOCX/XLSX/PPTX use `docProps/core.xml` (Dublin Core); ODT uses `meta.xml`. Both go through the shared `readZipDublinCore` helper in `internal/content/dublincore.go`.
 
+### Adding a CEL function
+
+CEL functions (callable from inside expressions, distinct from variables) are wired in `internal/celexpr/functions.go`. The pattern:
+
+1. Implement the algorithm as an exported pure-Go function (e.g. `Levenshtein`, `Soundex`) — exported so it's directly unit-testable without going through the CEL environment.
+2. Write a `ref.Val` binding (`*Binding` functions in `functions.go`) that adapts `ref.Val` arguments into Go primitives via `.Value().(string)` / `.Value().(int64)`, dispatches to the algorithm, and wraps the result via `types.Int(...)`, `types.String(...)`, `types.Double(...)`, or `types.DefaultTypeAdapter.NativeToValue(...)` for slices/maps.
+3. Add a `cel.Function(name, cel.Overload(id, argTypes, returnType, cel.BinaryBinding|UnaryBinding|FunctionBinding(impl)))` entry to `fuzzyFunctions()` in the same file.
+4. Add a `FunctionDoc` entry to `celexpr.Schema()` in `internal/celexpr/schema.go`. This is the only place function docs live — both the CLI `--list` output (via `printFuncs` in `cmd/file-search-on/main.go`) and the MCP `list_attributes` tool surface them automatically.
+5. Optionally update the MCP `search` tool's `Description` in `internal/mcpserver/server.go` if the new function is significant enough to mention in the handshake.
+6. Add unit tests for the algorithm in `internal/celexpr/functions_test.go` and a CEL-level integration test in the same file's `TestEvaluateFuzzyFunctions` (table-driven).
+
+The four call sites — algorithm impl, binding, env declaration, schema doc — all live in `functions.go` + `schema.go`. cel-go binds at runtime, so missing any of them surfaces as a CEL "undeclared reference" error during expression compilation, not at Go-build time.
+
 ### MCP server
 
 `internal/mcpserver` is a thin adapter over the existing `search.Walk` and `celexpr.Schema()`. The `mcp` subcommand starts a stdio JSON-RPC server using the official Go SDK; nothing else in the binary changes when MCP mode is active.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Focused recipe collections live under [`examples/`](./examples/):
 | [`examples/data.md`](./examples/data.md) | JSON arrays vs objects, CSV column membership, XML root elements |
 | [`examples/text.md`](./examples/text.md) | Plain text / log files — line count, word count, big-line caps |
 | [`examples/cookbook.md`](./examples/cookbook.md) | Cross-cutting recipes — dedupe, mixed media filters, pipeline integration |
+| [`examples/fuzzy-search.md`](./examples/fuzzy-search.md) | Fuzzy / phonetic / n-gram similarity matching — `levenshtein`, `soundex`, `ngrams`, `ngram_similarity` |
 
 A handful of representative one-liners:
 
@@ -154,6 +155,12 @@ file-search-on 'is_office && language == "fr"' -d ~/Documents
 
 # Audio tracks ≥ 96 kHz (hi-res)
 file-search-on 'is_audio && sample_rate >= 96000' -d ~/Music
+
+# Fuzzy: artist tag within 2 edits of "Radiohead" (catches typos)
+file-search-on 'is_audio && levenshtein(artist, "Radiohead") <= 2' -d ~/Music
+
+# Phonetic: any author whose name sounds like "Smith"
+file-search-on 'is_markdown && soundex(author) == soundex("Smith")' -d ./posts
 ```
 
 Combine paths and types — find HTML files inside a `build/` directory:
@@ -237,6 +244,17 @@ Run `file-search-on --list` for the canonical, up-to-date listing. The summary t
 | `frame_rate` | double | fps |
 | `duration` | double | Seconds (shared with audio) |
 | `bitrate` | int | Kbps (shared with audio) |
+
+### Built-in functions
+
+CEL expressions can call these fuzzy / phonetic helpers in addition to the standard CEL operators. Full recipes in [`examples/fuzzy-search.md`](./examples/fuzzy-search.md).
+
+| Function | Returns | Use it for |
+| --- | --- | --- |
+| `levenshtein(a, b)` | int | Edit distance (rune-aware, case-sensitive) — typo-tolerant equality |
+| `soundex(s)` | string | American Soundex (NARA standard) — phonetic name matching |
+| `ngrams(s, n)` | list&lt;string&gt; | Character n-grams — set composition with `.exists()` / `.size()` |
+| `ngram_similarity(a, b, n)` | double | Jaccard 0.0–1.0 over n-gram sets — substring-tolerant similarity |
 
 ## MCP server mode
 

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -129,6 +129,9 @@ func printHelp() {
 	fmt.Println("Markdown front-matter attributes (YAML ---, TOML +++, JSON {}):")
 	printAttrs(schema.Frontmatter, 18, 11)
 	fmt.Println()
+	fmt.Println("Built-in functions:")
+	printFuncs(schema.Functions)
+	fmt.Println()
 	fmt.Println("Registered content types:")
 	for _, ct := range contentpkg.DefaultRegistry().Types() {
 		fmt.Printf("  %-20s %v\n", ct.Name(), ct.Extensions())
@@ -139,6 +142,15 @@ func printAttrs(attrs []celexpr.AttributeDoc, nameWidth, typeWidth int) {
 	for _, a := range attrs {
 		typeField := "(" + a.Type + ")"
 		fmt.Printf("  %-*s %-*s - %s\n", nameWidth, a.Name, typeWidth, typeField, a.Description)
+	}
+}
+
+func printFuncs(funcs []celexpr.FunctionDoc) {
+	for _, f := range funcs {
+		fmt.Printf("  %s\n      %s\n", f.Signature, f.Description)
+		if f.Example != "" {
+			fmt.Printf("      e.g. %s\n", f.Example)
+		}
 	}
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ CEL expression recipes by content family, plus cross-cutting cookbook patterns.
 | [`data.md`](./data.md) | JSON / CSV / TSV / XML — `csv_columns`, `json_kind`, `root_element` |
 | [`text.md`](./text.md) | Plain text and HTML — `line_count`, `word_count`, long-line caps |
 | [`cookbook.md`](./cookbook.md) | Cross-family queries, output-format pipelines, integration with find / jq / ffmpeg / rga |
+| [`fuzzy-search.md`](./fuzzy-search.md) | Fuzzy / phonetic / n-gram similarity matching with `levenshtein`, `soundex`, `ngrams`, `ngram_similarity` |
 
 Every recipe is a complete `file-search-on '<expr>'` invocation that you can paste and run. Most include a few variations and useful output-format snippets.
 

--- a/examples/audio.md
+++ b/examples/audio.md
@@ -126,3 +126,18 @@ file-search-on 'is_audio && artist == "Radiohead"' -o bare > radiohead.list
 # JSON for analytics — duration histogram
 file-search-on 'is_audio' -o json | jq '.duration | floor / 60 | floor' | sort -n | uniq -c
 ```
+
+## Fuzzy matching for messy tags
+
+```sh
+# Catch artist-name typos within 2 edits — useful when tags came from scrapers.
+file-search-on 'is_audio && levenshtein(artist, "Radiohead") <= 2'
+
+# Phonetic match — "Smith", "Smyth", "Smithe" all encode to S530.
+file-search-on 'is_audio && soundex(artist) == soundex("Smith")'
+
+# Albums similar to a target — Jaccard over n-gram sets.
+file-search-on 'is_audio && ngram_similarity(album, "OK Computer", 2) > 0.7'
+```
+
+See [`fuzzy-search.md`](./fuzzy-search.md) for the full set of fuzzy / phonetic recipes.

--- a/examples/cookbook.md
+++ b/examples/cookbook.md
@@ -138,6 +138,22 @@ When run as an MCP server (`file-search-on mcp`), the same expressions work. An 
 
 The MCP `search` tool returns the same attribute set as `-o json` — see [`list_attributes`](https://github.com/richardwooding/file-search-on#mcp-server-mode) for the schema.
 
+The `list_attributes` payload also includes the four built-in fuzzy functions (`levenshtein`, `soundex`, `ngrams`, `ngram_similarity`) with their signatures and examples — agents pick them up via the MCP handshake without prior knowledge.
+
+## Fuzzy / phonetic matching across families
+
+```sh
+# Cross-family phonetic search — any author / artist / camera-make matching a phonetic target.
+file-search-on '(is_markdown && soundex(author) == soundex("Schmidt")) ||
+                (is_audio && soundex(artist) == soundex("Schmidt")) ||
+                (is_image && soundex(camera_make) == soundex("Schmidt"))'
+
+# Tolerate typos in cross-cutting filename matches.
+file-search-on 'levenshtein(name, "kubernetes-deploy.yaml") <= 3'
+```
+
+See [`fuzzy-search.md`](./fuzzy-search.md) for the dedicated fuzzy / phonetic recipe collection.
+
 ## When file-search-on isn't the right tool
 
 - **Content search inside files** — use `ripgrep` (text), `rga` (multi-format), or `xsv` (CSV). `file-search-on` does metadata filtering; pipe its output into a content tool.

--- a/examples/fuzzy-search.md
+++ b/examples/fuzzy-search.md
@@ -1,0 +1,95 @@
+# Recipes — Fuzzy search
+
+The CEL environment ships four built-in functions for typo-tolerant and phonetic matching. These complement exact-match operators (`==`, `in`, `contains`) when the input data is hand-typed, scraped, or transliterated.
+
+| Function | Returns | Use it for |
+| --- | --- | --- |
+| `levenshtein(a, b) -> int` | edit count | typo-tolerant equality (artist names, authors, camera makes) |
+| `soundex(s) -> string` | 4-char ASCII code | phonetic matching (names that sound alike but spell differently) |
+| `ngrams(s, n) -> list<string>` | character n-grams | low-level set composition with `.exists()` / `.size()` |
+| `ngram_similarity(a, b, n) -> double` | Jaccard 0.0–1.0 | substring-tolerant similarity (titles, headlines) |
+
+Run `file-search-on --list` for the canonical signatures.
+
+## Levenshtein — typo-tolerant equality
+
+```sh
+# Within 2 edits of "Radiohead" — covers "Radiohad", "Radiohad ", "Radiohea", etc.
+file-search-on 'is_audio && levenshtein(artist, "Radiohead") <= 2' -d ~/Music
+
+# Authors with mistyped first names in markdown front-matter.
+file-search-on 'is_markdown && levenshtein(author, "Jane Doe") <= 1' -d ./posts
+
+# Camera make typos in EXIF — useful when scraping.
+file-search-on 'is_image && levenshtein(camera_make, "FUJIFILM") <= 2' -d ~/Photos
+```
+
+Levenshtein is rune-aware: `café` vs `cafe` is one edit, not three.
+
+## Soundex — phonetic matching
+
+```sh
+# Matches "Smith", "Smyth", "Smithe", "Smit" — all encode to S530.
+file-search-on 'is_markdown && soundex(author) == soundex("Smith")' -d ./posts
+
+# EXIF camera-make matches across capitalisation and minor typos.
+file-search-on 'is_image && soundex(camera_make) == soundex("Nikon")' -d ~/Photos
+
+# Audio-artist phonetic match — "Johnson" / "Jonson" / "Jansen" all collide on J525.
+file-search-on 'is_audio && soundex(artist) == soundex("Johnson")' -d ~/Music
+```
+
+Soundex is the NARA standard: vowels separate same-code consonants, but H and W are transparent. `Ashcraft` and `Ashcroft` both encode to `A261`.
+
+## N-gram similarity — substring-tolerant similarity
+
+```sh
+# Titles within 60% n-gram overlap of "kubernetes" — catches "Kuburnates",
+# "Kubernates", and other transliterations.
+file-search-on 'is_markdown && ngram_similarity(title, "kubernetes", 2) > 0.6' -d ./posts
+
+# Audio albums with fuzzy similarity to a target — useful when tag spelling is messy.
+file-search-on 'is_audio && ngram_similarity(album, "OK Computer", 2) > 0.7' -d ~/Music
+
+# Filename match — survives reorderings ("file-search-on" vs "search-file-on" still high).
+file-search-on 'ngram_similarity(name, "file-search-on", 3) > 0.5'
+```
+
+Pick `n` based on the length of your target string: `n=2` for short tokens (≤8 chars), `n=3` for typical words, `n=4+` for long phrases. Smaller `n` is more forgiving but matches more false positives.
+
+## Composing the n-gram builder
+
+The raw `ngrams(s, n)` builder is occasionally useful when you want set-membership over n-grams rather than the Jaccard score:
+
+```sh
+# Files whose title contains the trigram "kub" anywhere.
+file-search-on 'is_markdown && "kub" in ngrams(title, 3)' -d ./posts
+
+# Long-enough title (more than 5 unique trigrams).
+file-search-on 'is_markdown && ngrams(title, 3).size() > 5' -d ./posts
+```
+
+## Combining fuzzy with exact
+
+Fuzzy operators compose with the rest of CEL:
+
+```sh
+# Photos shot with a Nikon body that I tagged "portrait" in front-matter
+# (assuming a sidecar markdown for each image).
+file-search-on '
+  is_image &&
+  soundex(camera_make) == soundex("Nikon") &&
+  iso < 800 &&
+  f_stop < 2.8
+' -d ~/Photos
+
+# Markdown drafts mentioning anything Kubernetes-shaped in the title.
+file-search-on '
+  is_markdown && draft &&
+  ngram_similarity(title, "kubernetes", 3) > 0.5
+' -d ./drafts
+```
+
+## Performance note
+
+Levenshtein is O(n × m) per call. N-gram similarity is O(n + m) for set construction plus O(min(|A|, |B|)) for the intersection. Both are fast on the short strings these queries usually touch (artist names, titles, camera makes). For long bodies — e.g. running `ngram_similarity` against PDF abstracts — query throughput can drop noticeably. Filter to a content-type subset first (`is_markdown && ...`) to keep the hot path narrow.

--- a/examples/images.md
+++ b/examples/images.md
@@ -122,3 +122,17 @@ file-search-on 'is_image && iso > 0' -o json | jq -s 'sort_by(-.iso) | .[].path'
 # Bare paths for xargs (e.g. copy a year's photos)
 file-search-on 'is_image && taken_at > timestamp("2024-01-01T00:00:00Z")' -o bare | xargs -I {} cp {} ~/photos-2024/
 ```
+
+## Fuzzy matching for camera / lens names
+
+EXIF strings vary across capitalisation and minor punctuation. Fuzzy operators normalise this without an explicit canonicalisation pass.
+
+```sh
+# Phonetic match catches "NIKON", "Nikon", "Nikkon" — all encode to the same Soundex code.
+file-search-on 'is_image && soundex(camera_make) == soundex("Nikon")'
+
+# Lens-model match within 3 edits — covers minor differences in formatting.
+file-search-on 'is_image && levenshtein(lens, "70-200mm f/2.8") <= 3'
+```
+
+See [`fuzzy-search.md`](./fuzzy-search.md) for the full set of fuzzy / phonetic recipes.

--- a/examples/markdown.md
+++ b/examples/markdown.md
@@ -137,3 +137,15 @@ file-search-on 'is_markdown && !draft' --format '{{.Path}}\t{{.Title}}\t{{.WordC
 # Full JSON for jq pipelines
 file-search-on 'is_markdown' -o json | jq 'select(.frontmatter.weight > 50) | .path'
 ```
+
+## Fuzzy matching
+
+```sh
+# Authors whose front-matter spelling is within 2 edits of the target.
+file-search-on 'is_markdown && levenshtein(author, "Jane Doe") <= 2'
+
+# Titles with high n-gram overlap to a topic — survives misspellings.
+file-search-on 'is_markdown && ngram_similarity(title, "kubernetes", 2) > 0.6'
+```
+
+See [`fuzzy-search.md`](./fuzzy-search.md) for the full set of fuzzy / phonetic recipes.

--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -45,7 +45,7 @@ type Evaluator struct {
 
 // New creates a new evaluator for the given CEL expression
 func New(expr string) (*Evaluator, error) {
-	env, err := cel.NewEnv(
+	opts := []cel.EnvOption{
 		cel.Variable("name", cel.StringType),
 		cel.Variable("path", cel.StringType),
 		cel.Variable("dir", cel.StringType),
@@ -109,7 +109,9 @@ func New(expr string) (*Evaluator, error) {
 		cel.Variable("categories", cel.ListType(cel.StringType)),
 		cel.Variable("draft", cel.BoolType),
 		cel.Variable("date", cel.TimestampType),
-	)
+	}
+	opts = append(opts, fuzzyFunctions()...)
+	env, err := cel.NewEnv(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating CEL environment: %w", err)
 	}

--- a/internal/celexpr/functions.go
+++ b/internal/celexpr/functions.go
@@ -1,0 +1,288 @@
+package celexpr
+
+import (
+	"unicode"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// fuzzyFunctions returns the cel.EnvOption set that registers fuzzy-string
+// functions on the CEL environment. Adding a new function means: implement
+// it below, declare it here, and add a FunctionDoc entry in schema.go's
+// Schema(). All three sites move together — the Schema entry is what the
+// CLI --list and the MCP list_attributes tool surface to clients.
+func fuzzyFunctions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Function("levenshtein",
+			cel.Overload("levenshtein_string_string",
+				[]*cel.Type{cel.StringType, cel.StringType},
+				cel.IntType,
+				cel.BinaryBinding(levenshteinBinding),
+			),
+		),
+		cel.Function("soundex",
+			cel.Overload("soundex_string",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(soundexBinding),
+			),
+		),
+		cel.Function("ngrams",
+			cel.Overload("ngrams_string_int",
+				[]*cel.Type{cel.StringType, cel.IntType},
+				cel.ListType(cel.StringType),
+				cel.BinaryBinding(ngramsBinding),
+			),
+		),
+		cel.Function("ngram_similarity",
+			cel.Overload("ngram_similarity_string_string_int",
+				[]*cel.Type{cel.StringType, cel.StringType, cel.IntType},
+				cel.DoubleType,
+				cel.FunctionBinding(ngramSimilarityBinding),
+			),
+		),
+	}
+}
+
+// CEL bindings — adapt ref.Val arguments to Go primitives, dispatch to the
+// pure algorithm, wrap the result back into a ref.Val.
+
+func levenshteinBinding(a, b ref.Val) ref.Val {
+	sa, ok := a.Value().(string)
+	if !ok {
+		return types.NewErr("levenshtein: expected string for arg 1, got %T", a.Value())
+	}
+	sb, ok := b.Value().(string)
+	if !ok {
+		return types.NewErr("levenshtein: expected string for arg 2, got %T", b.Value())
+	}
+	return types.Int(int64(Levenshtein(sa, sb)))
+}
+
+func soundexBinding(v ref.Val) ref.Val {
+	s, ok := v.Value().(string)
+	if !ok {
+		return types.NewErr("soundex: expected string, got %T", v.Value())
+	}
+	return types.String(Soundex(s))
+}
+
+func ngramsBinding(a, b ref.Val) ref.Val {
+	s, ok := a.Value().(string)
+	if !ok {
+		return types.NewErr("ngrams: expected string for arg 1, got %T", a.Value())
+	}
+	n, ok := b.Value().(int64)
+	if !ok {
+		return types.NewErr("ngrams: expected int for arg 2, got %T", b.Value())
+	}
+	return types.DefaultTypeAdapter.NativeToValue(Ngrams(s, int(n)))
+}
+
+func ngramSimilarityBinding(args ...ref.Val) ref.Val {
+	if len(args) != 3 {
+		return types.NewErr("ngram_similarity: expected 3 args, got %d", len(args))
+	}
+	sa, ok := args[0].Value().(string)
+	if !ok {
+		return types.NewErr("ngram_similarity: expected string for arg 1, got %T", args[0].Value())
+	}
+	sb, ok := args[1].Value().(string)
+	if !ok {
+		return types.NewErr("ngram_similarity: expected string for arg 2, got %T", args[1].Value())
+	}
+	n, ok := args[2].Value().(int64)
+	if !ok {
+		return types.NewErr("ngram_similarity: expected int for arg 3, got %T", args[2].Value())
+	}
+	return types.Double(NgramSimilarity(sa, sb, int(n)))
+}
+
+// Algorithm implementations — exported so they can be unit-tested directly,
+// without going through the CEL environment.
+
+// Levenshtein returns the edit distance between a and b, counted in
+// rune-level insertions, deletions, and substitutions. Case-sensitive.
+// Two-row dynamic programming, O(len(a) * len(b)) time, O(min(len)) space.
+func Levenshtein(a, b string) int {
+	ra := []rune(a)
+	rb := []rune(b)
+	if len(ra) == 0 {
+		return len(rb)
+	}
+	if len(rb) == 0 {
+		return len(ra)
+	}
+	// Ensure rb is the shorter slice so the row buffer is small.
+	if len(rb) > len(ra) {
+		ra, rb = rb, ra
+	}
+	prev := make([]int, len(rb)+1)
+	curr := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		curr[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(
+				curr[j-1]+1,    // insertion
+				prev[j]+1,      // deletion
+				prev[j-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(rb)]
+}
+
+func min3(a, b, c int) int {
+	m := min(b, a)
+	if c < m {
+		m = c
+	}
+	return m
+}
+
+// Soundex returns the American Soundex code (NARA standard) for the
+// given word. The result is always a 4-character upper-case ASCII string
+// of the form letter+digit+digit+digit. Non-letters are skipped. Empty
+// or no-letter input returns "0000".
+//
+// Encoding map:
+//
+//	B F P V         -> 1
+//	C G J K Q S X Z -> 2
+//	D T             -> 3
+//	L               -> 4
+//	M N             -> 5
+//	R               -> 6
+//
+// Vowels (A E I O U Y) are not emitted but reset the same-code
+// suppression state, so consonant pairs separated by a vowel are
+// preserved (e.g. "Robert" -> "R163"). H and W are transparent — they
+// emit nothing AND leave the suppression state untouched, so consonants
+// separated only by H/W collapse (e.g. "Ashcraft" -> "A261", because
+// the H between S and C means the C's code-2 is treated as adjacent to
+// S's code-2 and dropped). The first letter of the word's code seeds
+// the suppression state, so Pfister -> P236 (the F is dropped because
+// it shares P's code).
+func Soundex(s string) string {
+	const padded = "0000"
+	letters := make([]rune, 0, len(s))
+	for _, r := range s {
+		if unicode.IsLetter(r) {
+			letters = append(letters, unicode.ToUpper(r))
+		}
+	}
+	if len(letters) == 0 {
+		return padded
+	}
+	first := letters[0]
+	if first > 127 {
+		// Non-ASCII letter — Soundex is ASCII-only; degrade gracefully.
+		return padded
+	}
+
+	out := make([]byte, 0, 4)
+	out = append(out, byte(first))
+	prevCode := soundexCode(first)
+	for _, r := range letters[1:] {
+		if len(out) == 4 {
+			break
+		}
+		if r == 'H' || r == 'W' {
+			// Transparent: emit nothing, leave prevCode alone.
+			continue
+		}
+		c := soundexCode(r)
+		if c == 0 {
+			// Vowel (A E I O U Y): reset suppression so the next
+			// consonant always emits even if same code as previous.
+			prevCode = 0
+			continue
+		}
+		if c == prevCode {
+			continue
+		}
+		out = append(out, '0'+byte(c))
+		prevCode = c
+	}
+	for len(out) < 4 {
+		out = append(out, '0')
+	}
+	return string(out)
+}
+
+func soundexCode(r rune) int {
+	switch r {
+	case 'B', 'F', 'P', 'V':
+		return 1
+	case 'C', 'G', 'J', 'K', 'Q', 'S', 'X', 'Z':
+		return 2
+	case 'D', 'T':
+		return 3
+	case 'L':
+		return 4
+	case 'M', 'N':
+		return 5
+	case 'R':
+		return 6
+	}
+	return 0
+}
+
+// Ngrams returns the character-level n-grams of s as a slice of strings,
+// in left-to-right order. Returns an empty slice (not nil) when n <= 0
+// or n > rune-length of s. Rune-aware.
+func Ngrams(s string, n int) []string {
+	if n <= 0 {
+		return []string{}
+	}
+	rs := []rune(s)
+	if n > len(rs) {
+		return []string{}
+	}
+	out := make([]string, 0, len(rs)-n+1)
+	for i := 0; i+n <= len(rs); i++ {
+		out = append(out, string(rs[i:i+n]))
+	}
+	return out
+}
+
+// NgramSimilarity returns the Jaccard similarity between the SETS of
+// character n-grams of a and b: |A ∩ B| / |A ∪ B|. Returns 1.0 when
+// both n-gram sets are empty (e.g. both strings empty or both shorter
+// than n). Returns 0.0 when only one side is empty.
+func NgramSimilarity(a, b string, n int) float64 {
+	setA := ngramSet(a, n)
+	setB := ngramSet(b, n)
+	if len(setA) == 0 && len(setB) == 0 {
+		return 1.0
+	}
+	if len(setA) == 0 || len(setB) == 0 {
+		return 0.0
+	}
+	intersect := 0
+	for g := range setA {
+		if _, ok := setB[g]; ok {
+			intersect++
+		}
+	}
+	union := len(setA) + len(setB) - intersect
+	return float64(intersect) / float64(union)
+}
+
+func ngramSet(s string, n int) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, g := range Ngrams(s, n) {
+		out[g] = struct{}{}
+	}
+	return out
+}

--- a/internal/celexpr/functions.go
+++ b/internal/celexpr/functions.go
@@ -131,7 +131,7 @@ func Levenshtein(a, b string) int {
 			if ra[i-1] == rb[j-1] {
 				cost = 0
 			}
-			curr[j] = min3(
+			curr[j] = min(
 				curr[j-1]+1,    // insertion
 				prev[j]+1,      // deletion
 				prev[j-1]+cost, // substitution
@@ -140,14 +140,6 @@ func Levenshtein(a, b string) int {
 		prev, curr = curr, prev
 	}
 	return prev[len(rb)]
-}
-
-func min3(a, b, c int) int {
-	m := min(b, a)
-	if c < m {
-		m = c
-	}
-	return m
 }
 
 // Soundex returns the American Soundex code (NARA standard) for the

--- a/internal/celexpr/functions_test.go
+++ b/internal/celexpr/functions_test.go
@@ -1,0 +1,169 @@
+package celexpr_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+)
+
+func TestLevenshtein(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"abc", "abc", 0},
+		// Classic single-edit cases.
+		{"kitten", "sitting", 3},
+		{"sunday", "saturday", 3},
+		{"flaw", "lawn", 2},
+		// Case-sensitive.
+		{"Apple", "apple", 1},
+		// Rune-aware (multi-byte runes count as one edit, not three).
+		{"café", "cafe", 1},
+		{"naïve", "naive", 1},
+		// Asymmetric lengths trigger the "shorter side along columns" branch.
+		{"a", "abcdef", 5},
+		{"abcdef", "a", 5},
+	}
+	for _, tc := range cases {
+		got := celexpr.Levenshtein(tc.a, tc.b)
+		if got != tc.want {
+			t.Errorf("Levenshtein(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestSoundex(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		// Knuth's worked examples (TAOCP §6.1).
+		{"Robert", "R163"},
+		{"Rupert", "R163"},
+		{"Rubin", "R150"},
+		{"Ashcraft", "A261"},
+		{"Tymczak", "T522"},
+		{"Pfister", "P236"},
+		// Case insensitivity.
+		{"smith", "S530"},
+		{"SMITH", "S530"},
+		// Vowels separate same-code consonants (e.g. C-A-S keeps both 2's? no
+		// — vowel resets state so a same-code letter on the other side still
+		// emits): Jackson -> J250 (J-K both code 2, but they're adjacent and
+		// the K is not preserved; c collapses into the J). The historic
+		// answer is "J250".
+		{"Jackson", "J250"},
+		// Pad short input to 4 chars.
+		{"Lee", "L000"},
+		// Truncate long output to 4 chars.
+		{"Washington", "W252"},
+		// Empty / no-letter input.
+		{"", "0000"},
+		{"123", "0000"},
+		// Non-letter characters skipped.
+		{"O'Brien", "O165"},
+	}
+	for _, tc := range cases {
+		got := celexpr.Soundex(tc.in)
+		if got != tc.want {
+			t.Errorf("Soundex(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNgrams(t *testing.T) {
+	cases := []struct {
+		s    string
+		n    int
+		want []string
+	}{
+		{"hello", 2, []string{"he", "el", "ll", "lo"}},
+		{"hello", 3, []string{"hel", "ell", "llo"}},
+		{"abc", 3, []string{"abc"}},
+		{"abc", 4, []string{}},        // n > len
+		{"hello", 0, []string{}},      // n == 0
+		{"hello", -1, []string{}},     // n negative
+		{"", 2, []string{}},           // empty input
+		{"café", 2, []string{"ca", "af", "fé"}}, // rune-aware (é is 1 rune)
+	}
+	for _, tc := range cases {
+		got := celexpr.Ngrams(tc.s, tc.n)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("Ngrams(%q, %d) = %v, want %v", tc.s, tc.n, got, tc.want)
+		}
+	}
+}
+
+func TestNgramSimilarity(t *testing.T) {
+	cases := []struct {
+		a, b string
+		n    int
+		want float64
+	}{
+		// Both empty by the n-gram set definition (both shorter than n).
+		{"", "", 2, 1.0},
+		// One empty, one not — totally dissimilar.
+		{"", "hello", 2, 0.0},
+		// Identical strings — full overlap.
+		{"hello", "hello", 2, 1.0},
+		// Single typo — most n-grams shared.
+		{"kubernetes", "kubernetez", 3, 7.0 / 9.0},
+		// Disjoint short strings — zero overlap.
+		{"abc", "xyz", 2, 0.0},
+	}
+	const epsilon = 1e-9
+	for _, tc := range cases {
+		got := celexpr.NgramSimilarity(tc.a, tc.b, tc.n)
+		if diff := got - tc.want; diff < -epsilon || diff > epsilon {
+			t.Errorf("NgramSimilarity(%q, %q, %d) = %g, want %g", tc.a, tc.b, tc.n, got, tc.want)
+		}
+	}
+}
+
+func TestEvaluateFuzzyFunctions(t *testing.T) {
+	// Use FileAttributes directly so test is independent of content-type
+	// detection. The artist / camera_make / title fields ride along via Extra.
+	attrs := &celexpr.FileAttributes{
+		Name:        "song.mp3",
+		Path:        "/music/song.mp3",
+		Dir:         "/music",
+		Size:        1024,
+		Ext:         ".mp3",
+		ContentType: "audio/mp3",
+		IsAudio:     true,
+		Extra: map[string]any{
+			"artist":      "Radiohad",  // typo of "Radiohead"
+			"camera_make": "NIKON",
+			"title":       "kubernates", // typo of "kubernetes"
+		},
+	}
+	cases := []struct {
+		expr string
+		want bool
+	}{
+		{`levenshtein(artist, "Radiohead") <= 2`, true},
+		{`levenshtein(artist, "Beethoven") <= 2`, false},
+		{`soundex(camera_make) == soundex("Nikon")`, true},
+		{`soundex(camera_make) == soundex("Sony")`, false},
+		{`ngrams(title, 3).size() > 5`, true},
+		{`ngram_similarity(title, "kubernetes", 2) > 0.6`, true},
+		{`ngram_similarity(title, "docker", 2) < 0.3`, true},
+	}
+	for _, tc := range cases {
+		eval, err := celexpr.New(tc.expr)
+		if err != nil {
+			t.Fatalf("compile %q: %v", tc.expr, err)
+		}
+		got, err := eval.Evaluate(attrs)
+		if err != nil {
+			t.Fatalf("eval %q: %v", tc.expr, err)
+		}
+		if got != tc.want {
+			t.Errorf("expr %q: got %v, want %v", tc.expr, got, tc.want)
+		}
+	}
+}

--- a/internal/celexpr/schema.go
+++ b/internal/celexpr/schema.go
@@ -7,16 +7,28 @@ type AttributeDoc struct {
 	Description string `json:"description"`
 }
 
-// SchemaDoc groups the documented CEL attributes by category.
+// FunctionDoc describes a CEL-callable function registered on the
+// environment. Unlike attributes, functions have a signature (the formal
+// argument list and return type), so the schema needs a richer doc type.
+type FunctionDoc struct {
+	Name        string `json:"name"`
+	Signature   string `json:"signature"`
+	Description string `json:"description"`
+	Example     string `json:"example,omitempty"`
+}
+
+// SchemaDoc groups the documented CEL attributes by category, plus the
+// callable built-in functions registered on the environment.
 type SchemaDoc struct {
 	Common       []AttributeDoc `json:"common"`
 	TypeSpecific []AttributeDoc `json:"type_specific"`
 	Frontmatter  []AttributeDoc `json:"frontmatter"`
+	Functions    []FunctionDoc  `json:"functions"`
 }
 
 // Schema returns the structured documentation for every CEL attribute
-// the evaluator declares. Both the CLI's --list output and the MCP
-// list_attributes tool format their output from this.
+// and function the evaluator declares. Both the CLI's --list output and
+// the MCP list_attributes tool format their output from this.
 func Schema() SchemaDoc {
 	return SchemaDoc{
 		Common: []AttributeDoc{
@@ -87,6 +99,32 @@ func Schema() SchemaDoc {
 			{"categories", "list<str>", "front-matter categories"},
 			{"draft", "bool", "front-matter draft flag"},
 			{"date", "timestamp", "front-matter date"},
+		},
+		Functions: []FunctionDoc{
+			{
+				Name:        "levenshtein",
+				Signature:   "levenshtein(string, string) -> int",
+				Description: "Edit distance (rune-aware, case-sensitive). Counts insertions, deletions, and substitutions needed to turn the first string into the second.",
+				Example:     `is_audio && levenshtein(artist, "Radiohead") <= 2`,
+			},
+			{
+				Name:        "soundex",
+				Signature:   "soundex(string) -> string",
+				Description: "American Soundex phonetic code (4-character ASCII, e.g. 'Robert' -> 'R163'). Useful for matching name spellings that sound alike.",
+				Example:     `is_image && soundex(camera_make) == soundex("Nikon")`,
+			},
+			{
+				Name:        "ngrams",
+				Signature:   "ngrams(string, int) -> list<string>",
+				Description: "Character-level n-grams of the input (sliding window, length n). Empty list when n <= 0 or n exceeds the rune length of the string.",
+				Example:     `ngrams("kubernetes", 3).size() > 5`,
+			},
+			{
+				Name:        "ngram_similarity",
+				Signature:   "ngram_similarity(string, string, int) -> double",
+				Description: "Jaccard similarity over character n-gram sets, ranging 0.0 (no overlap) to 1.0 (identical sets). Both empty -> 1.0; only one empty -> 0.0.",
+				Example:     `is_markdown && ngram_similarity(title, "kubernetes", 2) > 0.6`,
+			},
 		},
 	}
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -288,12 +288,12 @@ func New(version string) *mcp.Server {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "search",
-		Description: "Recursively search a directory for files matching a CEL expression evaluated over file metadata and content-type-specific attributes.",
+		Description: "Recursively search a directory for files matching a CEL expression evaluated over file metadata and content-type-specific attributes. CEL expressions can use built-in fuzzy-match functions: levenshtein(a, b) for edit distance, soundex(s) for phonetic codes, ngrams(s, n) for character n-grams, and ngram_similarity(a, b, n) for Jaccard similarity. Call list_attributes for the full attribute and function schema.",
 	}, searchHandler)
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_attributes",
-		Description: "List every CEL attribute available to the search tool, plus the registered content types.",
+		Description: "List every CEL attribute available to the search tool, the built-in functions (levenshtein, soundex, ngrams, ngram_similarity) with their signatures, and the registered content types.",
 	}, listAttributesHandler)
 
 	return s


### PR DESCRIPTION
## Summary

Adds four CEL-callable fuzzy-string functions so typo-tolerant and phonetic matching becomes possible inside expressions:

| Function | Returns | Use case |
| --- | --- | --- |
| `levenshtein(a, b)` | `int` | Edit distance — typo-tolerant equality |
| `soundex(s)` | `string` | NARA-standard phonetic code — name spellings that sound alike |
| `ngrams(s, n)` | `list<string>` | Character n-grams — set composition |
| `ngram_similarity(a, b, n)` | `double` | Jaccard 0.0–1.0 — substring-tolerant similarity |

All hand-rolled, no new dependencies. Rune-aware where applicable (Levenshtein, n-grams). Soundex follows the NARA standard: vowels reset same-code suppression, but **H** and **W** are transparent — so `Ashcraft` → `A261` and `Pfister` → `P236`.

This is the first time CEL functions (as opposed to variables) are wired into the codebase, so the change also lays down the plumbing pattern documented in CLAUDE.md.

## What changed

- `internal/celexpr/functions.go` (new) — impls + `cel.Function` declarations + a `fuzzyFunctions()` helper that returns `[]cel.EnvOption`
- `internal/celexpr/schema.go` — new `FunctionDoc` type, `Functions []FunctionDoc` field on `SchemaDoc`, populated with all four
- `internal/celexpr/evaluator.go` — `New()` now builds `opts := []cel.EnvOption{...}` and spreads `fuzzyFunctions()` in before calling `cel.NewEnv(opts...)`
- `cmd/file-search-on/main.go` — `printHelp` grows a "Built-in functions" section via a new `printFuncs` helper
- `internal/mcpserver/server.go` — `search` and `list_attributes` tool descriptions both mention the fuzzy functions, so MCP clients (Claude Desktop, Cline, etc.) pick them up at handshake time
- `examples/fuzzy-search.md` (new) — dedicated recipe collection: typo-tolerant artist search, phonetic name lookup, n-gram similarity for titles, composing the raw `ngrams` builder
- `examples/{markdown,audio,images,cookbook}.md` — small fuzzy hooks per family with cross-links to the dedicated page
- `examples/README.md`, `README.md` — link to the fuzzy recipe page; README's attributes table grows a "Built-in functions" subsection
- `CLAUDE.md` — new "Adding a CEL function" subsection documenting the four-call-site pattern

## MCP handshake awareness

The `list_attributes` MCP tool already returns `celexpr.SchemaDoc`; the new `Functions` field surfaces in its structured output automatically. Verified via stdio JSON-RPC smoke:

\`\`\`
functions:
  - levenshtein          levenshtein(string, string) -> int
  - soundex              soundex(string) -> string
  - ngrams               ngrams(string, int) -> list<string>
  - ngram_similarity     ngram_similarity(string, string, int) -> double
\`\`\`

The `search` tool's `Description` also lists them inline so an agent can compose CEL without a separate `list_attributes` call.

## Test plan

- [x] \`go test -race ./...\` — all green
- [x] Unit tests cover Knuth's worked Soundex examples (Robert/Rupert/Rubin/Ashcraft/Tymczak/Pfister/Lee/Washington/O'Brien), Levenshtein classics (kitten/sitting=3, sunday/saturday=3) plus rune-aware (`café`/`cafe`=1) and asymmetric-length cases, n-gram edge cases (n≤0, n>len, empty input), and a CEL-level integration test exercising all four functions inside expressions
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` idempotent
- [x] \`./file-search-on --list\` shows the new Built-in functions section
- [x] Real CLI smoke: \`./file-search-on 'is_markdown && soundex(name) == soundex("CookBuk.md")' -d ./examples\` correctly matches \`cookbook.md\`
- [x] MCP \`list_attributes\` returns the four functions in structured output (verified via stdio JSON-RPC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)