### PR TITLE
feat(audio): ReplayGain track / album gain attributes

### DIFF
--- a/cmd/file-search-on/output.go
+++ b/cmd/file-search-on/output.go
@@ -95,6 +95,9 @@ type Record struct {
 
 	Subtitles         bool     `json:"subtitles,omitempty"`
 	SubtitleLanguages []string `json:"subtitle_languages,omitempty"`
+
+	ReplayGainTrackGain float64 `json:"replaygain_track_gain,omitempty"`
+	ReplayGainAlbumGain float64 `json:"replaygain_album_gain,omitempty"`
 }
 
 // recordFrom projects a search.Result into the wire shape. Falls back to
@@ -269,6 +272,12 @@ func recordFrom(r search.Result) Record {
 	if v, ok := a.Extra["subtitle_languages"].([]string); ok && len(v) > 0 {
 		rec.SubtitleLanguages = v
 	}
+	if v, ok := a.Extra["replaygain_track_gain"].(float64); ok {
+		rec.ReplayGainTrackGain = v
+	}
+	if v, ok := a.Extra["replaygain_album_gain"].(float64); ok {
+		rec.ReplayGainAlbumGain = v
+	}
 	if v, ok := a.Extra["frontmatter_format"].(string); ok {
 		rec.FrontmatterFormat = v
 	}
@@ -377,6 +386,8 @@ func printVerbose(w io.Writer, results []search.Result) {
 		printIfInt(w, "sample_rate", rec.SampleRate)
 		printIfInt(w, "channels", rec.Channels)
 		printIfInt(w, "bit_depth", rec.BitDepth)
+		printIfFloat(w, "rg_track_gain", rec.ReplayGainTrackGain)
+		printIfFloat(w, "rg_album_gain", rec.ReplayGainAlbumGain)
 
 		// Video.
 		printIfStr(w, "video_codec", rec.VideoCodec)

--- a/cmd/file-search-on/output.go
+++ b/cmd/file-search-on/output.go
@@ -92,6 +92,9 @@ type Record struct {
 	ColorPrimaries string `json:"color_primaries,omitempty"`
 	ColorTransfer  string `json:"color_transfer,omitempty"`
 	IsHDR          bool   `json:"is_hdr,omitempty"`
+
+	Subtitles         bool     `json:"subtitles,omitempty"`
+	SubtitleLanguages []string `json:"subtitle_languages,omitempty"`
 }
 
 // recordFrom projects a search.Result into the wire shape. Falls back to
@@ -260,6 +263,12 @@ func recordFrom(r search.Result) Record {
 	if v, ok := a.Extra["is_hdr"].(bool); ok {
 		rec.IsHDR = v
 	}
+	if v, ok := a.Extra["subtitles"].(bool); ok {
+		rec.Subtitles = v
+	}
+	if v, ok := a.Extra["subtitle_languages"].([]string); ok && len(v) > 0 {
+		rec.SubtitleLanguages = v
+	}
 	if v, ok := a.Extra["frontmatter_format"].(string); ok {
 		rec.FrontmatterFormat = v
 	}
@@ -380,6 +389,12 @@ func printVerbose(w io.Writer, results []search.Result) {
 		printIfStr(w, "color_transfer", rec.ColorTransfer)
 		if rec.IsHDR {
 			fp(w, "  %-13s %v\n", "is_hdr", true)
+		}
+		if rec.Subtitles {
+			fp(w, "  %-13s %v\n", "subtitles", true)
+		}
+		if len(rec.SubtitleLanguages) > 0 {
+			fp(w, "  %-13s %s\n", "sub_langs", strings.Join(rec.SubtitleLanguages, ", "))
 		}
 
 		// Frontmatter shape + lists + date.

--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -111,6 +111,8 @@ func New(expr string) (*Evaluator, error) {
 		cel.Variable("is_hdr", cel.BoolType),
 		cel.Variable("subtitles", cel.BoolType),
 		cel.Variable("subtitle_languages", cel.ListType(cel.StringType)),
+		cel.Variable("replaygain_track_gain", cel.DoubleType),
+		cel.Variable("replaygain_album_gain", cel.DoubleType),
 		cel.Variable("frontmatter", cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable("frontmatter_format", cel.StringType),
 		cel.Variable("tags", cel.ListType(cel.StringType)),
@@ -206,6 +208,8 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 		"is_hdr":             false,
 		"subtitles":          false,
 		"subtitle_languages": []string{},
+		"replaygain_track_gain": float64(0),
+		"replaygain_album_gain": float64(0),
 		"frontmatter":        map[string]any{},
 		"frontmatter_format": "",
 		"tags":               []string{},
@@ -311,6 +315,10 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 				activation["subtitles"] = v
 			case "subtitle_languages":
 				activation["subtitle_languages"] = v
+			case "replaygain_track_gain":
+				activation["replaygain_track_gain"] = v
+			case "replaygain_album_gain":
+				activation["replaygain_album_gain"] = v
 			case "frontmatter":
 				activation["frontmatter"] = v
 			case "frontmatter_format":

--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -109,6 +109,8 @@ func New(expr string) (*Evaluator, error) {
 		cel.Variable("color_primaries", cel.StringType),
 		cel.Variable("color_transfer", cel.StringType),
 		cel.Variable("is_hdr", cel.BoolType),
+		cel.Variable("subtitles", cel.BoolType),
+		cel.Variable("subtitle_languages", cel.ListType(cel.StringType)),
 		cel.Variable("frontmatter", cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable("frontmatter_format", cel.StringType),
 		cel.Variable("tags", cel.ListType(cel.StringType)),
@@ -202,6 +204,8 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 		"color_primaries":    "",
 		"color_transfer":     "",
 		"is_hdr":             false,
+		"subtitles":          false,
+		"subtitle_languages": []string{},
 		"frontmatter":        map[string]any{},
 		"frontmatter_format": "",
 		"tags":               []string{},
@@ -303,6 +307,10 @@ func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
 				activation["color_transfer"] = v
 			case "is_hdr":
 				activation["is_hdr"] = v
+			case "subtitles":
+				activation["subtitles"] = v
+			case "subtitle_languages":
+				activation["subtitle_languages"] = v
 			case "frontmatter":
 				activation["frontmatter"] = v
 			case "frontmatter_format":

--- a/internal/celexpr/schema.go
+++ b/internal/celexpr/schema.go
@@ -90,6 +90,8 @@ func Schema() SchemaDoc {
 			{"is_hdr", "bool", "true when transfer is PQ (HDR10 / HDR10+ / Dolby Vision base layer) or HLG. The canonical 'this video is HDR' signal."},
 			{"subtitles", "bool", "true when at least one subtitle / closed-caption track is present (MP4 text/subt/sbtl/clcp tracks; MKV TrackType 17). Empty for AVI."},
 			{"subtitle_languages", "list<str>", "ISO 639-2 language codes from each subtitle track in declaration order. Empty string when language is unspecified or marked 'und'."},
+			{"replaygain_track_gain", "double", "ReplayGain track gain in dB (negative = quieter, positive = louder). Sourced from Vorbis comments (FLAC + OGG REPLAYGAIN_TRACK_GAIN) and ID3v2 TXXX user-defined-text frames (MP3). M4A iTunes ---- atoms not yet covered."},
+			{"replaygain_album_gain", "double", "ReplayGain album gain in dB. Same sources / coverage as replaygain_track_gain."},
 			{"sample_rate", "int", "audio sample rate in Hz"},
 			{"channels", "int", "audio channel count (1 = mono, 2 = stereo, etc.)"},
 			{"bit_depth", "int", "audio bits per sample (FLAC STREAMINFO / MP4 stsd sample_size; zero for MP3 / OGG which don't store it)"},

--- a/internal/celexpr/schema.go
+++ b/internal/celexpr/schema.go
@@ -88,6 +88,8 @@ func Schema() SchemaDoc {
 			{"color_primaries", "string", "video colour primaries — 'bt709' (HD), 'bt2020' (HDR / wide-gamut), 'p3' (DCI-P3 / Display P3), or '' if unspecified. Decoded from MP4 colr nclx or MKV Colour element."},
 			{"color_transfer", "string", "video transfer characteristics — 'bt709' (SDR), 'pq' (SMPTE ST 2084 — HDR10), 'hlg' (Hybrid Log-Gamma — broadcast HDR), or '' if unspecified."},
 			{"is_hdr", "bool", "true when transfer is PQ (HDR10 / HDR10+ / Dolby Vision base layer) or HLG. The canonical 'this video is HDR' signal."},
+			{"subtitles", "bool", "true when at least one subtitle / closed-caption track is present (MP4 text/subt/sbtl/clcp tracks; MKV TrackType 17). Empty for AVI."},
+			{"subtitle_languages", "list<str>", "ISO 639-2 language codes from each subtitle track in declaration order. Empty string when language is unspecified or marked 'und'."},
 			{"sample_rate", "int", "audio sample rate in Hz"},
 			{"channels", "int", "audio channel count (1 = mono, 2 = stereo, etc.)"},
 			{"bit_depth", "int", "audio bits per sample (FLAC STREAMINFO / MP4 stsd sample_size; zero for MP3 / OGG which don't store it)"},

--- a/internal/content/audiotype.go
+++ b/internal/content/audiotype.go
@@ -68,6 +68,20 @@ func (a *audioType) Attributes(ctx context.Context, fsys fs.FS, path string) (At
 		if t, _ := m.Track(); t > 0 {
 			attrs["track"] = int64(t)
 		}
+		// ReplayGain track / album gain in dB (negative = quieter,
+		// positive = louder). Format-specific extraction sits in the
+		// helper; populated for Vorbis comments (FLAC + OGG) and
+		// ID3v2 TXXX frames (MP3). M4A iTunes ---- atoms are not yet
+		// covered — out of scope for the initial #33 implementation;
+		// flagged in the schema doc.
+		if track, album := extractReplayGain(m.Raw()); track != 0 || album != 0 {
+			if track != 0 {
+				attrs["replaygain_track_gain"] = track
+			}
+			if album != 0 {
+				attrs["replaygain_album_gain"] = album
+			}
+		}
 	}
 	// Tag-read failure isn't fatal — playback metadata still flows through
 	// the per-format parsers below.

--- a/internal/content/replaygain.go
+++ b/internal/content/replaygain.go
@@ -1,0 +1,83 @@
+package content
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/dhowden/tag"
+)
+
+// extractReplayGain pulls ReplayGain track and album gain values (in dB)
+// from the dhowden/tag Raw() map. Two storage paths are covered:
+//
+//   - **Vorbis comments** (FLAC + OGG): keys like REPLAYGAIN_TRACK_GAIN
+//     map directly to a string value such as "-7.42 dB". Vorbis tag
+//     names are case-insensitive per spec but dhowden/tag normalises
+//     them to upper case, so we look for the canonical upper-case keys.
+//   - **ID3v2** (MP3): each ReplayGain value lives in its own TXXX
+//     user-defined-text frame. Multiple TXXX frames coexist; dhowden/tag
+//     stores them in Raw() under "TXXX", "TXXX_1", "TXXX_2", … each as
+//     a *tag.Comm with Description = "replaygain_track_gain" (or _album_)
+//     and Text = the dB value.
+//
+// **Not yet covered**: M4A iTunes-style "----" atoms inside
+// moov/udta/meta/ilst (mean=com.apple.iTunes, name=replaygain_track_gain).
+// Tracked for a follow-up — most Apple Music libraries use Sound Check
+// (the iTunNORM atom) rather than ReplayGain anyway.
+//
+// Returns 0 for any value that's missing or unparseable.
+func extractReplayGain(raw map[string]any) (track, album float64) {
+	// Vorbis comments path — direct uppercase string keys.
+	if v, ok := raw["REPLAYGAIN_TRACK_GAIN"].(string); ok {
+		track = parseGainDB(v)
+	}
+	if v, ok := raw["REPLAYGAIN_ALBUM_GAIN"].(string); ok {
+		album = parseGainDB(v)
+	}
+
+	// ID3v2 TXXX path — iterate looking for replaygain descriptions.
+	for k, v := range raw {
+		if !strings.HasPrefix(k, "TXXX") {
+			continue
+		}
+		c, ok := v.(*tag.Comm)
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(c.Description) {
+		case "replaygain_track_gain":
+			if track == 0 {
+				track = parseGainDB(c.Text)
+			}
+		case "replaygain_album_gain":
+			if album == 0 {
+				album = parseGainDB(c.Text)
+			}
+		}
+	}
+	return track, album
+}
+
+// parseGainDB parses a ReplayGain value string. Common forms:
+//
+//	"-7.42 dB"
+//	"-7.42dB"
+//	"+1.50 dB"
+//	"-7.42"
+//
+// Whitespace and a trailing "dB" / "DB" / "db" suffix are stripped,
+// then strconv.ParseFloat is run. Returns 0 for an unparseable input.
+func parseGainDB(s string) float64 {
+	s = strings.TrimSpace(s)
+	for _, suffix := range []string{"dB", "DB", "db"} {
+		if strings.HasSuffix(s, suffix) {
+			s = strings.TrimSpace(s[:len(s)-len(suffix)])
+			break
+		}
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}

--- a/internal/content/replaygain_test.go
+++ b/internal/content/replaygain_test.go
@@ -1,0 +1,92 @@
+package content
+
+import (
+	"math"
+	"testing"
+
+	"github.com/dhowden/tag"
+)
+
+func TestParseGainDB(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+	}{
+		{"-7.42 dB", -7.42},
+		{"-7.42dB", -7.42},
+		{"+1.50 dB", 1.50},
+		{"-7.42", -7.42},
+		{"  -7.42 dB  ", -7.42},
+		{"-7.42 DB", -7.42},
+		{"-7.42 db", -7.42},
+		{"0 dB", 0},
+		// Unparseable inputs.
+		{"", 0},
+		{"not a number", 0},
+		{"dB", 0},
+	}
+	for _, tc := range cases {
+		got := parseGainDB(tc.in)
+		if math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("parseGainDB(%q) = %v; want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestExtractReplayGain_Vorbis(t *testing.T) {
+	raw := map[string]any{
+		"REPLAYGAIN_TRACK_GAIN": "-7.42 dB",
+		"REPLAYGAIN_ALBUM_GAIN": "-6.83 dB",
+		"REPLAYGAIN_TRACK_PEAK": "0.987",     // ignored — peaks not surfaced
+		"OTHER":                  "some value",
+	}
+	track, album := extractReplayGain(raw)
+	if math.Abs(track-(-7.42)) > 1e-9 {
+		t.Errorf("track = %v; want -7.42", track)
+	}
+	if math.Abs(album-(-6.83)) > 1e-9 {
+		t.Errorf("album = %v; want -6.83", album)
+	}
+}
+
+func TestExtractReplayGain_ID3v2_TXXX(t *testing.T) {
+	// dhowden/tag stores TXXX user-defined-text frames as *tag.Comm
+	// with Description = the descriptor and Text = the value. Multiple
+	// TXXX frames coexist under "TXXX", "TXXX_1", "TXXX_2", …
+	raw := map[string]any{
+		"TXXX":   &tag.Comm{Description: "replaygain_track_gain", Text: "-5.10 dB"},
+		"TXXX_1": &tag.Comm{Description: "replaygain_album_gain", Text: "-4.20 dB"},
+		"TXXX_2": &tag.Comm{Description: "replaygain_track_peak", Text: "0.98"}, // ignored
+		"TXXX_3": &tag.Comm{Description: "OTHER", Text: "ignored"},
+		"TIT2":   "song title",
+	}
+	track, album := extractReplayGain(raw)
+	if math.Abs(track-(-5.10)) > 1e-9 {
+		t.Errorf("track = %v; want -5.10", track)
+	}
+	if math.Abs(album-(-4.20)) > 1e-9 {
+		t.Errorf("album = %v; want -4.20", album)
+	}
+}
+
+func TestExtractReplayGain_VorbisWinsOverTXXX(t *testing.T) {
+	// If both Vorbis-style and TXXX entries are present (impossible in
+	// practice — a file has one tag format — but the helper should be
+	// well-defined either way), the Vorbis path runs first and the
+	// TXXX path only fills in zero-valued sides.
+	raw := map[string]any{
+		"REPLAYGAIN_TRACK_GAIN": "-1.00 dB",
+		"TXXX": &tag.Comm{Description: "replaygain_track_gain", Text: "-99.99 dB"},
+	}
+	track, _ := extractReplayGain(raw)
+	if math.Abs(track-(-1.00)) > 1e-9 {
+		t.Errorf("track = %v; want -1.00 (vorbis path should win)", track)
+	}
+}
+
+func TestExtractReplayGain_Empty(t *testing.T) {
+	track, album := extractReplayGain(map[string]any{})
+	if track != 0 || album != 0 {
+		t.Errorf("empty Raw -> track=%v album=%v; want 0,0", track, album)
+	}
+}

--- a/internal/content/video_mkv.go
+++ b/internal/content/video_mkv.go
@@ -30,6 +30,7 @@ var (
 	mkvIDColour         = []byte{0x55, 0xB0} // child of Video; H.273 colour metadata
 	mkvIDColPrimaries   = []byte{0x55, 0xBB}
 	mkvIDColTransfer    = []byte{0x55, 0xBA}
+	mkvIDLanguage       = []byte{0x22, 0xB5, 0x9C} // ISO 639-2 string in TrackEntry
 )
 
 // readMKVInfo walks the EBML tree of a MKV/WebM file extracting playback
@@ -106,6 +107,7 @@ func readMKVTrackEntry(r io.ReadSeeker, end int64, info *videoInfo) error {
 	var sampleRate float64
 	var channels uint64
 	var bitrate uint64 // bits per second (TrackEntry/Bitrate)
+	var language string
 
 	if err := walkEBML(r, mustPos(r), end, func(id []byte, end int64) error {
 		switch {
@@ -124,6 +126,10 @@ func readMKVTrackEntry(r io.ReadSeeker, end int64, info *videoInfo) error {
 		case idEquals(id, mkvIDBitrate):
 			if v, err := readEBMLUint(r, end); err == nil {
 				bitrate = v
+			}
+		case idEquals(id, mkvIDLanguage):
+			if v, err := readEBMLString(r, end); err == nil {
+				language = v
 			}
 		case idEquals(id, mkvIDVideo):
 			return walkEBML(r, mustPos(r), end, func(id []byte, end int64) error {
@@ -203,6 +209,13 @@ func readMKVTrackEntry(r io.ReadSeeker, end int64, info *videoInfo) error {
 				info.AudioChannels = int64(channels)
 			}
 		}
+	case 0x11: // subtitles (Matroska TrackType 17)
+		info.Subtitles = true
+		// Spec default language when omitted is "eng"; readEBMLString
+		// will leave language="" if the field is absent. Surface
+		// whatever's there (including "" when undeclared) so callers
+		// can distinguish missing from explicitly empty.
+		info.SubtitleLanguages = append(info.SubtitleLanguages, language)
 	}
 	return nil
 }

--- a/internal/content/video_mp4.go
+++ b/internal/content/video_mp4.go
@@ -50,6 +50,14 @@ type videoInfo struct {
 	ColourPrimaries string
 	ColourTransfer  string
 	IsHDR           bool
+
+	// Subtitles is true when at least one subtitle / closed-caption
+	// track is present in the container. SubtitleLanguages collects
+	// ISO 639-2 codes (or "" when language is unspecified) from those
+	// tracks, in declaration order. AVI doesn't carry standardised
+	// subtitle metadata; left empty.
+	Subtitles         bool
+	SubtitleLanguages []string
 }
 
 // readMP4VideoInfo walks an MP4/MOV/M4V atom tree extracting playback +
@@ -126,8 +134,8 @@ func videoScanTRAK(r io.ReadSeeker, trakStart, trakEnd int64, info *videoInfo) e
 		info.Rotation = rotation
 	}
 
-	// Pass 1: collect track type, timescale, minf bounds.
-	var trackType string
+	// Pass 1: collect track type, timescale, language, minf bounds.
+	var trackType, language string
 	var timescale uint32
 	var minfStart, minfEnd int64 = -1, -1
 	if _, err := r.Seek(mdiaStart, io.SeekStart); err != nil {
@@ -152,7 +160,7 @@ func videoScanTRAK(r io.ReadSeeker, trakStart, trakEnd int64, info *videoInfo) e
 			}
 			trackType = string(head[8:12])
 		case "mdhd":
-			timescale = readMDHDTimescale(r, contentLen)
+			timescale, language = readMDHD(r, contentLen)
 		case "minf":
 			cur, _ := r.Seek(0, io.SeekCurrent)
 			minfStart = cur
@@ -161,6 +169,15 @@ func videoScanTRAK(r io.ReadSeeker, trakStart, trakEnd int64, info *videoInfo) e
 		if _, err := r.Seek(next, io.SeekStart); err != nil {
 			return err
 		}
+	}
+
+	// Subtitle / closed-caption tracks don't have a stsd we want to walk
+	// (the codec name is in stsd but that's not what users filter on).
+	// Record presence + language and return.
+	if isSubtitleTrack(trackType) {
+		info.Subtitles = true
+		info.SubtitleLanguages = append(info.SubtitleLanguages, language)
+		return nil
 	}
 
 	if minfStart < 0 || trackType == "" {
@@ -399,27 +416,77 @@ func readVideoMVHD(r io.ReadSeeker, contentLen int64, info *videoInfo) error {
 	return nil
 }
 
-// readMDHDTimescale reads the 4-byte timescale from a track-level media
-// header. Layout same shape as mvhd (version-conditional offsets).
-func readMDHDTimescale(r io.ReadSeeker, contentLen int64) uint32 {
+// readMDHD reads the timescale + ISO 639-2 language from a track-level
+// media header. Layout (v0):
+//
+//	1 byte version + 3 bytes flags
+//	4 bytes creation_time
+//	4 bytes modification_time
+//	4 bytes timescale          (offset 12)
+//	4 bytes duration
+//	2 bytes language           (offset 20) — 15 bits packed 5+5+5
+//	2 bytes pre_defined
+//
+// v1 widens the times to 64-bit; timescale is at +20, language at +32.
+//
+// Language is stored as three 5-bit values, each char = (5-bit value)
+// + 0x60. Returns "" if the language field is the "und" placeholder
+// (0x55C4) or otherwise unparseable.
+func readMDHD(r io.ReadSeeker, contentLen int64) (uint32, string) {
 	if contentLen < 4 {
-		return 0
+		return 0, ""
 	}
 	buf := make([]byte, contentLen)
 	if _, err := io.ReadFull(r, buf); err != nil {
-		return 0
+		return 0, ""
 	}
 	version := buf[0]
-	if version == 1 {
-		if len(buf) < 24 {
-			return 0
+	var timescale uint32
+	var langOff int
+	switch version {
+	case 1:
+		if len(buf) < 36 {
+			return 0, ""
 		}
-		return binary.BigEndian.Uint32(buf[20:24])
+		timescale = binary.BigEndian.Uint32(buf[20:24])
+		langOff = 32
+	default:
+		if len(buf) < 24 {
+			return 0, ""
+		}
+		timescale = binary.BigEndian.Uint32(buf[12:16])
+		langOff = 20
 	}
-	if len(buf) < 16 {
-		return 0
+	lang := decodeMDHDLanguage(binary.BigEndian.Uint16(buf[langOff : langOff+2]))
+	return timescale, lang
+}
+
+func decodeMDHDLanguage(packed uint16) string {
+	// 0x55C4 == "und" — explicit "undefined". Treat as empty.
+	if packed == 0x55C4 || packed == 0 {
+		return ""
 	}
-	return binary.BigEndian.Uint32(buf[12:16])
+	c1 := byte((packed>>10)&0x1F) + 0x60
+	c2 := byte((packed>>5)&0x1F) + 0x60
+	c3 := byte(packed&0x1F) + 0x60
+	for _, c := range []byte{c1, c2, c3} {
+		if c < 'a' || c > 'z' {
+			return ""
+		}
+	}
+	return string([]byte{c1, c2, c3})
+}
+
+// isSubtitleTrack reports whether an MP4 hdlr handler_type is a
+// subtitle / closed-caption track. text = 3GPP timed text; subt =
+// MPEG-4 subtitle; sbtl = closed captions in MOV; clcp = MOV
+// 608/708 captioning.
+func isSubtitleTrack(t string) bool {
+	switch t {
+	case "text", "subt", "sbtl", "clcp":
+		return true
+	}
+	return false
 }
 
 // readVideoSTSD parses stsd. For video tracks we read VisualSampleEntry

--- a/internal/content/video_mp4_subtitles_test.go
+++ b/internal/content/video_mp4_subtitles_test.go
@@ -1,0 +1,51 @@
+package content
+
+import "testing"
+
+func TestDecodeMDHDLanguage(t *testing.T) {
+	pack := func(s string) uint16 {
+		if len(s) != 3 {
+			t.Fatalf("language must be 3 chars, got %q", s)
+		}
+		return uint16((s[0]-0x60)&0x1F)<<10 |
+			uint16((s[1]-0x60)&0x1F)<<5 |
+			uint16((s[2]-0x60)&0x1F)
+	}
+
+	cases := []struct {
+		name   string
+		packed uint16
+		want   string
+	}{
+		{"english", pack("eng"), "eng"},
+		{"french", pack("fre"), "fre"},
+		{"spanish", pack("spa"), "spa"},
+		{"japanese", pack("jpn"), "jpn"},
+		{"german", pack("ger"), "ger"},
+		{"undefined sentinel", 0x55C4, ""}, // "und" placeholder treated as empty
+		{"all zeros", 0, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeMDHDLanguage(tc.packed)
+			if got != tc.want {
+				t.Errorf("decode(%#x) = %q; want %q", tc.packed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsSubtitleTrack(t *testing.T) {
+	subtitles := []string{"text", "subt", "sbtl", "clcp"}
+	others := []string{"vide", "soun", "hint", "meta", ""}
+	for _, t1 := range subtitles {
+		if !isSubtitleTrack(t1) {
+			t.Errorf("isSubtitleTrack(%q) = false; want true", t1)
+		}
+	}
+	for _, t1 := range others {
+		if isSubtitleTrack(t1) {
+			t.Errorf("isSubtitleTrack(%q) = true; want false", t1)
+		}
+	}
+}

--- a/internal/content/videotype.go
+++ b/internal/content/videotype.go
@@ -94,6 +94,12 @@ func (v *videoType) Attributes(ctx context.Context, fsys fs.FS, path string) (At
 	if info.IsHDR {
 		attrs["is_hdr"] = true
 	}
+	if info.Subtitles {
+		attrs["subtitles"] = true
+	}
+	if len(info.SubtitleLanguages) > 0 {
+		attrs["subtitle_languages"] = info.SubtitleLanguages
+	}
 	return attrs, nil
 }
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -113,6 +113,9 @@ type SearchMatch struct {
 	ColorPrimaries string `json:"color_primaries,omitempty"`
 	ColorTransfer  string `json:"color_transfer,omitempty"`
 	IsHDR          bool   `json:"is_hdr,omitempty"`
+
+	Subtitles         bool     `json:"subtitles,omitempty"`
+	SubtitleLanguages []string `json:"subtitle_languages,omitempty"`
 }
 
 // matchFrom projects a search.Result (with Attrs populated) into a
@@ -270,6 +273,12 @@ func matchFrom(r search.Result) SearchMatch {
 	}
 	if v, ok := a.Extra["is_hdr"].(bool); ok {
 		m.IsHDR = v
+	}
+	if v, ok := a.Extra["subtitles"].(bool); ok {
+		m.Subtitles = v
+	}
+	if v, ok := a.Extra["subtitle_languages"].([]string); ok && len(v) > 0 {
+		m.SubtitleLanguages = v
 	}
 	if v, ok := a.Extra["frontmatter_format"].(string); ok {
 		m.FrontmatterFormat = v

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -116,6 +116,9 @@ type SearchMatch struct {
 
 	Subtitles         bool     `json:"subtitles,omitempty"`
 	SubtitleLanguages []string `json:"subtitle_languages,omitempty"`
+
+	ReplayGainTrackGain float64 `json:"replaygain_track_gain,omitempty"`
+	ReplayGainAlbumGain float64 `json:"replaygain_album_gain,omitempty"`
 }
 
 // matchFrom projects a search.Result (with Attrs populated) into a
@@ -279,6 +282,12 @@ func matchFrom(r search.Result) SearchMatch {
 	}
 	if v, ok := a.Extra["subtitle_languages"].([]string); ok && len(v) > 0 {
 		m.SubtitleLanguages = v
+	}
+	if v, ok := a.Extra["replaygain_track_gain"].(float64); ok {
+		m.ReplayGainTrackGain = v
+	}
+	if v, ok := a.Extra["replaygain_album_gain"].(float64); ok {
+		m.ReplayGainAlbumGain = v
 	}
 	if v, ok := a.Extra["frontmatter_format"].(string); ok {
 		m.FrontmatterFormat = v


### PR DESCRIPTION
Closes #33 (partial — M4A iTunes `----` atoms deferred).

> **Stacked on #56** (subtitles). After #56 lands, GitHub will auto-retarget this PR's base to `main`.

## Summary

Two new CEL attributes for ReplayGain loudness metadata, exposed in dB:

| Attribute | Type | Use it for |
| --- | --- | --- |
| `replaygain_track_gain` | double | per-track gain (negative = quieter, positive = louder) |
| `replaygain_album_gain` | double | per-album gain |

```sh
file-search-on 'is_audio && replaygain_track_gain == 0' ~/Music    # untagged
file-search-on 'is_audio && replaygain_track_gain < -10' ~/Music   # loud masters
file-search-on 'is_audio && replaygain_album_gain != 0'            # album-tagged
```

## Coverage

| Format | Storage | Status |
| --- | --- | --- |
| FLAC | Vorbis comments `REPLAYGAIN_TRACK_GAIN` / `_ALBUM_GAIN` | ✅ covered |
| OGG Vorbis | Vorbis comments, same keys | ✅ covered |
| MP3 | ID3v2 `TXXX` user-defined-text frames with `Description=replaygain_track_gain` / `_album_gain` | ✅ covered |
| M4A | iTunes-style `----` atoms inside `moov/udta/meta/ilst` (`mean=com.apple.iTunes`, `name=replaygain_*`) | ❌ not covered (follow-up) |

M4A iTunes `----` parsing requires walking dhowden/tag's nested descriptor format and is non-trivial. Apple's own libraries prefer Sound Check (the `iTunNORM` atom) over ReplayGain anyway, so this is a reasonable scope cut. Noted in `celexpr.Schema()`.

## Implementation

- `internal/content/replaygain.go` (new):
  - `extractReplayGain(raw)` walks the dhowden/tag `Raw()` map. Two probe paths: direct uppercase Vorbis-comment keys, then ID3v2 `TXXX` iteration (`*tag.Comm` values whose `Description` names the field).
  - `parseGainDB(s)` handles the value formats real files use: `"-7.42 dB"`, `"-7.42dB"`, `"+1.50 dB"`, `"-7.42"`, with whitespace tolerance and case-insensitive `dB` suffix.

- `audiotype.go`: after the existing `tag.ReadFrom()` block, calls the helper and surfaces the values when non-zero.

- Standard four-call-site discipline (variable + default + switch + schema doc), plus SearchMatch / Record projections.

## Tests

- `TestParseGainDB` — 11 input formats covering all real-world variants (with / without `dB` suffix, +/- signs, case variants, surrounding whitespace, empty, unparseable).
- `TestExtractReplayGain_Vorbis` — REPLAYGAIN_TRACK_GAIN + REPLAYGAIN_ALBUM_GAIN both populated; ignored REPLAYGAIN_TRACK_PEAK and unrelated keys.
- `TestExtractReplayGain_ID3v2_TXXX` — builds a raw map with four TXXX frames (track gain, album gain, track peak [ignored], arbitrary description [ignored]) plus an unrelated TIT2; extractor pulls the right pair.
- `TestExtractReplayGain_VorbisWinsOverTXXX` — defines well-defined behaviour when both paths populate the same field (Vorbis first; TXXX fills zero-valued sides only).
- `TestExtractReplayGain_Empty` — empty Raw map → 0 / 0.

## Test plan

- [x] `go test -race ./...` — green
- [x] `go vet` / `golangci-lint` clean
- [x] `go fix` idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)