### PR TITLE
feat(audio): add bit_depth attribute (FLAC + MP4)

### DIFF
--- a/cmd/file-search-on/output.go
+++ b/cmd/file-search-on/output.go
@@ -79,6 +79,7 @@ type Record struct {
 	Bitrate    int64   `json:"bitrate,omitempty"`
 	SampleRate int64   `json:"sample_rate,omitempty"`
 	Channels   int64   `json:"channels,omitempty"`
+	BitDepth   int64   `json:"bit_depth,omitempty"`
 
 	VideoCodec  string  `json:"video_codec,omitempty"`
 	AudioCodec  string  `json:"audio_codec,omitempty"`
@@ -220,6 +221,9 @@ func recordFrom(r search.Result) Record {
 	if v, ok := a.Extra["channels"].(int64); ok {
 		rec.Channels = v
 	}
+	if v, ok := a.Extra["bit_depth"].(int64); ok {
+		rec.BitDepth = v
+	}
 	if v, ok := a.Extra["video_codec"].(string); ok {
 		rec.VideoCodec = v
 	}
@@ -341,6 +345,7 @@ func printVerbose(w io.Writer, results []search.Result) {
 		printIfInt(w, "bitrate", rec.Bitrate)
 		printIfInt(w, "sample_rate", rec.SampleRate)
 		printIfInt(w, "channels", rec.Channels)
+		printIfInt(w, "bit_depth", rec.BitDepth)
 
 		// Video.
 		printIfStr(w, "video_codec", rec.VideoCodec)

--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -98,6 +98,7 @@ func New(expr string) (*Evaluator, error) {
 		cel.Variable("bitrate", cel.IntType),
 		cel.Variable("sample_rate", cel.IntType),
 		cel.Variable("channels", cel.IntType),
+		cel.Variable("bit_depth", cel.IntType),
 		cel.Variable("video_codec", cel.StringType),
 		cel.Variable("audio_codec", cel.StringType),
 		cel.Variable("video_width", cel.IntType),
@@ -185,6 +186,7 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 		"bitrate":            int64(0),
 		"sample_rate":        int64(0),
 		"channels":           int64(0),
+		"bit_depth":          int64(0),
 		"video_codec":        "",
 		"audio_codec":        "",
 		"video_width":        int64(0),
@@ -269,6 +271,8 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 				activation["sample_rate"] = v
 			case "channels":
 				activation["channels"] = v
+			case "bit_depth":
+				activation["bit_depth"] = v
 			case "video_codec":
 				activation["video_codec"] = v
 			case "audio_codec":

--- a/internal/celexpr/schema.go
+++ b/internal/celexpr/schema.go
@@ -86,6 +86,7 @@ func Schema() SchemaDoc {
 			{"bitrate", "int", "audio average bitrate in kbps (computed file_size * 8 / duration / 1000)"},
 			{"sample_rate", "int", "audio sample rate in Hz"},
 			{"channels", "int", "audio channel count (1 = mono, 2 = stereo, etc.)"},
+			{"bit_depth", "int", "audio bits per sample (FLAC STREAMINFO / MP4 stsd sample_size; zero for MP3 / OGG which don't store it)"},
 			{"video_codec", "string", "video codec (h264, h265, av1, vp9, vp8, mpeg4, etc.)"},
 			{"audio_codec", "string", "audio codec for the audio track in a video container (aac, mp3, opus, vorbis, etc.)"},
 			{"video_width", "int", "video frame width in pixels"},

--- a/internal/content/audio_flac.go
+++ b/internal/content/audio_flac.go
@@ -13,6 +13,7 @@ type audioInfo struct {
 	Duration   float64 // seconds
 	SampleRate int64   // Hz
 	Channels   int64
+	BitDepth   int64 // bits per sample (FLAC + MP4 only; MP3 and OGG leave it 0)
 }
 
 // readFLACInfo parses the STREAMINFO metadata block of a FLAC file. The block
@@ -55,21 +56,27 @@ func readFLACInfo(r io.ReadSeeker) (audioInfo, error) {
 	sampleRate := uint32(body[10])<<12 | uint32(body[11])<<4 | uint32(body[12])>>4
 	channels := int64((body[12]>>1)&0x07) + 1
 
+	// bps-1 is 5 bits straddling the byte 12/13 boundary: 1 bit at the
+	// bottom of body[12], 4 bits at the top of body[13]. Stored as
+	// (actual bps - 1), so 16-bit FLAC stores 15.
+	bitDepth := int64((body[12]&0x01)<<4) | int64((body[13]>>4)&0x0F)
+	bitDepth++
+
 	// Bytes 13-17: 4 high bits of bps-1 + 36 bits total_samples.
-	// We don't need bps for our shape; total_samples is the bottom 36 bits
-	// of body[13..17] (5 bytes, big-endian, with the top 4 bits being the
-	// remaining bits of bits-per-sample-1).
+	// total_samples is the bottom 36 bits of body[13..17] (5 bytes,
+	// big-endian, with the top 4 bits being the remaining bits of
+	// bits-per-sample-1).
 	hi := uint64(body[13]) & 0x0F
 	mid := uint64(binary.BigEndian.Uint32(body[14:18]))
 	totalSamples := (hi << 32) | mid
 
-	if sampleRate == 0 || totalSamples == 0 {
-		// Block is structurally valid but doesn't carry duration info.
-		return audioInfo{SampleRate: int64(sampleRate), Channels: channels}, nil
-	}
-	return audioInfo{
-		Duration:   float64(totalSamples) / float64(sampleRate),
+	info := audioInfo{
 		SampleRate: int64(sampleRate),
 		Channels:   channels,
-	}, nil
+		BitDepth:   bitDepth,
+	}
+	if sampleRate > 0 && totalSamples > 0 {
+		info.Duration = float64(totalSamples) / float64(sampleRate)
+	}
+	return info, nil
 }

--- a/internal/content/audio_mp4.go
+++ b/internal/content/audio_mp4.go
@@ -93,8 +93,9 @@ func readMVHD(r io.ReadSeeker, contentLen int64, info *audioInfo) error {
 // readAudioSTSD parses stsd looking for the first audio sample entry. Layout:
 // 1 byte version + 3 bytes flags + 4 bytes entry_count + first entry. Each
 // entry starts with the standard 8-byte box header + a 28-byte
-// AudioSampleEntry preamble; channels are at preamble offset +16 (uint16)
-// and sample_rate at +24 (uint16, fixed-point — only the integer part).
+// AudioSampleEntry preamble; channels are at preamble offset +16 (uint16),
+// sample_size (bits per sample) at +18 (uint16), and sample_rate at +24
+// (uint16, fixed-point — only the integer part).
 func readAudioSTSD(r io.ReadSeeker, end int64, info *audioInfo) error {
 	var preamble [8]byte
 	if _, err := io.ReadFull(r, preamble[:]); err != nil {
@@ -116,6 +117,7 @@ func readAudioSTSD(r io.ReadSeeker, end int64, info *audioInfo) error {
 				return err
 			}
 			info.Channels = int64(binary.BigEndian.Uint16(body[16:18]))
+			info.BitDepth = int64(binary.BigEndian.Uint16(body[18:20]))
 			info.SampleRate = int64(binary.BigEndian.Uint16(body[24:26]))
 			return nil
 		}

--- a/internal/content/audiotype.go
+++ b/internal/content/audiotype.go
@@ -89,6 +89,9 @@ func (a *audioType) Attributes(ctx context.Context, fsys fs.FS, path string) (At
 		if info.Channels > 0 {
 			attrs["channels"] = info.Channels
 		}
+		if info.BitDepth > 0 {
+			attrs["bit_depth"] = info.BitDepth
+		}
 	}
 	return attrs, nil
 }

--- a/internal/content/fixtures_smoke_test.go
+++ b/internal/content/fixtures_smoke_test.go
@@ -216,6 +216,17 @@ func TestFixturesAttributeSpotChecks(t *testing.T) {
 				if sr, _ := a["sample_rate"].(int64); sr != 44100 {
 					t.Errorf("sample_rate = %v; want 44100", a["sample_rate"])
 				}
+				if bd, _ := a["bit_depth"].(int64); bd != 16 {
+					t.Errorf("bit_depth = %v; want 16", a["bit_depth"])
+				}
+			},
+		},
+		{
+			path: "sample.m4a",
+			check: func(t *testing.T, a content.Attributes) {
+				if bd, _ := a["bit_depth"].(int64); bd != 16 {
+					t.Errorf("bit_depth = %v; want 16 (AAC nominal)", a["bit_depth"])
+				}
 			},
 		},
 		{

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -100,6 +100,7 @@ type SearchMatch struct {
 	Bitrate    int64   `json:"bitrate,omitempty"`
 	SampleRate int64   `json:"sample_rate,omitempty"`
 	Channels   int64   `json:"channels,omitempty"`
+	BitDepth   int64   `json:"bit_depth,omitempty"`
 
 	VideoCodec  string  `json:"video_codec,omitempty"`
 	AudioCodec  string  `json:"audio_codec,omitempty"`
@@ -230,6 +231,9 @@ func matchFrom(r search.Result) SearchMatch {
 	}
 	if v, ok := a.Extra["channels"].(int64); ok {
 		m.Channels = v
+	}
+	if v, ok := a.Extra["bit_depth"].(int64); ok {
+		m.BitDepth = v
 	}
 	if v, ok := a.Extra["video_codec"].(string); ok {
 		m.VideoCodec = v


### PR DESCRIPTION
Closes #32.

## Summary

Surfaces audio bits-per-sample as a CEL attribute, so callers can distinguish hi-res (24-bit FLAC / ALAC) from CD-quality (16-bit):

```sh
file-search-on 'is_audio && bit_depth >= 24' -d ~/Music
file-search-on 'is_audio && bit_depth == 16'
```

## Where it comes from

| Format | Source | Notes |
| --- | --- | --- |
| FLAC | STREAMINFO 5-bit `bits_per_sample - 1` | Straddles the byte 12/13 boundary (1 bit at bottom of body[12], 4 bits at top of body[13]). 16-bit FLAC stores 15; 24-bit stores 23. |
| M4A / MP4 | `mp4a` AudioSampleEntry preamble at offset +18 (uint16) | Sits between channels (+16) and sample_rate (+24), both of which the parser already reads. |
| MP3 | not stored | `bit_depth` left as zero; absent from JSON output |
| OGG Vorbis | not stored | same |

## Plumbing

Standard four-call-site discipline (variable declaration in `evaluator.go`, activation default, attrs.Extra switch case, schema doc) plus the `SearchMatch` / `Record` projections for MCP and CLI output.

## Test plan

- [x] `go test -race ./...` — all five packages green
- [x] `go vet` / `golangci-lint` clean
- [x] `go fix` idempotent
- [x] Fixture spot-check extended: `sample.flac` and `sample.m4a` both assert `bit_depth == 16`
- [x] CLI smoke: `./file-search-on attrs sample.flac | grep bit_depth` → `bit_depth     16`; same for `sample.m4a`; absent for `sample.mp3` (correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)