### PR TITLE
docs(examples): bring audio.md and video.md up to v0.10.0

### DIFF
--- a/examples/audio.md
+++ b/examples/audio.md
@@ -64,6 +64,20 @@ file-search-on 'is_audio && bitrate > 0 && bitrate < 192' -d ~/Music     # below
 file-search-on 'is_audio && bitrate >= 320'                              # 320 kbps+ MP3 / lossless
 ```
 
+`bitrate` is the computed average (file_size × 8 / duration / 1000). The codec/container-stored value lives in `nominal_bitrate` — useful when the average is skewed by an oversized header / cover art:
+
+```sh
+file-search-on 'is_audio && nominal_bitrate >= 256'   # MP3 first-frame ≥ 256 kbps
+file-search-on 'is_audio && nominal_bitrate < 128'    # encoder-declared low quality
+
+# Spot CBR-vs-VBR mismatch — average and nominal disagree by more than 20%.
+file-search-on 'is_audio && bitrate > 0 && nominal_bitrate > 0 &&
+                (bitrate * 100 / nominal_bitrate < 80 ||
+                 bitrate * 100 / nominal_bitrate > 120)'
+```
+
+`nominal_bitrate` is populated for MP3 (first-frame index) and OGG Vorbis (`bitrate_nominal` in the identification header). FLAC and M4A leave it 0 — the FLAC max_frame_size doesn't translate cleanly without frame timing, and M4A `esds` parsing is tracked as a follow-up.
+
 ## Hi-res audio
 
 Sample rate ≥ 96 kHz indicates hi-res content:
@@ -73,12 +87,48 @@ file-search-on 'is_audio && sample_rate >= 96000' -d ~/Music
 file-search-on 'is_audio && sample_rate >= 192000'   # ultra-hi-res, rare outside studio masters
 ```
 
+Bit depth is the second hi-res signal — 24-bit FLAC / ALAC versus 16-bit CD-quality:
+
+```sh
+file-search-on 'is_audio && bit_depth >= 24' -d ~/Music     # hi-res lossless
+file-search-on 'is_audio && bit_depth == 16'                # CD-quality
+
+# True hi-res = both ≥ 24-bit AND ≥ 96 kHz.
+file-search-on 'is_audio && bit_depth >= 24 && sample_rate >= 96000'
+```
+
+`bit_depth` is populated for FLAC (STREAMINFO) and MP4 audio (mp4a sample entry). MP3 and OGG don't store it — `bit_depth` stays 0.
+
 By channel count — surround mixes:
 
 ```sh
 file-search-on 'is_audio && channels > 2'             # 5.1, 7.1, etc.
 file-search-on 'is_audio && channels == 1'            # mono
 ```
+
+## ReplayGain / loudness
+
+Tracks tagged with ReplayGain carry a per-track and per-album gain in dB. Filter for untagged tracks (where playback software can't normalise volume):
+
+```sh
+file-search-on 'is_audio && replaygain_track_gain == 0' -d ~/Music
+```
+
+Loud-mastered tracks (very negative track gain — louder than reference, will be turned DOWN by ReplayGain-aware players):
+
+```sh
+file-search-on 'is_audio && replaygain_track_gain < -10'
+```
+
+Album-tagged vs track-only:
+
+```sh
+file-search-on 'is_audio && replaygain_album_gain != 0'        # album-aware libraries
+file-search-on 'is_audio && replaygain_track_gain != 0 &&
+                replaygain_album_gain == 0'                    # track-only tagging
+```
+
+ReplayGain is populated for FLAC and OGG (Vorbis comments) and MP3 (ID3v2 TXXX user-defined-text frames). M4A iTunes-style atoms aren't covered yet (most Apple Music libraries use Sound Check instead).
 
 ## Format-specific filters
 

--- a/examples/video.md
+++ b/examples/video.md
@@ -36,6 +36,14 @@ file-search-on 'is_video && audio_codec == "opus"'             # WebM / modern M
 file-search-on 'is_video && audio_codec == "ac3"'              # Blu-ray rips
 ```
 
+The first audio track's `sample_rate` and `channels` (the same keys used by standalone audio) populate from the video container too:
+
+```sh
+file-search-on 'is_video && sample_rate >= 48000'              # 48 kHz audio (broadcast / cinema)
+file-search-on 'is_video && channels > 2'                      # surround mixes (5.1, 7.1)
+file-search-on 'is_video && channels == 1'                     # mono / interview clips
+```
+
 ## Resolution
 
 ```sh
@@ -78,6 +86,54 @@ file-search-on 'is_video && bitrate < 1000 && video_height >= 1080'   # over-com
 file-search-on 'is_video && bitrate > 50000'                          # uncompressed / RAW captures
 ```
 
+`nominal_bitrate` is the codec/container-declared value. MP4 reads it from the `btrt` box's avgBitrate (a video-track-only number); MKV reads `Bitrate` (0x4FB1); AVI reads `avih.maxBytesPerSec` (a whole-file ceiling — not strictly video-only but the closest stored value). Useful for filtering streaming targets:
+
+```sh
+file-search-on 'is_video && nominal_bitrate >= 5000'   # ≥ 5 Mbps — Blu-ray / streaming masters
+file-search-on 'is_video && nominal_bitrate < 1000'    # streaming-friendly low-bitrate
+```
+
+## Rotation
+
+Phone-recorded clips often store portrait video as 1920×1080 with a 90° rotation matrix in MP4 `tkhd`. The pixel dimensions stay landscape; `rotation` carries the displayed orientation:
+
+```sh
+file-search-on 'is_video && rotation == 90' -d ~/Movies          # portrait phone clips
+file-search-on 'is_video && rotation > 0'                         # any non-default rotation
+file-search-on 'is_video && rotation == 0 && video_height > video_width'   # genuinely-shot portrait
+```
+
+`rotation` is one of 0 / 90 / 180 / 270, decoded from MP4 `tkhd`'s 3×3 display matrix when it's a pure axis-aligned rotation. Non-MP4 containers and arbitrary affine matrices stay at 0.
+
+## HDR and colour-space
+
+Three attributes — `is_hdr`, `color_primaries`, `color_transfer` — decoded from MP4 `colr` (nclx form) and MKV `Colour` (0x55B0):
+
+```sh
+file-search-on 'is_video && is_hdr' -d ~/Movies                  # all HDR content
+file-search-on 'is_video && color_transfer == "pq"'              # HDR10 / Dolby Vision base layer
+file-search-on 'is_video && color_transfer == "hlg"'             # broadcast HDR (BBC iPlayer, NHK, etc.)
+file-search-on 'is_video && color_primaries == "bt2020"'         # wide-gamut SDR or HDR
+file-search-on 'is_video && color_primaries == "bt709"'          # standard HD
+file-search-on 'is_video && color_primaries == "p3"'             # DCI-P3 / Display P3
+```
+
+`is_hdr` is true when transfer is PQ (SMPTE ST 2084) or HLG. `color_primaries` and `color_transfer` map H.273 enum values to friendly short names (`bt709`, `bt2020`, `p3`, `pq`, `hlg`); unknown enums fall through to `""`. AVI carries no colour metadata.
+
+## Subtitles
+
+Detect embedded subtitle / closed-caption tracks and their languages:
+
+```sh
+file-search-on 'is_video && subtitles' -d ~/Movies                # any sub track present
+file-search-on 'is_video && "eng" in subtitle_languages'          # has English subs
+file-search-on 'is_video && subtitles &&
+                !("eng" in subtitle_languages)'                    # foreign-only — needs translation
+file-search-on 'is_video && size(subtitle_languages) > 1'         # multi-language releases
+```
+
+Sources: MP4 / MOV `trak` with handler `text` / `subt` / `sbtl` / `clcp`; MKV TrackEntry with `TrackType=17`. Languages are ISO 639-2 codes from MP4 `mdhd` or MKV `Language`; an empty string in the list means the track had no language tag (or was tagged `und`). AVI doesn't carry subtitles in any standard form.
+
 ## Format-specific filters
 
 ```sh
@@ -119,9 +175,28 @@ file-search-on 'is_video && video_codec == "h265"' -o json | jq -s 'map(.duratio
 file-search-on 'is_video && video_height >= 2160' -o bare
 ```
 
-## Known limitations
+## Combined queries — film discovery
 
-- **Aspect-ratio rotation**: phone-recorded clips often store portrait video as 1920×1080 with a 90° rotation matrix in `tkhd`. We currently report the stored dimensions, not the displayed dimensions. Tracked in [#36](https://github.com/richardwooding/file-search-on/issues/36).
-- **HDR**: `colr` (MP4) and `Colour` (MKV) elements aren't parsed; `is_hdr` is a follow-up. Tracked in [#38](https://github.com/richardwooding/file-search-on/issues/38).
-- **Subtitle tracks**: presence and language not surfaced. Tracked in [#39](https://github.com/richardwooding/file-search-on/issues/39).
-- **`audio_codec` is video-only** in the current build — for the audio track inside a video container. Audio sample_rate / channels for video files are tracked in [#37](https://github.com/richardwooding/file-search-on/issues/37).
+Find HDR films with English subtitles, modern codec, ≥ 1080p, longer than 30 minutes:
+
+```sh
+file-search-on '
+  is_video &&
+  is_hdr &&
+  "eng" in subtitle_languages &&
+  (video_codec == "h265" || video_codec == "av1") &&
+  video_height >= 1080 &&
+  duration > 1800
+' -d ~/Movies
+```
+
+Multi-language streaming targets (multiple subtitle tracks, ≤ 5 Mbps, AAC audio):
+
+```sh
+file-search-on '
+  is_video &&
+  size(subtitle_languages) > 1 &&
+  nominal_bitrate <= 5000 &&
+  audio_codec == "aac"
+' -d ~/Library
+```


### PR DESCRIPTION
Follow-up to the merged #61 (which only updated the README's attribute tables). This covers the parallel drift in `examples/`.

> The original commit was pushed to #61's branch after you'd already merged it; the orphaned commit has been recovered and rebased onto current main, so the diff here is purely the examples/ work.

## What was missing

`examples/audio.md` and `examples/video.md` had **zero recipes** for the 9 new attributes from v0.10.0. Worse, `examples/video.md` had a stale "Known limitations" section listing four issues (#36, #37, #38, #39) as future work — every one of which had already shipped. Readers were being told features didn't exist when they did.

## Audio (audio.md)

- Bitrate section explains `bitrate` (computed average) vs `nominal_bitrate` (codec-stored), with a CBR-vs-VBR mismatch detector that flags > 20% divergence between the two.
- Hi-res section grows `bit_depth` recipes including a combined "true hi-res = ≥24-bit AND ≥96 kHz" filter.
- New **ReplayGain** section: untagged tracks (`replaygain_track_gain == 0`), loud masters (`< -10 dB`), album-tagged vs track-only libraries.

## Video (video.md)

- "Audio track in a video" subsection grows `sample_rate` / `channels` recipes (since they now populate from the first audio track inside containers per #37 / #50 / #52).
- Bitrate section grows `nominal_bitrate` recipes (5 Mbps Blu-ray cutoff, streaming-friendly low-bitrate).
- New **Rotation** section: portrait phone clips, distinguishing rotation-encoded portrait from genuinely-shot portrait.
- New **HDR / colour-space** section: `is_hdr` filter, PQ vs HLG, BT.2020 / DCI-P3 / Display P3.
- New **Subtitles** section: presence detection, English-subs filter, foreign-only films, multi-language releases.
- New **Combined queries — film discovery** section: HDR + English subs + modern codec + 1080p+ + ≥30 min; multi-language streaming targets.
- The stale "Known limitations" section is removed entirely.

## Test plan

No code changes. Spot-checked `cookbook.md`, `images.md`, `fuzzy-search.md`, and `examples/README.md` — no remaining stale `tracked in #X` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)