### PR TITLE
feat(video): subtitle track presence + languages (MP4 + MKV)

### DIFF
--- a/cmd/file-search-on/output.go
+++ b/cmd/file-search-on/output.go
@@ -92,6 +92,9 @@ type Record struct {
 	ColorPrimaries string `json:"color_primaries,omitempty"`
 	ColorTransfer  string `json:"color_transfer,omitempty"`
 	IsHDR          bool   `json:"is_hdr,omitempty"`
+
+	Subtitles         bool     `json:"subtitles,omitempty"`
+	SubtitleLanguages []string `json:"subtitle_languages,omitempty"`
 }
 
 // recordFrom projects a search.Result into the wire shape. Falls back to
@@ -260,6 +263,12 @@ func recordFrom(r search.Result) Record {
 	if v, ok := a.Extra["is_hdr"].(bool); ok {
 		rec.IsHDR = v
 	}
+	if v, ok := a.Extra["subtitles"].(bool); ok {
+		rec.Subtitles = v
+	}
+	if v, ok := a.Extra["subtitle_languages"].([]string); ok && len(v) > 0 {
+		rec.SubtitleLanguages = v
+	}
 	if v, ok := a.Extra["frontmatter_format"].(string); ok {
 		rec.FrontmatterFormat = v
 	}
@@ -380,6 +389,12 @@ func printVerbose(w io.Writer, results []search.Result) {
 		printIfStr(w, "color_transfer", rec.ColorTransfer)
 		if rec.IsHDR {
 			fp(w, "  %-13s %v\n", "is_hdr", true)
+		}
+		if rec.Subtitles {
+			fp(w, "  %-13s %v\n", "subtitles", true)
+		}
+		if len(rec.SubtitleLanguages) > 0 {
+			fp(w, "  %-13s %s\n", "sub_langs", strings.Join(rec.SubtitleLanguages, ", "))
 		}
 
 		// Frontmatter shape + lists + date.

--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -109,6 +109,8 @@ func New(expr string) (*Evaluator, error) {
 		cel.Variable("color_primaries", cel.StringType),
 		cel.Variable("color_transfer", cel.StringType),
 		cel.Variable("is_hdr", cel.BoolType),
+		cel.Variable("subtitles", cel.BoolType),
+		cel.Variable("subtitle_languages", cel.ListType(cel.StringType)),
 		cel.Variable("frontmatter", cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable("frontmatter_format", cel.StringType),
 		cel.Variable("tags", cel.ListType(cel.StringType)),
@@ -202,6 +204,8 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 		"color_primaries":    "",
 		"color_transfer":     "",
 		"is_hdr":             false,
+		"subtitles":          false,
+		"subtitle_languages": []string{},
 		"frontmatter":        map[string]any{},
 		"frontmatter_format": "",
 		"tags":               []string{},
@@ -303,6 +307,10 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 				activation["color_transfer"] = v
 			case "is_hdr":
 				activation["is_hdr"] = v
+			case "subtitles":
+				activation["subtitles"] = v
+			case "subtitle_languages":
+				activation["subtitle_languages"] = v
 			case "frontmatter":
 				activation["frontmatter"] = v
 			case "frontmatter_format":

--- a/internal/celexpr/schema.go
+++ b/internal/celexpr/schema.go
@@ -88,6 +88,8 @@ func Schema() SchemaDoc {
 			{"color_primaries", "string", "video colour primaries — 'bt709' (HD), 'bt2020' (HDR / wide-gamut), 'p3' (DCI-P3 / Display P3), or '' if unspecified. Decoded from MP4 colr nclx or MKV Colour element."},
 			{"color_transfer", "string", "video transfer characteristics — 'bt709' (SDR), 'pq' (SMPTE ST 2084 — HDR10), 'hlg' (Hybrid Log-Gamma — broadcast HDR), or '' if unspecified."},
 			{"is_hdr", "bool", "true when transfer is PQ (HDR10 / HDR10+ / Dolby Vision base layer) or HLG. The canonical 'this video is HDR' signal."},
+			{"subtitles", "bool", "true when at least one subtitle / closed-caption track is present (MP4 text/subt/sbtl/clcp tracks; MKV TrackType 17). Empty for AVI."},
+			{"subtitle_languages", "list<str>", "ISO 639-2 language codes from each subtitle track in declaration order. Empty string when language is unspecified or marked 'und'."},
 			{"sample_rate", "int", "audio sample rate in Hz"},
 			{"channels", "int", "audio channel count (1 = mono, 2 = stereo, etc.)"},
 			{"bit_depth", "int", "audio bits per sample (FLAC STREAMINFO / MP4 stsd sample_size; zero for MP3 / OGG which don't store it)"},

--- a/internal/content/video_mkv.go
+++ b/internal/content/video_mkv.go
@@ -30,6 +30,7 @@ var (
 	mkvIDColour         = []byte{0x55, 0xB0} // child of Video; H.273 colour metadata
 	mkvIDColPrimaries   = []byte{0x55, 0xBB}
 	mkvIDColTransfer    = []byte{0x55, 0xBA}
+	mkvIDLanguage       = []byte{0x22, 0xB5, 0x9C} // ISO 639-2 string in TrackEntry
 )
 
 // readMKVInfo walks the EBML tree of a MKV/WebM file extracting playback
@@ -106,6 +107,7 @@ func readMKVTrackEntry(r io.ReadSeeker, end int64, info *videoInfo) error {
 	var sampleRate float64
 	var channels uint64
 	var bitrate uint64 // bits per second (TrackEntry/Bitrate)
+	var language string
 
 	if err := walkEBML(r, mustPos(r), end, func(id []byte, end int64) error {
 		switch {
@@ -124,6 +126,10 @@ func readMKVTrackEntry(r io.ReadSeeker, end int64, info *videoInfo) error {
 		case idEquals(id, mkvIDBitrate):
 			if v, err := readEBMLUint(r, end); err == nil {
 				bitrate = v
+			}
+		case idEquals(id, mkvIDLanguage):
+			if v, err := readEBMLString(r, end); err == nil {
+				language = v
 			}
 		case idEquals(id, mkvIDVideo):
 			return walkEBML(r, mustPos(r), end, func(id []byte, end int64) error {
@@ -203,6 +209,13 @@ func readMKVTrackEntry(r io.ReadSeeker, end int64, info *videoInfo) error {
 				info.AudioChannels = int64(channels)
 			}
 		}
+	case 0x11: // subtitles (Matroska TrackType 17)
+		info.Subtitles = true
+		// Spec default language when omitted is "eng"; readEBMLString
+		// will leave language="" if the field is absent. Surface
+		// whatever's there (including "" when undeclared) so callers
+		// can distinguish missing from explicitly empty.
+		info.SubtitleLanguages = append(info.SubtitleLanguages, language)
 	}
 	return nil
 }

--- a/internal/content/video_mp4.go
+++ b/internal/content/video_mp4.go
@@ -50,6 +50,14 @@ type videoInfo struct {
 	ColourPrimaries string
 	ColourTransfer  string
 	IsHDR           bool
+
+	// Subtitles is true when at least one subtitle / closed-caption
+	// track is present in the container. SubtitleLanguages collects
+	// ISO 639-2 codes (or "" when language is unspecified) from those
+	// tracks, in declaration order. AVI doesn't carry standardised
+	// subtitle metadata; left empty.
+	Subtitles         bool
+	SubtitleLanguages []string
 }
 
 // readMP4VideoInfo walks an MP4/MOV/M4V atom tree extracting playback +
@@ -126,8 +134,8 @@ func videoScanTRAK(r io.ReadSeeker, trakStart, trakEnd int64, info *videoInfo) e
 		info.Rotation = rotation
 	}
 
-	// Pass 1: collect track type, timescale, minf bounds.
-	var trackType string
+	// Pass 1: collect track type, timescale, language, minf bounds.
+	var trackType, language string
 	var timescale uint32
 	var minfStart, minfEnd int64 = -1, -1
 	if _, err := r.Seek(mdiaStart, io.SeekStart); err != nil {
@@ -152,7 +160,7 @@ func videoScanTRAK(r io.ReadSeeker, trakStart, trakEnd int64, info *videoInfo) e
 			}
 			trackType = string(head[8:12])
 		case "mdhd":
-			timescale = readMDHDTimescale(r, contentLen)
+			timescale, language = readMDHD(r, contentLen)
 		case "minf":
 			cur, _ := r.Seek(0, io.SeekCurrent)
 			minfStart = cur
@@ -161,6 +169,15 @@ func videoScanTRAK(r io.ReadSeeker, trakStart, trakEnd int64, info *videoInfo) e
 		if _, err := r.Seek(next, io.SeekStart); err != nil {
 			return err
 		}
+	}
+
+	// Subtitle / closed-caption tracks don't have a stsd we want to walk
+	// (the codec name is in stsd but that's not what users filter on).
+	// Record presence + language and return.
+	if isSubtitleTrack(trackType) {
+		info.Subtitles = true
+		info.SubtitleLanguages = append(info.SubtitleLanguages, language)
+		return nil
 	}
 
 	if minfStart < 0 || trackType == "" {
@@ -399,27 +416,77 @@ func readVideoMVHD(r io.ReadSeeker, contentLen int64, info *videoInfo) error {
 	return nil
 }
 
-// readMDHDTimescale reads the 4-byte timescale from a track-level media
-// header. Layout same shape as mvhd (version-conditional offsets).
-func readMDHDTimescale(r io.ReadSeeker, contentLen int64) uint32 {
+// readMDHD reads the timescale + ISO 639-2 language from a track-level
+// media header. Layout (v0):
+//
+//	1 byte version + 3 bytes flags
+//	4 bytes creation_time
+//	4 bytes modification_time
+//	4 bytes timescale          (offset 12)
+//	4 bytes duration
+//	2 bytes language           (offset 20) — 15 bits packed 5+5+5
+//	2 bytes pre_defined
+//
+// v1 widens the times to 64-bit; timescale is at +20, language at +32.
+//
+// Language is stored as three 5-bit values, each char = (5-bit value)
+// + 0x60. Returns "" if the language field is the "und" placeholder
+// (0x55C4) or otherwise unparseable.
+func readMDHD(r io.ReadSeeker, contentLen int64) (uint32, string) {
 	if contentLen < 4 {
-		return 0
+		return 0, ""
 	}
 	buf := make([]byte, contentLen)
 	if _, err := io.ReadFull(r, buf); err != nil {
-		return 0
+		return 0, ""
 	}
 	version := buf[0]
-	if version == 1 {
-		if len(buf) < 24 {
-			return 0
+	var timescale uint32
+	var langOff int
+	switch version {
+	case 1:
+		if len(buf) < 36 {
+			return 0, ""
 		}
-		return binary.BigEndian.Uint32(buf[20:24])
+		timescale = binary.BigEndian.Uint32(buf[20:24])
+		langOff = 32
+	default:
+		if len(buf) < 24 {
+			return 0, ""
+		}
+		timescale = binary.BigEndian.Uint32(buf[12:16])
+		langOff = 20
 	}
-	if len(buf) < 16 {
-		return 0
+	lang := decodeMDHDLanguage(binary.BigEndian.Uint16(buf[langOff : langOff+2]))
+	return timescale, lang
+}
+
+func decodeMDHDLanguage(packed uint16) string {
+	// 0x55C4 == "und" — explicit "undefined". Treat as empty.
+	if packed == 0x55C4 || packed == 0 {
+		return ""
 	}
-	return binary.BigEndian.Uint32(buf[12:16])
+	c1 := byte((packed>>10)&0x1F) + 0x60
+	c2 := byte((packed>>5)&0x1F) + 0x60
+	c3 := byte(packed&0x1F) + 0x60
+	for _, c := range []byte{c1, c2, c3} {
+		if c < 'a' || c > 'z' {
+			return ""
+		}
+	}
+	return string([]byte{c1, c2, c3})
+}
+
+// isSubtitleTrack reports whether an MP4 hdlr handler_type is a
+// subtitle / closed-caption track. text = 3GPP timed text; subt =
+// MPEG-4 subtitle; sbtl = closed captions in MOV; clcp = MOV
+// 608/708 captioning.
+func isSubtitleTrack(t string) bool {
+	switch t {
+	case "text", "subt", "sbtl", "clcp":
+		return true
+	}
+	return false
 }
 
 // readVideoSTSD parses stsd. For video tracks we read VisualSampleEntry

--- a/internal/content/video_mp4_subtitles_test.go
+++ b/internal/content/video_mp4_subtitles_test.go
@@ -1,0 +1,51 @@
+package content
+
+import "testing"
+
+func TestDecodeMDHDLanguage(t *testing.T) {
+	pack := func(s string) uint16 {
+		if len(s) != 3 {
+			t.Fatalf("language must be 3 chars, got %q", s)
+		}
+		return uint16((s[0]-0x60)&0x1F)<<10 |
+			uint16((s[1]-0x60)&0x1F)<<5 |
+			uint16((s[2]-0x60)&0x1F)
+	}
+
+	cases := []struct {
+		name   string
+		packed uint16
+		want   string
+	}{
+		{"english", pack("eng"), "eng"},
+		{"french", pack("fre"), "fre"},
+		{"spanish", pack("spa"), "spa"},
+		{"japanese", pack("jpn"), "jpn"},
+		{"german", pack("ger"), "ger"},
+		{"undefined sentinel", 0x55C4, ""}, // "und" placeholder treated as empty
+		{"all zeros", 0, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeMDHDLanguage(tc.packed)
+			if got != tc.want {
+				t.Errorf("decode(%#x) = %q; want %q", tc.packed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsSubtitleTrack(t *testing.T) {
+	subtitles := []string{"text", "subt", "sbtl", "clcp"}
+	others := []string{"vide", "soun", "hint", "meta", ""}
+	for _, t1 := range subtitles {
+		if !isSubtitleTrack(t1) {
+			t.Errorf("isSubtitleTrack(%q) = false; want true", t1)
+		}
+	}
+	for _, t1 := range others {
+		if isSubtitleTrack(t1) {
+			t.Errorf("isSubtitleTrack(%q) = true; want false", t1)
+		}
+	}
+}

--- a/internal/content/videotype.go
+++ b/internal/content/videotype.go
@@ -94,6 +94,12 @@ func (v *videoType) Attributes(ctx context.Context, fsys fs.FS, path string) (At
 	if info.IsHDR {
 		attrs["is_hdr"] = true
 	}
+	if info.Subtitles {
+		attrs["subtitles"] = true
+	}
+	if len(info.SubtitleLanguages) > 0 {
+		attrs["subtitle_languages"] = info.SubtitleLanguages
+	}
 	return attrs, nil
 }
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -113,6 +113,9 @@ type SearchMatch struct {
 	ColorPrimaries string `json:"color_primaries,omitempty"`
 	ColorTransfer  string `json:"color_transfer,omitempty"`
 	IsHDR          bool   `json:"is_hdr,omitempty"`
+
+	Subtitles         bool     `json:"subtitles,omitempty"`
+	SubtitleLanguages []string `json:"subtitle_languages,omitempty"`
 }
 
 // matchFrom projects a search.Result (with Attrs populated) into a
@@ -270,6 +273,12 @@ func matchFrom(r search.Result) SearchMatch {
 	}
 	if v, ok := a.Extra["is_hdr"].(bool); ok {
 		m.IsHDR = v
+	}
+	if v, ok := a.Extra["subtitles"].(bool); ok {
+		m.Subtitles = v
+	}
+	if v, ok := a.Extra["subtitle_languages"].([]string); ok && len(v) > 0 {
+		m.SubtitleLanguages = v
 	}
 	if v, ok := a.Extra["frontmatter_format"].(string); ok {
 		m.FrontmatterFormat = v


### PR DESCRIPTION
Closes #39.

> **Stacked on #55** (HDR / colour-space). After #55 lands, GitHub will auto-retarget this PR's base to `main`.

## Summary

Two new CEL attributes for filtering by embedded subtitles:

| Attribute | Type | Use it for |
| --- | --- | --- |
| `subtitles` | bool | Any subtitle / closed-caption track present |
| `subtitle_languages` | list&lt;string&gt; | ISO 639-2 codes per track, declaration order |

```sh
file-search-on 'is_video && subtitles' -d ~/Movies
file-search-on 'is_video && "eng" in subtitle_languages'
file-search-on 'is_video && subtitles && !("eng" in subtitle_languages)'   # foreign-only
```

## Where it lives

| Format | Source |
| --- | --- |
| MP4 / MOV | `trak` with `hdlr.handler_type` ∈ {`text`, `subt`, `sbtl`, `clcp`}; language from `mdhd`'s 15-bit packed ISO 639-2 field (3×5 bits, each char = chunk + 0x60) |
| MKV / WebM | `TrackEntry` with `TrackType=0x11` (17); `Language` (0x22B59C) string |
| AVI | no standardised subtitle metadata; both attributes stay empty/false |

## Implementation

**MP4 / MOV** (`video_mp4.go`):
- New `readMDHD` (returns timescale + language; supersedes the old `readMDHDTimescale`).
- New `decodeMDHDLanguage` (3×5-bit packed → string; treats the "und" sentinel `0x55C4` as `""`).
- New `isSubtitleTrack` for the four handler-type names.
- `videoScanTRAK` short-circuits for subtitle tracks: records presence + language and returns before walking `minf/stbl` (subtitle tracks don't have stsd content we care about).

**MKV / WebM** (`video_mkv.go`):
- New `mkvIDLanguage` (`0x22B59C`) constant.
- `readMKVTrackEntry` walker grows a Language case.
- `TrackType=0x11` branch records presence + language.

Spec default language for MKV is "eng" when omitted; we leave the string empty in that case so callers can distinguish missing from explicitly-tagged "eng".

## Tests

- `TestDecodeMDHDLanguage` drives the bit-packed decoder over eng / fre / spa / jpn / ger plus the "und" sentinel and an all-zeros input.
- `TestIsSubtitleTrack` exercises the four subtitle handler types and the negative cases (vide, soun, hint, meta, "").

The fixture-bank video files have no subtitle tracks, so existing fixtures continue to report `subtitles=false` — accurate for that content.

## Test plan

- [x] `go test -race ./...` — green
- [x] `go vet` / `golangci-lint` clean (the now-unused `readMDHDTimescale` thin wrapper has been removed)
- [x] `go fix` idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)