### PR TITLE
fix(content): MKV/WebM parser skips EBML header body

### DIFF
--- a/internal/content/fixtures_smoke_test.go
+++ b/internal/content/fixtures_smoke_test.go
@@ -271,6 +271,51 @@ func TestFixturesAttributeSpotChecks(t *testing.T) {
 			},
 		},
 		{
+			// Regression cover for #51: ffmpeg-emitted MKV files have a
+			// populated EBML header (EBMLVersion, DocType, etc.). The
+			// parser used to read only the header's id + size and then
+			// land on the header's first child instead of the Segment,
+			// causing every subsequent attribute read to fail silently.
+			path: "sample.mkv",
+			check: func(t *testing.T, a content.Attributes) {
+				if w, _ := a["video_width"].(int64); w != 64 {
+					t.Errorf("video_width = %v; want 64", a["video_width"])
+				}
+				if h, _ := a["video_height"].(int64); h != 48 {
+					t.Errorf("video_height = %v; want 48", a["video_height"])
+				}
+				if a["video_codec"] != "h264" {
+					t.Errorf("video_codec = %q; want h264", a["video_codec"])
+				}
+				if d, _ := a["duration"].(float64); d <= 0 {
+					t.Errorf("duration = %v; want > 0", a["duration"])
+				}
+				if a["audio_codec"] != "vorbis" {
+					t.Errorf("audio_codec = %q; want vorbis", a["audio_codec"])
+				}
+				if sr, _ := a["sample_rate"].(int64); sr != 44100 {
+					t.Errorf("sample_rate = %v; want 44100", a["sample_rate"])
+				}
+			},
+		},
+		{
+			path: "sample.webm",
+			check: func(t *testing.T, a content.Attributes) {
+				if w, _ := a["video_width"].(int64); w != 64 {
+					t.Errorf("video_width = %v; want 64", a["video_width"])
+				}
+				if a["video_codec"] != "vp9" {
+					t.Errorf("video_codec = %q; want vp9", a["video_codec"])
+				}
+				if a["audio_codec"] != "opus" {
+					t.Errorf("audio_codec = %q; want opus", a["audio_codec"])
+				}
+				if sr, _ := a["sample_rate"].(int64); sr != 48000 {
+					t.Errorf("sample_rate = %v; want 48000", a["sample_rate"])
+				}
+			},
+		},
+		{
 			path: "sample.docx",
 			check: func(t *testing.T, a content.Attributes) {
 				if a["title"] != "Sample Office Fixture" {

--- a/internal/content/video_mkv.go
+++ b/internal/content/video_mkv.go
@@ -43,9 +43,20 @@ func readMKVInfo(r io.ReadSeeker, fileSize int64) (videoInfo, error) {
 		return videoInfo{}, err
 	}
 
-	// Skip the top-level EBML header element. After it, we expect a Segment.
-	if _, _, err := readEBMLElement(r); err != nil {
+	// Skip the top-level EBML header element. We need to skip BOTH its
+	// header (id + size VINTs, consumed by readEBMLElement) and its
+	// body — real ffmpeg output populates the header with child
+	// elements (EBMLVersion, EBMLReadVersion, DocType, etc.). Without
+	// the body skip, the next readEBMLElement call lands on the
+	// header's first child instead of the Segment.
+	_, hdrSize, err := readEBMLElement(r)
+	if err != nil {
 		return videoInfo{}, err
+	}
+	if hdrSize > 0 {
+		if _, err := r.Seek(hdrSize, io.SeekCurrent); err != nil {
+			return videoInfo{}, err
+		}
 	}
 	id, size, err := readEBMLElement(r)
 	if err != nil {


### PR DESCRIPTION
Closes #51.

## Root cause

The parser at `internal/content/video_mkv.go:46` read the top-level EBML header element's id + size VINTs but **never seeked past its body**. Real ffmpeg-emitted MKV/WebM files populate that body with seven child elements (`EBMLVersion`, `EBMLReadVersion`, `EBMLMaxIDLength`, `EBMLMaxSizeLength`, `DocType`, `DocTypeVersion`, `DocTypeReadVersion`).

Next `readEBMLElement` therefore landed on the header's **first child** (`4286` = EBMLVersion) instead of on the Segment, and the resulting `expected Segment element` error was swallowed by the caller — surfacing as silently-empty `Attributes`.

Diagnostic walk over `sample.mkv` confirms:

```
pos=0x0  id=1a45dfa3 size=35 (end=0x28)    # EBML header
  pos=0x5  id=4286 size=1                  # EBMLVersion — what the parser was reading as the next sibling
  pos=0x9  id=42f7 size=1                  # EBMLReadVersion
  ...
pos=0x28 id=18538067 size=14527            # Segment (what we wanted)
```

So my hypothesis #1 from the issue ("SeekHead first") was wrong. It's even more elementary: the EBML header itself was never being skipped past.

## Why the existing synthetic test missed it

`internal/content/video_mkv_test.go` builds an EBML header with an **empty body** (`ebmlElem(headerID, []byte{})`). With size=0, the read-without-seek-past-body path happens to land on the Segment correctly. So the unit test passed while real files broke.

## Fix

After reading the EBML header's id + size, seek by `hdrSize` bytes from the current position to skip the body before reading the next sibling. One-liner; the existing synthetic test still passes (size=0 → `Seek(0, current)` is a no-op).

## Tests

- New fixture spot-checks for `sample.mkv` and `sample.webm` in `fixtures_smoke_test.go` — assert the full attribute set: `video_width` / `video_height`, `video_codec`, `duration > 0`, `audio_codec`, `sample_rate`. Both fixtures were regenerated in #50 with audio tracks and have been silently failing these assertions ever since #46 added the fixture bank — they finally get coverage.
- Existing `video_mkv_test.go` synthetic test continues to pass.

## End-to-end verification

```
$ ./file-search-on attrs sample.mkv | grep -E 'duration|width|codec|sample_rate|channels'
  duration      1.024
  sample_rate   44,100
  channels      2
  video_codec   h264
  audio_codec   vorbis
  video_width   64
  video_height  48

$ ./file-search-on attrs sample.webm | grep -E 'duration|width|codec|sample_rate'
  duration      1.008
  sample_rate   48,000
  video_codec   vp9
  audio_codec   opus
  video_width   64
```

Before this fix, both produced `is_video=true` and nothing else.

## Test plan

- [x] `go test -race ./...` — green (the new fixture spot checks for MKV / WebM pass; existing synthetic MKV test still passes)
- [x] `go vet` / `golangci-lint` clean
- [x] `go fix` idempotent
- [x] CLI smoke against both fixtures shows the full attribute set

🤖 Generated with [Claude Code](https://claude.com/claude-code)