### PR TITLE
refactor(content): abstract IO behind fs.FS

### DIFF
--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -3,7 +3,7 @@ package celexpr
 import (
 	"context"
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
 	"time"
@@ -302,23 +302,28 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 	return out == types.True, nil
 }
 
-// BuildAttributes builds file attributes for a given path. ctx is checked
-// at entry and threaded into ContentType.Attributes so per-file work can be
-// cancelled mid-scan.
-func BuildAttributes(ctx context.Context, path string, registry *content.Registry) (*FileAttributes, error) {
+// BuildAttributes builds file attributes for a given path. fsys is the
+// filesystem to read from; fsPath is the fs.FS-style key (forward slashes,
+// relative to the fsys root) used for IO; displayPath is the OS-native
+// path surfaced to users via FileAttributes.Path. In production both come
+// from the walker (`os.DirFS(root)` + relative slash path / `filepath.Join`
+// of the same). In tests, both can be the same fs-style key. ctx is
+// checked at entry and threaded into ContentType.Attributes so per-file
+// work can be cancelled mid-scan.
+func BuildAttributes(ctx context.Context, fsys fs.FS, fsPath, displayPath string, registry *content.Registry) (*FileAttributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	info, err := os.Stat(path)
+	info, err := fs.Stat(fsys, fsPath)
 	if err != nil {
 		return nil, err
 	}
 
 	name := info.Name()
 	ext := strings.ToLower(filepath.Ext(name))
-	dir := filepath.Dir(path)
+	dir := filepath.Dir(displayPath)
 
-	ct := registry.Detect(path)
+	ct := registry.Detect(fsys, fsPath)
 	contentTypeName := ""
 	isMarkdown, isJSON, isXML, isHTML, isPDF, isImage := false, false, false, false, false, false
 	isText, isCSV, isEPUB, isOffice, isAudio, isVideo := false, false, false, false, false, false
@@ -352,7 +357,7 @@ func BuildAttributes(ctx context.Context, path string, registry *content.Registr
 		case strings.HasPrefix(contentTypeName, "video/"):
 			isVideo = true
 		}
-		extra, err = ct.Attributes(ctx, path)
+		extra, err = ct.Attributes(ctx, fsys, fsPath)
 		if err != nil {
 			return nil, err
 		}
@@ -360,7 +365,7 @@ func BuildAttributes(ctx context.Context, path string, registry *content.Registr
 
 	return &FileAttributes{
 		Name:        name,
-		Path:        path,
+		Path:        displayPath,
 		Dir:         dir,
 		Size:        info.Size(),
 		Ext:         ext,

--- a/internal/content/audio_flac_test.go
+++ b/internal/content/audio_flac_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 // buildFLAC builds a minimal FLAC file with a STREAMINFO block containing
@@ -58,11 +57,11 @@ func TestFLACInfo(t *testing.T) {
 	if err := os.WriteFile(path, buildFLAC(44100, 2, 4_410_000), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "audio/flac" {
 		t.Fatalf("Detect: got %v, want audio/flac", ct)
 	}
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -86,8 +85,8 @@ func TestFLACBadMagic(t *testing.T) {
 	if err := os.WriteFile(path, []byte("not a flac"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
-	attrs, err := ct.Attributes(t.Context(), path)
+	ct := detectAt(path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}

--- a/internal/content/audio_mp3_test.go
+++ b/internal/content/audio_mp3_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 // buildMP3WithXing builds a minimal MP3 file: a tiny ID3v2 header (just an
@@ -52,11 +51,11 @@ func TestMP3WithXing(t *testing.T) {
 	if err := os.WriteFile(path, buildMP3WithXing(frames), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "audio/mpeg" {
 		t.Fatalf("Detect: got %v, want audio/mpeg", ct)
 	}
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -87,8 +86,8 @@ func TestMP3CBRFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ct := content.DefaultRegistry().Detect(path)
-	attrs, err := ct.Attributes(t.Context(), path)
+	ct := detectAt(path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}

--- a/internal/content/audio_mp4_test.go
+++ b/internal/content/audio_mp4_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 // atomBox builds an MP4 atom (size + 4-byte type + content). Returns the
@@ -91,11 +90,11 @@ func TestMP4Info(t *testing.T) {
 	if err := os.WriteFile(path, buildMP4(1000, 100_000, 44100, 2), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "audio/mp4" {
 		t.Fatalf("Detect: got %v, want audio/mp4", ct)
 	}
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}

--- a/internal/content/audio_ogg_test.go
+++ b/internal/content/audio_ogg_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 // buildOGG builds a minimal OGG file containing:
@@ -58,11 +57,11 @@ func TestOGGInfo(t *testing.T) {
 	if err := os.WriteFile(path, buildOGG(48000, 2, 4_800_000), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "audio/ogg" {
 		t.Fatalf("Detect: got %v, want audio/ogg", ct)
 	}
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}

--- a/internal/content/audiotype.go
+++ b/internal/content/audiotype.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"os"
+	"io/fs"
 
 	"github.com/dhowden/tag"
 )
@@ -31,19 +31,19 @@ func (a *audioType) MagicBytes() [][]byte { return a.magic }
 // FLAC/OGG) so a single ReadFrom covers all four registered types. Header-
 // only reads — sub-millisecond per file. Tag-only; duration / bitrate are
 // out of scope for v1 and would need format-specific decoders.
-func (a *audioType) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (a *audioType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	attrs := Attributes{}
 
-	f, err := os.Open(path)
+	rs, fileSize, closer, err := openReadSeeker(fsys, path)
 	if err != nil {
 		return attrs, nil
 	}
-	defer func() { _ = f.Close() }()
+	defer func() { _ = closer() }()
 
-	if m, err := tag.ReadFrom(f); err == nil {
+	if m, err := tag.ReadFrom(rs); err == nil {
 		if v := m.Title(); v != "" {
 			attrs["title"] = v
 		}
@@ -75,22 +75,19 @@ func (a *audioType) Attributes(ctx context.Context, path string) (Attributes, er
 	// Playback metadata via per-format binary parsing. Each parser is bounded
 	// (header + at most a 64 KiB tail for OGG); they don't take ctx because
 	// the entry-point check at the top covers cancellation between files.
-	fileSize, err := f.Seek(0, io.SeekEnd)
-	if err == nil {
-		_, _ = f.Seek(0, io.SeekStart)
-		if info, err := readAudioInfo(a.name, f, fileSize); err == nil {
-			if info.Duration > 0 {
-				attrs["duration"] = info.Duration
-				if br := int64(float64(fileSize) * 8 / info.Duration / 1000); br > 0 {
-					attrs["bitrate"] = br
-				}
+	_, _ = rs.Seek(0, io.SeekStart)
+	if info, err := readAudioInfo(a.name, rs, fileSize); err == nil {
+		if info.Duration > 0 {
+			attrs["duration"] = info.Duration
+			if br := int64(float64(fileSize) * 8 / info.Duration / 1000); br > 0 {
+				attrs["bitrate"] = br
 			}
-			if info.SampleRate > 0 {
-				attrs["sample_rate"] = info.SampleRate
-			}
-			if info.Channels > 0 {
-				attrs["channels"] = info.Channels
-			}
+		}
+		if info.SampleRate > 0 {
+			attrs["sample_rate"] = info.SampleRate
+		}
+		if info.Channels > 0 {
+			attrs["channels"] = info.Channels
 		}
 	}
 	return attrs, nil

--- a/internal/content/audiotype_test.go
+++ b/internal/content/audiotype_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 // id3v2Frame is one text frame: 4-byte ID, 4-byte big-endian size, 2-byte
@@ -66,11 +65,11 @@ func TestAudioMP3Tags(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "audio/mpeg" {
 		t.Fatalf("Detect: got %v, want audio/mpeg", ct)
 	}
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -102,11 +101,11 @@ func TestAudioMP3NoTags(t *testing.T) {
 	if err := os.WriteFile(path, []byte("garbage data"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "audio/mpeg" {
 		t.Fatalf("Detect: got %v, want audio/mpeg", ct)
 	}
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -138,7 +137,7 @@ func TestAudioTypesRegistered(t *testing.T) {
 			if err := os.WriteFile(path, nil, 0o644); err != nil {
 				t.Fatal(err)
 			}
-			ct := content.DefaultRegistry().Detect(path)
+			ct := detectAt(path)
 			if ct == nil || ct.Name() != tc.want {
 				t.Errorf("Detect(%s): got %v, want %s", tc.ext, ct, tc.want)
 			}
@@ -153,10 +152,10 @@ func TestAudioRespectsCancellation(t *testing.T) {
 	if err := os.WriteFile(path, body, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := ct.Attributes(ctx, path)
+	_, err := attributesAt(ctx, ct, path)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Attributes(cancelled): err = %v, want context.Canceled", err)
 	}

--- a/internal/content/csv.go
+++ b/internal/content/csv.go
@@ -4,8 +4,8 @@ import (
 	"bufio"
 	"context"
 	"encoding/csv"
-	"os"
-	"path/filepath"
+	"io/fs"
+	"path"
 	"strings"
 )
 
@@ -19,18 +19,18 @@ func (c *csvType) Name() string         { return "csv" }
 func (c *csvType) Extensions() []string { return []string{".csv", ".tsv"} }
 func (c *csvType) MagicBytes() [][]byte { return nil }
 
-func (c *csvType) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (c *csvType) Attributes(ctx context.Context, fsys fs.FS, p string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(path)
+	f, err := fsys.Open(p)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = f.Close() }()
 
 	delim := ','
-	if strings.EqualFold(filepath.Ext(path), ".tsv") {
+	if strings.EqualFold(path.Ext(p), ".tsv") {
 		delim = '\t'
 	}
 

--- a/internal/content/csv_test.go
+++ b/internal/content/csv_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 func TestCSVAttributes(t *testing.T) {
@@ -40,11 +39,11 @@ func TestCSVAttributes(t *testing.T) {
 			if err := os.WriteFile(path, []byte(tc.body), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			ct := content.DefaultRegistry().Detect(path)
+			ct := detectAt(path)
 			if ct == nil || ct.Name() != "csv" {
 				t.Fatalf("Detect: got %v, want csv", ct)
 			}
-			attrs, err := ct.Attributes(t.Context(), path)
+			attrs, err := attributesAt(t.Context(), ct, path)
 			if err != nil {
 				t.Fatalf("Attributes: %v", err)
 			}
@@ -68,8 +67,8 @@ func TestCSVEmpty(t *testing.T) {
 	if err := os.WriteFile(path, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
-	attrs, err := ct.Attributes(t.Context(), path)
+	ct := detectAt(path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}

--- a/internal/content/detector.go
+++ b/internal/content/detector.go
@@ -2,32 +2,43 @@ package content
 
 import (
 	"bytes"
-	"os"
-	"path/filepath"
+	"io"
+	"io/fs"
+	"path"
 	"slices"
 	"strings"
 )
 
-// Detect detects the content type of a file using extension first, then magic bytes
-func (r *Registry) Detect(path string) ContentType {
+// Detect detects the content type of a file using extension first, then
+// magic bytes. Path is an fs.FS-style key (forward slashes); fsys is the
+// filesystem that provides Open access for magic-byte sniffing when no
+// extension matches. fsys may be nil when the caller knows extension
+// matching alone is sufficient.
+func (r *Registry) Detect(fsys fs.FS, p string) ContentType {
 	r.mu.RLock()
 	types := make([]ContentType, len(r.types))
 	copy(types, r.types)
 	r.mu.RUnlock()
 
-	ext := strings.ToLower(filepath.Ext(path))
+	ext := strings.ToLower(path.Ext(p))
 	for _, ct := range types {
 		if slices.Contains(ct.Extensions(), ext) {
 			return ct
 		}
 	}
-	f, err := os.Open(path)
+	if fsys == nil {
+		return nil
+	}
+	f, err := fsys.Open(p)
 	if err != nil {
 		return nil
 	}
 	defer func() { _ = f.Close() }()
 	buf := make([]byte, 512)
-	n, _ := f.Read(buf)
+	n, err := f.Read(buf)
+	if err != nil && err != io.EOF {
+		return nil
+	}
 	buf = buf[:n]
 	for _, ct := range types {
 		for _, magic := range ct.MagicBytes() {

--- a/internal/content/detector_test.go
+++ b/internal/content/detector_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 func TestDetect(t *testing.T) {
@@ -26,7 +25,7 @@ func TestDetect(t *testing.T) {
 		if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
 			t.Fatal(err)
 		}
-		ct := content.DefaultRegistry().Detect(path)
+		ct := detectAt(path)
 		if ct == nil {
 			t.Errorf("Detect(%s): got nil, want %s", tc.file, tc.want)
 			continue

--- a/internal/content/docx.go
+++ b/internal/content/docx.go
@@ -1,6 +1,9 @@
 package content
 
-import "context"
+import (
+	"context"
+	"io/fs"
+)
 
 func init() {
 	Register(&docxType{})
@@ -11,6 +14,6 @@ type docxType struct{}
 func (d *docxType) Name() string         { return "office/docx" }
 func (d *docxType) Extensions() []string { return []string{".docx"} }
 func (d *docxType) MagicBytes() [][]byte { return nil }
-func (d *docxType) Attributes(ctx context.Context, path string) (Attributes, error) {
-	return ooxmlAttributes(ctx, path)
+func (d *docxType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
+	return ooxmlAttributes(ctx, fsys, path)
 }

--- a/internal/content/epub.go
+++ b/internal/content/epub.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/xml"
 	"io"
+	"io/fs"
 )
 
 func init() {
@@ -17,22 +18,26 @@ func (e *epubType) Name() string         { return "epub" }
 func (e *epubType) Extensions() []string { return []string{".epub"} }
 func (e *epubType) MagicBytes() [][]byte { return nil }
 
-func (e *epubType) Attributes(ctx context.Context, filePath string) (Attributes, error) {
+func (e *epubType) Attributes(ctx context.Context, fsys fs.FS, filePath string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	zr, err := zip.OpenReader(filePath)
+	ra, size, closer, err := openReaderAt(fsys, filePath)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = zr.Close() }()
+	defer func() { _ = closer() }()
+	zr, err := zip.NewReader(ra, size)
+	if err != nil {
+		return nil, err
+	}
 
-	opfPath, err := readOPFPath(&zr.Reader)
+	opfPath, err := readOPFPath(zr)
 	if err != nil || opfPath == "" {
 		return Attributes{}, nil
 	}
 
-	title, author, lang := readZipDublinCore(ctx, &zr.Reader, opfPath)
+	title, author, lang := readZipDublinCore(ctx, zr, opfPath)
 
 	attrs := Attributes{
 		"language": lang,

--- a/internal/content/epub_test.go
+++ b/internal/content/epub_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 const containerXML = `<?xml version="1.0" encoding="UTF-8"?>
@@ -55,12 +54,12 @@ func TestEPUBAttributes(t *testing.T) {
 	path := filepath.Join(dir, "guide.epub")
 	writeMinimalEPUB(t, path)
 
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "epub" {
 		t.Fatalf("Detect: got %v, want epub", ct)
 	}
 
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -81,11 +80,11 @@ func TestEPUBNotAZip(t *testing.T) {
 	if err := os.WriteFile(path, []byte("not a zip"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "epub" {
 		t.Fatalf("Detect: got %v, want epub", ct)
 	}
-	if _, err := ct.Attributes(t.Context(), path); err == nil {
+	if _, err := attributesAt(t.Context(), ct, path); err == nil {
 		t.Errorf("Attributes on broken zip: expected error, got nil")
 	}
 }

--- a/internal/content/frontmatter_test.go
+++ b/internal/content/frontmatter_test.go
@@ -23,7 +23,7 @@ func markdownAttrs(t *testing.T, path string) content.Attributes {
 	t.Helper()
 	for _, ct := range content.DefaultRegistry().Types() {
 		if ct.Name() == "markdown" {
-			attrs, err := ct.Attributes(t.Context(), path)
+			attrs, err := attributesAt(t.Context(), ct, path)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/content/fsutil.go
+++ b/internal/content/fsutil.go
@@ -1,0 +1,75 @@
+package content
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+)
+
+// openReadSeeker opens path on fsys and returns it as an io.ReadSeeker plus
+// the file size. If the underlying fs.File already supports io.Seeker — as
+// *os.File does when fsys is os.DirFS — it's returned directly so large
+// media files don't have to be slurped into memory. If the fs.File is
+// sequential-only (embed.FS, fstest.MapFS, gzip-fs wrappers, …) the file
+// is read into memory once and wrapped in a *bytes.Reader, which satisfies
+// both io.ReadSeeker and io.ReaderAt — exactly what zip.NewReader and
+// pdf.NewReader need.
+//
+// The returned closer must always be deferred. It's a no-op when the file
+// was slurped (the underlying fs.File was already closed inside this
+// function); for the streaming fast path it closes the underlying file.
+func openReadSeeker(fsys fs.FS, path string) (io.ReadSeeker, int64, func() error, error) {
+	f, err := fsys.Open(path)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	if rs, ok := f.(io.ReadSeeker); ok {
+		// Production fast path: streaming via *os.File.
+		info, err := f.Stat()
+		if err != nil {
+			_ = f.Close()
+			return nil, 0, nil, err
+		}
+		return rs, info.Size(), f.Close, nil
+	}
+	// Sequential-only fs.File (embed.FS, fstest.MapFS, …): slurp.
+	buf, readErr := io.ReadAll(f)
+	closeErr := f.Close()
+	if err := errors.Join(readErr, closeErr); err != nil {
+		return nil, 0, nil, err
+	}
+	return bytes.NewReader(buf), int64(len(buf)), func() error { return nil }, nil
+}
+
+// openReaderAt is the io.ReaderAt-flavoured cousin of openReadSeeker, for
+// callers like zip.NewReader and pdf.NewReader that need ReaderAt rather
+// than ReadSeeker. The returned reader satisfies both. Closer rules are
+// the same.
+func openReaderAt(fsys fs.FS, path string) (io.ReaderAt, int64, func() error, error) {
+	f, err := fsys.Open(path)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	if ra, ok := f.(io.ReaderAt); ok {
+		info, err := f.Stat()
+		if err != nil {
+			_ = f.Close()
+			return nil, 0, nil, err
+		}
+		return ra, info.Size(), f.Close, nil
+	}
+	buf, readErr := io.ReadAll(f)
+	closeErr := f.Close()
+	if err := errors.Join(readErr, closeErr); err != nil {
+		return nil, 0, nil, err
+	}
+	return bytes.NewReader(buf), int64(len(buf)), func() error { return nil }, nil
+}
+
+// readAll reads the entire contents of path on fsys. Used by the
+// markdown / json / xml / csv / html / text parsers that don't need
+// random access.
+func readAll(fsys fs.FS, path string) ([]byte, error) {
+	return fs.ReadFile(fsys, path)
+}

--- a/internal/content/htmltype.go
+++ b/internal/content/htmltype.go
@@ -3,7 +3,7 @@ package content
 import (
 	"bufio"
 	"context"
-	"os"
+	"io/fs"
 	"regexp"
 	"strings"
 )
@@ -29,11 +29,11 @@ var (
 	htmlLangRe = regexp.MustCompile(`(?i)<html[^>]*\blang\s*=\s*["']?([A-Za-z][\w-]*)`)
 )
 
-func (h *htmlType) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (h *htmlType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(path)
+	f, err := fsys.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/content/htmltype_test.go
+++ b/internal/content/htmltype_test.go
@@ -12,7 +12,7 @@ func htmlAttrs(t *testing.T, path string) content.Attributes {
 	t.Helper()
 	for _, ct := range content.DefaultRegistry().Types() {
 		if ct.Name() == "html" {
-			attrs, err := ct.Attributes(t.Context(), path)
+			attrs, err := attributesAt(t.Context(), ct, path)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/content/imagetype.go
+++ b/internal/content/imagetype.go
@@ -7,7 +7,7 @@ import (
 	_ "image/jpeg"
 	_ "image/png"
 	"io"
-	"os"
+	"io/fs"
 
 	"github.com/evanoberholster/imagemeta"
 	"github.com/evanoberholster/imagemeta/exif2"
@@ -37,7 +37,7 @@ func (i *imageType) Name() string         { return i.name }
 func (i *imageType) Extensions() []string { return i.exts }
 func (i *imageType) MagicBytes() [][]byte { return i.magic }
 
-func (i *imageType) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (i *imageType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -46,26 +46,26 @@ func (i *imageType) Attributes(ctx context.Context, path string) (Attributes, er
 		"height": int64(0),
 	}
 
-	f, err := os.Open(path)
+	rs, _, closer, err := openReadSeeker(fsys, path)
 	if err != nil {
 		return attrs, nil
 	}
-	defer func() { _ = f.Close() }()
+	defer func() { _ = closer() }()
 
 	// EXIF-bearing types: try imagemeta first. Header-only read; sub-ms.
 	if supportsEXIF(i.name) {
-		if e, err := imagemeta.Decode(f); err == nil {
+		if e, err := imagemeta.Decode(rs); err == nil {
 			populateEXIF(attrs, e)
 		}
 		// Reset for the stdlib fallback regardless of imagemeta's outcome.
-		_, _ = f.Seek(0, io.SeekStart)
+		_, _ = rs.Seek(0, io.SeekStart)
 	}
 
 	// stdlib width/height for JPEG/PNG/GIF — fills in if EXIF didn't.
 	if attrs["width"] == int64(0) {
 		switch i.name {
 		case "image/jpeg", "image/png", "image/gif":
-			if cfg, _, err := image.DecodeConfig(f); err == nil {
+			if cfg, _, err := image.DecodeConfig(rs); err == nil {
 				attrs["width"] = int64(cfg.Width)
 				attrs["height"] = int64(cfg.Height)
 			}

--- a/internal/content/imagetype_test.go
+++ b/internal/content/imagetype_test.go
@@ -16,11 +16,11 @@ import (
 
 func imageAttrs(t *testing.T, ctx context.Context, path string) content.Attributes {
 	t.Helper()
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil {
 		t.Fatalf("Detect: nil for %s", path)
 	}
-	attrs, err := ct.Attributes(ctx, path)
+	attrs, err := attributesAt(ctx, ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestHEICRegistered(t *testing.T) {
 		if err := os.WriteFile(path, nil, 0o644); err != nil {
 			t.Fatal(err)
 		}
-		ct := content.DefaultRegistry().Detect(path)
+		ct := detectAt(path)
 		if ct == nil || ct.Name() != "image/heic" {
 			t.Errorf("Detect(%s): got %v, want image/heic", ext, ct)
 		}
@@ -119,11 +119,11 @@ func TestImageRespectsCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	ct := content.DefaultRegistry().Detect("testdata/exif-light.jpg")
+	ct := detectAt("testdata/exif-light.jpg")
 	if ct == nil {
 		t.Fatal("Detect: nil for testdata/exif-light.jpg")
 	}
-	_, err := ct.Attributes(ctx, "testdata/exif-light.jpg")
+	_, err := attributesAt(ctx, ct, "testdata/exif-light.jpg")
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Attributes(cancelled ctx): err = %v, want context.Canceled", err)
 	}

--- a/internal/content/jsontype.go
+++ b/internal/content/jsontype.go
@@ -3,7 +3,7 @@ package content
 import (
 	"context"
 	"encoding/json"
-	"os"
+	"io/fs"
 )
 
 func init() {
@@ -23,11 +23,11 @@ func (j *jsonType) MagicBytes() [][]byte {
 	}
 }
 
-func (j *jsonType) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (j *jsonType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(path)
+	f, err := fsys.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/content/limits_test.go
+++ b/internal/content/limits_test.go
@@ -51,14 +51,14 @@ func TestTextRespectsLineCap(t *testing.T) {
 		content.SetMaxLineBytes(content.DefaultMaxLineBytes)
 	})
 
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "text" {
 		t.Fatalf("Detect: got %v, want text", ct)
 	}
 
 	// 64 KiB cap: scanner can't fit the 200 KB line, returns no records.
 	content.SetMaxLineBytes(64 * 1024)
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes (low cap): %v", err)
 	}
@@ -68,7 +68,7 @@ func TestTextRespectsLineCap(t *testing.T) {
 
 	// 1 MiB cap: line fits, count is 1.
 	content.SetMaxLineBytes(content.DefaultMaxLineBytes)
-	attrs, err = ct.Attributes(t.Context(), path)
+	attrs, err = attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes (default cap): %v", err)
 	}

--- a/internal/content/markdown.go
+++ b/internal/content/markdown.go
@@ -4,8 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"io"
-	"os"
+	"io/fs"
 	"strings"
 )
 
@@ -21,17 +20,11 @@ func (m *markdownType) Extensions() []string {
 }
 func (m *markdownType) MagicBytes() [][]byte { return nil }
 
-func (m *markdownType) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (m *markdownType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = f.Close() }()
-
-	data, err := io.ReadAll(f)
+	data, err := readAll(fsys, path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/content/odt.go
+++ b/internal/content/odt.go
@@ -3,6 +3,7 @@ package content
 import (
 	"archive/zip"
 	"context"
+	"io/fs"
 )
 
 func init() {
@@ -18,16 +19,20 @@ func (o *odtType) MagicBytes() [][]byte { return nil }
 // Attributes reads OpenDocument metadata from `meta.xml`. ODT differs from
 // OOXML only in the metadata entry path; the inner element vocabulary is the
 // same Dublin Core triple, so readZipDublinCore handles the parsing.
-func (o *odtType) Attributes(ctx context.Context, filePath string) (Attributes, error) {
+func (o *odtType) Attributes(ctx context.Context, fsys fs.FS, filePath string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	zr, err := zip.OpenReader(filePath)
+	ra, size, closer, err := openReaderAt(fsys, filePath)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = zr.Close() }()
+	defer func() { _ = closer() }()
+	zr, err := zip.NewReader(ra, size)
+	if err != nil {
+		return nil, err
+	}
 
-	title, author, lang := readZipDublinCore(ctx, &zr.Reader, "meta.xml")
+	title, author, lang := readZipDublinCore(ctx, zr, "meta.xml")
 	return officeAttributes(title, author, lang), nil
 }

--- a/internal/content/openxml.go
+++ b/internal/content/openxml.go
@@ -3,21 +3,26 @@ package content
 import (
 	"archive/zip"
 	"context"
+	"io/fs"
 )
 
 // ooxmlAttributes is the shared body for DOCX/XLSX/PPTX. All three are
 // OOXML zip packages that store metadata in `docProps/core.xml`.
-func ooxmlAttributes(ctx context.Context, filePath string) (Attributes, error) {
+func ooxmlAttributes(ctx context.Context, fsys fs.FS, filePath string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	zr, err := zip.OpenReader(filePath)
+	ra, size, closer, err := openReaderAt(fsys, filePath)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = zr.Close() }()
+	defer func() { _ = closer() }()
+	zr, err := zip.NewReader(ra, size)
+	if err != nil {
+		return nil, err
+	}
 
-	title, author, lang := readZipDublinCore(ctx, &zr.Reader, "docProps/core.xml")
+	title, author, lang := readZipDublinCore(ctx, zr, "docProps/core.xml")
 	return officeAttributes(title, author, lang), nil
 }
 

--- a/internal/content/openxml_test.go
+++ b/internal/content/openxml_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 const ooxmlCoreXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -81,11 +80,11 @@ func TestOOXMLAttributes(t *testing.T) {
 		t.Run(tc.ext, func(t *testing.T) {
 			path := filepath.Join(dir, "doc"+tc.ext)
 			writeOOXMLZip(t, path)
-			ct := content.DefaultRegistry().Detect(path)
+			ct := detectAt(path)
 			if ct == nil || ct.Name() != tc.want {
 				t.Fatalf("Detect: got %v, want %s", ct, tc.want)
 			}
-			attrs, err := ct.Attributes(t.Context(), path)
+			attrs, err := attributesAt(t.Context(), ct, path)
 			if err != nil {
 				t.Fatalf("Attributes: %v", err)
 			}
@@ -107,12 +106,12 @@ func TestODTAttributes(t *testing.T) {
 	path := filepath.Join(dir, "open.odt")
 	writeODTZip(t, path)
 
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "office/odt" {
 		t.Fatalf("Detect: got %v, want office/odt", ct)
 	}
 
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -134,8 +133,8 @@ func TestOfficeMissingMetadata(t *testing.T) {
 	writeZipWithEntries(t, path, map[string]string{
 		"[Content_Types].xml": `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>`,
 	})
-	ct := content.DefaultRegistry().Detect(path)
-	attrs, err := ct.Attributes(t.Context(), path)
+	ct := detectAt(path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -153,8 +152,8 @@ func TestOfficeNotAZip(t *testing.T) {
 	if err := os.WriteFile(path, []byte("not a zip"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
-	if _, err := ct.Attributes(t.Context(), path); err == nil {
+	ct := detectAt(path)
+	if _, err := attributesAt(t.Context(), ct, path); err == nil {
 		t.Errorf("Attributes on broken zip: expected error, got nil")
 	}
 }

--- a/internal/content/pdftype.go
+++ b/internal/content/pdftype.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/xml"
 	"io"
+	"io/fs"
 	"strings"
 
 	"github.com/ledongthuc/pdf"
@@ -34,15 +35,19 @@ func (p *pdfType) MagicBytes() [][]byte {
 // Each individual lookup is sub-millisecond on real PDFs; ctx is checked
 // at entry and between the catalog/XMP fallback paths so a cancelled walk
 // stops promptly.
-func (p *pdfType) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (p *pdfType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	f, r, err := pdf.Open(path)
+	ra, size, closer, err := openReaderAt(fsys, path)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = f.Close() }()
+	defer func() { _ = closer() }()
+	r, err := pdf.NewReader(ra, size)
+	if err != nil {
+		return nil, err
+	}
 
 	trailer := r.Trailer()
 	root := trailer.Key("Root")

--- a/internal/content/pdftype_test.go
+++ b/internal/content/pdftype_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 // pdfFixture builds a minimal valid PDF byte slice with the given metadata.
@@ -99,11 +98,11 @@ func TestPDFCatalogLang(t *testing.T) {
 		catalogLang: "en-US",
 	})
 
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "pdf" {
 		t.Fatalf("Detect: got %v, want pdf", ct)
 	}
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -130,8 +129,8 @@ func TestPDFXMPLanguageFallback(t *testing.T) {
 		xmpLanguage: "fr",
 	})
 
-	ct := content.DefaultRegistry().Detect(path)
-	attrs, err := ct.Attributes(t.Context(), path)
+	ct := detectAt(path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -150,8 +149,8 @@ func TestPDFCatalogLangBeatsXMP(t *testing.T) {
 		xmpLanguage: "de",
 	})
 
-	ct := content.DefaultRegistry().Detect(path)
-	attrs, err := ct.Attributes(t.Context(), path)
+	ct := detectAt(path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -164,8 +163,8 @@ func TestPDFNoLanguage(t *testing.T) {
 	dir := t.TempDir()
 	path := writePDF(t, dir, "doc.pdf", pdfFixture{title: "x", author: "y"})
 
-	ct := content.DefaultRegistry().Detect(path)
-	attrs, err := ct.Attributes(t.Context(), path)
+	ct := detectAt(path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -178,10 +177,10 @@ func TestPDFRespectsCancellation(t *testing.T) {
 	dir := t.TempDir()
 	path := writePDF(t, dir, "doc.pdf", pdfFixture{title: "x", author: "y", catalogLang: "en"})
 
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := ct.Attributes(ctx, path)
+	_, err := attributesAt(ctx, ct, path)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Attributes(cancelled ctx): err = %v, want context.Canceled", err)
 	}

--- a/internal/content/pptx.go
+++ b/internal/content/pptx.go
@@ -1,6 +1,9 @@
 package content
 
-import "context"
+import (
+	"context"
+	"io/fs"
+)
 
 func init() {
 	Register(&pptxType{})
@@ -11,6 +14,6 @@ type pptxType struct{}
 func (p *pptxType) Name() string         { return "office/pptx" }
 func (p *pptxType) Extensions() []string { return []string{".pptx"} }
 func (p *pptxType) MagicBytes() [][]byte { return nil }
-func (p *pptxType) Attributes(ctx context.Context, path string) (Attributes, error) {
-	return ooxmlAttributes(ctx, path)
+func (p *pptxType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
+	return ooxmlAttributes(ctx, fsys, path)
 }

--- a/internal/content/testhelpers_test.go
+++ b/internal/content/testhelpers_test.go
@@ -1,0 +1,24 @@
+package content_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+)
+
+// detectAt opens an absolute filesystem path through os.DirFS, splitting
+// the path into its directory and base. Convenience for tests that already
+// write fixtures to t.TempDir() and want to keep the call shape close to
+// the pre-FS-refactor `Detect(path)` form.
+func detectAt(path string) content.ContentType {
+	dir := filepath.Dir(path)
+	return content.DefaultRegistry().Detect(os.DirFS(dir), filepath.Base(path))
+}
+
+// attributesAt is the Attributes counterpart of detectAt.
+func attributesAt(ctx context.Context, ct content.ContentType, path string) (content.Attributes, error) {
+	dir := filepath.Dir(path)
+	return ct.Attributes(ctx, os.DirFS(dir), filepath.Base(path))
+}

--- a/internal/content/text.go
+++ b/internal/content/text.go
@@ -3,7 +3,7 @@ package content
 import (
 	"bufio"
 	"context"
-	"os"
+	"io/fs"
 	"strings"
 )
 
@@ -17,11 +17,11 @@ func (t *textType) Name() string         { return "text" }
 func (t *textType) Extensions() []string { return []string{".txt", ".text", ".log"} }
 func (t *textType) MagicBytes() [][]byte { return nil }
 
-func (t *textType) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (t *textType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(path)
+	f, err := fsys.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/content/text_test.go
+++ b/internal/content/text_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 func TestTextAttributes(t *testing.T) {
@@ -19,12 +18,12 @@ func TestTextAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "text" {
 		t.Fatalf("Detect: got %v, want text", ct)
 	}
 
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}
@@ -43,7 +42,7 @@ func TestTextDetectionByExtension(t *testing.T) {
 		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		ct := content.DefaultRegistry().Detect(path)
+		ct := detectAt(path)
 		if ct == nil || ct.Name() != "text" {
 			t.Errorf("Detect(%s): got %v, want text", ext, ct)
 		}
@@ -60,14 +59,14 @@ func TestTextRespectsCancellation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "text" {
 		t.Fatalf("Detect: got %v, want text", ct)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel
-	_, err := ct.Attributes(ctx, path)
+	_, err := attributesAt(ctx, ct, path)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("Attributes(cancelled ctx): err = %v, want context.Canceled", err)
 	}
@@ -79,8 +78,8 @@ func TestTextEmpty(t *testing.T) {
 	if err := os.WriteFile(path, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
-	attrs, err := ct.Attributes(t.Context(), path)
+	ct := detectAt(path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}

--- a/internal/content/types.go
+++ b/internal/content/types.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"context"
+	"io/fs"
 	"sync"
 )
 
@@ -16,11 +17,15 @@ type ContentType interface {
 	Extensions() []string
 	// MagicBytes returns magic byte sequences for detection (nil if not used)
 	MagicBytes() [][]byte
-	// Attributes extracts type-specific attributes from the file at path.
-	// Implementations should check ctx.Err() at entry and (for loop-bound
-	// readers) periodically during scanning. Returning ctx.Err() on
-	// cancellation lets the walker terminate cleanly.
-	Attributes(ctx context.Context, path string) (Attributes, error)
+	// Attributes extracts type-specific attributes from the file at path
+	// on fsys. Path is interpreted as an fs.FS-style key (forward slashes,
+	// relative to the FS root). Implementations should check ctx.Err() at
+	// entry and (for loop-bound readers) periodically during scanning.
+	// Returning ctx.Err() on cancellation lets the walker terminate cleanly.
+	//
+	// Production threads `os.DirFS(root)` here; tests can pass embed.FS or
+	// fstest.MapFS for hermetic execution.
+	Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error)
 }
 
 // Registry holds all registered content types

--- a/internal/content/video_avi_test.go
+++ b/internal/content/video_avi_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 // avih builds a minimal AVI main header (avih chunk body, 56 bytes).
@@ -80,11 +79,11 @@ func TestAVIInfo(t *testing.T) {
 	if err := os.WriteFile(path, buildAVI(33333, 3000, 1280, 720, "H264"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "video/x-msvideo" {
 		t.Fatalf("Detect: got %v, want video/x-msvideo", ct)
 	}
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}

--- a/internal/content/video_mkv_test.go
+++ b/internal/content/video_mkv_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 // vintEncode encodes a uint64 as an EBML variable-length integer using the
@@ -96,11 +95,11 @@ func TestMKVInfo(t *testing.T) {
 	if err := os.WriteFile(path, buildMKV(1_000_000, 100_000, 1920, 1080, 33_333_333), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "video/x-matroska" {
 		t.Fatalf("Detect: got %v, want video/x-matroska", ct)
 	}
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}

--- a/internal/content/video_mp4_test.go
+++ b/internal/content/video_mp4_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/richardwooding/file-search-on/internal/content"
 )
 
 // buildVideoMP4 constructs a minimal MP4 file with a video track (avc1) +
@@ -111,11 +110,11 @@ func TestVideoMP4Info(t *testing.T) {
 	if err := os.WriteFile(path, buildVideoMP4(1000, 100_000, 1920, 1080, 30000, 1000), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ct := content.DefaultRegistry().Detect(path)
+	ct := detectAt(path)
 	if ct == nil || ct.Name() != "video/mp4" {
 		t.Fatalf("Detect: got %v, want video/mp4", ct)
 	}
-	attrs, err := ct.Attributes(t.Context(), path)
+	attrs, err := attributesAt(t.Context(), ct, path)
 	if err != nil {
 		t.Fatalf("Attributes: %v", err)
 	}

--- a/internal/content/videotype.go
+++ b/internal/content/videotype.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"os"
+	"io/fs"
 )
 
 func init() {
@@ -28,27 +28,23 @@ func (v *videoType) MagicBytes() [][]byte { return v.magic }
 // Attributes dispatches to a per-format binary parser. Each parser is
 // header- + tail-bounded (sub-millisecond on real files); ctx is honoured
 // at entry to skip work when a walk is already cancelled.
-func (v *videoType) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (v *videoType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	attrs := Attributes{}
 
-	f, err := os.Open(path)
+	rs, fileSize, closer, err := openReadSeeker(fsys, path)
 	if err != nil {
 		return attrs, nil
 	}
-	defer func() { _ = f.Close() }()
+	defer func() { _ = closer() }()
 
-	fileSize, err := f.Seek(0, io.SeekEnd)
-	if err != nil {
-		return attrs, nil
-	}
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
+	if _, err := rs.Seek(0, io.SeekStart); err != nil {
 		return attrs, nil
 	}
 
-	info, err := readVideoInfo(v.name, f, fileSize)
+	info, err := readVideoInfo(v.name, rs, fileSize)
 	if err != nil {
 		return attrs, nil
 	}

--- a/internal/content/xlsx.go
+++ b/internal/content/xlsx.go
@@ -1,6 +1,9 @@
 package content
 
-import "context"
+import (
+	"context"
+	"io/fs"
+)
 
 func init() {
 	Register(&xlsxType{})
@@ -11,6 +14,6 @@ type xlsxType struct{}
 func (x *xlsxType) Name() string         { return "office/xlsx" }
 func (x *xlsxType) Extensions() []string { return []string{".xlsx"} }
 func (x *xlsxType) MagicBytes() [][]byte { return nil }
-func (x *xlsxType) Attributes(ctx context.Context, path string) (Attributes, error) {
-	return ooxmlAttributes(ctx, path)
+func (x *xlsxType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
+	return ooxmlAttributes(ctx, fsys, path)
 }

--- a/internal/content/xmltype.go
+++ b/internal/content/xmltype.go
@@ -3,7 +3,7 @@ package content
 import (
 	"context"
 	"encoding/xml"
-	"os"
+	"io/fs"
 )
 
 func init() {
@@ -22,11 +22,11 @@ func (x *xmlType) MagicBytes() [][]byte {
 	}
 }
 
-func (x *xmlType) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (x *xmlType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(path)
+	f, err := fsys.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/walker.go
+++ b/internal/search/walker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -38,6 +39,10 @@ type Options struct {
 	// FileAttributes the CEL evaluator built. Off by default so the cheap
 	// path-and-size case does not pay the pointer-keeping cost.
 	IncludeAttributes bool
+	// FS overrides the filesystem used for walking and IO. Defaults to
+	// `os.DirFS(Root)` when nil. Tests inject embed.FS or fstest.MapFS for
+	// hermetic execution; production almost never sets this.
+	FS fs.FS
 }
 
 // Walk walks the directory and returns matching files
@@ -52,9 +57,19 @@ func Walk(ctx context.Context, opts Options, registry *content.Registry) ([]Resu
 		return nil, err
 	}
 
+	fsys := opts.FS
+	if fsys == nil {
+		root := opts.Root
+		if root == "" {
+			root = "."
+		}
+		fsys = os.DirFS(root)
+	}
+
 	var mu sync.Mutex
 	var results []Result
-	paths := make(chan string, opts.Workers*2)
+	type job struct{ fsPath, displayPath string }
+	jobs := make(chan job, opts.Workers*2)
 	var wg sync.WaitGroup
 
 	for i := 0; i < opts.Workers; i++ {
@@ -63,11 +78,11 @@ func Walk(ctx context.Context, opts Options, registry *content.Registry) ([]Resu
 				select {
 				case <-ctx.Done():
 					return
-				case path, ok := <-paths:
+				case j, ok := <-jobs:
 					if !ok {
 						return
 					}
-					attrs, err := celexpr.BuildAttributes(ctx, path, registry)
+					attrs, err := celexpr.BuildAttributes(ctx, fsys, j.fsPath, j.displayPath, registry)
 					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 						return
 					}
@@ -79,7 +94,7 @@ func Walk(ctx context.Context, opts Options, registry *content.Registry) ([]Resu
 						continue
 					}
 					r := Result{
-						Path:        path,
+						Path:        j.displayPath,
 						ContentType: attrs.ContentType,
 						Size:        attrs.Size,
 					}
@@ -94,21 +109,28 @@ func Walk(ctx context.Context, opts Options, registry *content.Registry) ([]Resu
 		})
 	}
 
-	walkErr := filepath.WalkDir(opts.Root, func(path string, d fs.DirEntry, err error) error {
+	walkErr := fs.WalkDir(fsys, ".", func(fsPath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
 		if d.IsDir() {
 			return nil
 		}
+		// User-facing path: OS-native join with Root when set, else the
+		// fs-style path. Tests that pass an in-memory FS without a Root
+		// see fs-style paths in Result.Path.
+		displayPath := fsPath
+		if opts.Root != "" {
+			displayPath = filepath.Join(opts.Root, filepath.FromSlash(fsPath))
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case paths <- path:
+		case jobs <- job{fsPath: fsPath, displayPath: displayPath}:
 		}
 		return nil
 	})
-	close(paths)
+	close(jobs)
 	wg.Wait()
 
 	return results, walkErr


### PR DESCRIPTION
## Summary

Lays the groundwork for hermetic, fixture-based testing by decoupling `internal/content/` from the real filesystem. The `ContentType.Attributes` and `Registry.Detect` interfaces now take an `fs.FS` plus an fs-style path; production passes `os.DirFS(opts.Root)`, tests can pass `embed.FS` / `fstest.MapFS`.

**Behaviourally a no-op for end users.** Same paths, same attribute extraction, same performance for production (streaming reads preserved through duck-typing — see below). The point is to unblock the follow-up PR that adds a public-domain fixture bank.

## What changed

- **New `fs.FS`-aware open helpers** in `internal/content/fsutil.go`:

  ```go
  openReadSeeker(fsys, path) (io.ReadSeeker, int64, closer, error)
  openReaderAt(fsys, path)   (io.ReaderAt,  int64, closer, error)
  readAll(fsys, path)        ([]byte, error)
  ```

  They duck-type on the returned `fs.File`:

  - `*os.File` (production via `os.DirFS`) already implements `io.Seeker` + `io.ReaderAt` — return it directly so streaming reads stay streaming.
  - `embed.FS` / `fstest.MapFS` / other sequential-only files get read into `*bytes.Reader` once. `bytes.Reader` satisfies both interfaces, which is exactly what `zip.NewReader` / `pdf.NewReader` / `imagemeta.Decode` / `tag.ReadFrom` want.

  Net effect: a 4 GB MP4 isn't slurped in production, but tests can drive every content type from in-memory bytes without touching disk.

- **All 13 `Attributes` implementations migrate** from `os.Open(path)` to the helper:

  - Sequential parsers (markdown, html, xml, json, csv, text) use `fsys.Open` + bufio / decoder directly.
  - Random-access parsers (image, audio, video, FLAC) go through `openReadSeeker`.
  - Zip-based parsers (epub, ooxml-shared, odt) switch from `zip.OpenReader(path)` to `zip.NewReader(ra, size)` via `openReaderAt`.
  - PDF: `pdf.Open(path)` → `pdf.NewReader(ra, size)` (the library has had both since forever).

- **Detector** grows an `fsys` parameter for magic-byte sniffing. `nil` is allowed when the caller only wants extension matching.

- **Caller chain** threads the FS through:

  - `celexpr.BuildAttributes(ctx, fsys, fsPath, displayPath, registry)` — splits the path into fs-style (for IO) and OS-native display (for `Result.Path`).
  - `search.Walk` switches from `filepath.WalkDir` to `fs.WalkDir(fsys, ".")`, defaulting `fsys` to `os.DirFS(opts.Root)`. `Options.FS` is the new injection point for tests.

- **Tests** are migrated via a small `testhelpers_test.go` in `package content_test` that exposes `detectAt(path)` and `attributesAt(ctx, ct, path)` wrappers. Existing tests that wrote synthetic bytes to `t.TempDir()` keep their call shape intact — they just call the helper, which constructs `os.DirFS(filepath.Dir(path))` under the hood. This keeps the test-migration noise minimal in this PR; the follow-up PR will introduce `embed.FS`-driven tests proper.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race ./...` — all five packages green
- [x] `go vet ./...` clean
- [x] `golangci-lint run` — 0 issues
- [x] `go fix ./...` idempotent
- [x] CLI smoke: `./file-search-on 'is_markdown' -d ./examples` returns the same paths as before, OS-native (`examples/README.md`, …)
- [x] CLI smoke: `./file-search-on 'is_image' -d ./internal/content/testdata` correctly detects the existing JPEG fixture

## Followup

PR 2 will add a public-domain test-fixture bank under `internal/content/testdata/fixtures/` (one ≤4 KB sample per format, all CC0 / generated-by-us) and embed it via `//go:embed` for hermetic per-format smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)