### PR TITLE
feat(audio): M4A nominal_bitrate via esds Elementary Stream Descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Run `file-search-on --list` for the canonical, up-to-date listing. The summary t
 | `year`, `track` | int | Release year, track number |
 | `duration` | double | Seconds |
 | `bitrate` | int | kbps — computed average (`file_size × 8 / duration / 1000`) |
-| `nominal_bitrate` | int | kbps — codec/container-stored. MP3 first-frame bitrate; OGG `bitrate_nominal`; M4A esds [not yet, see #58] |
+| `nominal_bitrate` | int | kbps — codec/container-stored. MP3 first-frame bitrate; OGG `bitrate_nominal`; M4A esds (avgBitrate, maxBitrate fallback) |
 | `sample_rate` | int | Hz |
 | `channels` | int | 1 = mono, 2 = stereo, … |
 | `bit_depth` | int | Bits per sample. FLAC STREAMINFO + MP4 `stsd`; 0 for MP3 / OGG (not stored) |

--- a/examples/audio.md
+++ b/examples/audio.md
@@ -76,7 +76,7 @@ file-search-on 'is_audio && bitrate > 0 && nominal_bitrate > 0 &&
                  bitrate * 100 / nominal_bitrate > 120)'
 ```
 
-`nominal_bitrate` is populated for MP3 (first-frame index) and OGG Vorbis (`bitrate_nominal` in the identification header). FLAC and M4A leave it 0 — the FLAC max_frame_size doesn't translate cleanly without frame timing, and M4A `esds` parsing is tracked as a follow-up.
+`nominal_bitrate` is populated for MP3 (first-frame index), OGG Vorbis (`bitrate_nominal` in the identification header), and M4A (esds Elementary Stream Descriptor — `avgBitrate` preferred, `maxBitrate` fallback). FLAC leaves it 0 because `max_frame_size` doesn't translate cleanly to kbps without frame timing.
 
 ## Hi-res audio
 

--- a/internal/celexpr/schema.go
+++ b/internal/celexpr/schema.go
@@ -84,7 +84,7 @@ func Schema() SchemaDoc {
 			{"genre", "string", "audio genre tag"},
 			{"duration", "double", "audio duration in seconds (FLAC STREAMINFO / MP3 Xing / OGG granule / MP4 mvhd)"},
 			{"bitrate", "int", "average bitrate in kbps (computed file_size * 8 / duration / 1000) — applies to audio and video"},
-			{"nominal_bitrate", "int", "codec/container-stored bitrate in kbps, distinct from the computed average. Audio: MP3 first-frame bitrate, OGG Vorbis bitrate_nominal. Video: MP4 btrt avgBitrate, MKV/WebM TrackEntry Bitrate, AVI avih maxBytesPerSec. M4A esds and FLAC max_frame_size are not yet decoded — leave 0."},
+			{"nominal_bitrate", "int", "codec/container-stored bitrate in kbps, distinct from the computed average. Audio: MP3 first-frame bitrate, OGG Vorbis bitrate_nominal, M4A esds avgBitrate (with maxBitrate fallback). Video: MP4 btrt avgBitrate, MKV/WebM TrackEntry Bitrate, AVI avih maxBytesPerSec. FLAC max_frame_size is not surfaced — it doesn't translate cleanly to kbps without frame timing."},
 			{"color_primaries", "string", "video colour primaries — 'bt709' (HD), 'bt2020' (HDR / wide-gamut), 'p3' (DCI-P3 / Display P3), or '' if unspecified. Decoded from MP4 colr nclx or MKV Colour element."},
 			{"color_transfer", "string", "video transfer characteristics — 'bt709' (SDR), 'pq' (SMPTE ST 2084 — HDR10), 'hlg' (Hybrid Log-Gamma — broadcast HDR), or '' if unspecified."},
 			{"is_hdr", "bool", "true when transfer is PQ (HDR10 / HDR10+ / Dolby Vision base layer) or HLG. The canonical 'this video is HDR' signal."},

--- a/internal/content/audio_mp4.go
+++ b/internal/content/audio_mp4.go
@@ -95,7 +95,8 @@ func readMVHD(r io.ReadSeeker, contentLen int64, info *audioInfo) error {
 // entry starts with the standard 8-byte box header + a 28-byte
 // AudioSampleEntry preamble; channels are at preamble offset +16 (uint16),
 // sample_size (bits per sample) at +18 (uint16), and sample_rate at +24
-// (uint16, fixed-point — only the integer part).
+// (uint16, fixed-point — only the integer part). Children (esds for AAC)
+// follow the preamble and end at the sample-entry box's `next` offset.
 func readAudioSTSD(r io.ReadSeeker, end int64, info *audioInfo) error {
 	var preamble [8]byte
 	if _, err := io.ReadFull(r, preamble[:]); err != nil {
@@ -119,12 +120,138 @@ func readAudioSTSD(r io.ReadSeeker, end int64, info *audioInfo) error {
 			info.Channels = int64(binary.BigEndian.Uint16(body[16:18]))
 			info.BitDepth = int64(binary.BigEndian.Uint16(body[18:20]))
 			info.SampleRate = int64(binary.BigEndian.Uint16(body[24:26]))
+			// Walk children of the audio sample entry for esds (AAC
+			// Elementary Stream Descriptor) carrying maxBitrate / avgBitrate.
+			readAudioSampleEntryChildren(r, next, info)
 			return nil
 		}
 		if _, err := r.Seek(next, io.SeekStart); err != nil {
 			return err
 		}
 	}
+}
+
+// readAudioSampleEntryChildren walks children of an mp4a / alac / etc.
+// AudioSampleEntry, looking for the esds box. Reader is positioned just
+// after the 28-byte preamble; `end` is the end of the parent sample-entry
+// box. esds carries codec-stored avg / max bitrate inside the MPEG-4
+// Elementary Stream Descriptor (ES_DescrTag = 0x03) →
+// DecoderConfigDescriptor (tag 0x04) chain.
+func readAudioSampleEntryChildren(r io.ReadSeeker, end int64, info *audioInfo) {
+	for {
+		pos, _ := r.Seek(0, io.SeekCurrent)
+		if pos >= end {
+			return
+		}
+		size, name, contentLen, err := readBoxHeader(r)
+		if err != nil {
+			return
+		}
+		next := pos + size
+		if name == "esds" {
+			body := make([]byte, contentLen)
+			if _, err := io.ReadFull(r, body); err == nil {
+				if avg, maxBR, ok := readESDSBitrates(body); ok {
+					switch {
+					case avg > 0:
+						info.NominalBitrate = int64(avg) / 1000
+					case maxBR > 0:
+						info.NominalBitrate = int64(maxBR) / 1000
+					}
+				}
+			}
+		}
+		if _, err := r.Seek(next, io.SeekStart); err != nil {
+			return
+		}
+	}
+}
+
+// readESDSBitrates parses an esds box body and extracts the
+// avgBitrate / maxBitrate from the DecoderConfigDescriptor. esds layout:
+//
+//	4 bytes  version + flags
+//	1 byte   tag (0x03 = ES_DescrTag)
+//	N bytes  variable-length size  (readVarLenSize: 7 bits/byte with
+//	                                 high-bit continuation flag)
+//	2 bytes  ES_ID
+//	1 byte   flags (top 3 bits gate optional fields below)
+//	[2 bytes dependsOn_ES_ID]      if streamDependenceFlag (0x80)
+//	[1+L bytes URL]                if URL_Flag (0x40)
+//	[2 bytes OCR_ES_ID]            if OCRstreamFlag (0x20)
+//	1 byte   tag (0x04 = DecoderConfigDescrTag)
+//	N bytes  variable-length size
+//	1 byte   objectTypeIndication
+//	1 byte   streamType + upStream + reserved
+//	3 bytes  bufferSizeDB
+//	4 bytes  maxBitrate    ← we want this
+//	4 bytes  avgBitrate    ← and this
+//	... DecoderSpecificInfo (tag 0x05) follows but we stop here ...
+//
+// References: ISO/IEC 14496-1 §7.2 (ES_Descriptor),
+// ISO/IEC 14496-14 (MP4 file format).
+func readESDSBitrates(buf []byte) (avg, maxBR uint32, ok bool) {
+	if len(buf) < 4 {
+		return 0, 0, false
+	}
+	p := 4 // skip version + flags
+	if p >= len(buf) || buf[p] != 0x03 {
+		return 0, 0, false
+	}
+	p++
+	_, n := readDescriptorSize(buf[p:])
+	if n == 0 {
+		return 0, 0, false
+	}
+	p += n
+	if p+3 > len(buf) {
+		return 0, 0, false
+	}
+	flags := buf[p+2]
+	p += 3
+	if flags&0x80 != 0 { // streamDependenceFlag
+		p += 2
+	}
+	if flags&0x40 != 0 { // URL_Flag — 1 byte length, then URL bytes
+		if p >= len(buf) {
+			return 0, 0, false
+		}
+		p += 1 + int(buf[p])
+	}
+	if flags&0x20 != 0 { // OCRstreamFlag
+		p += 2
+	}
+	if p >= len(buf) || buf[p] != 0x04 {
+		return 0, 0, false
+	}
+	p++
+	_, n = readDescriptorSize(buf[p:])
+	if n == 0 {
+		return 0, 0, false
+	}
+	p += n
+	// DecoderConfigDescriptor body: 1 + 1 + 3 + 4 + 4 = 13 bytes minimum.
+	if p+13 > len(buf) {
+		return 0, 0, false
+	}
+	maxBR = binary.BigEndian.Uint32(buf[p+5 : p+9])
+	avg = binary.BigEndian.Uint32(buf[p+9 : p+13])
+	return avg, maxBR, true
+}
+
+// readDescriptorSize decodes the MPEG-4 expandable-class size field:
+// 7 bits per byte with a continuation bit at the top of each. Spec caps
+// it at 4 bytes; anything longer is treated as malformed (returns 0, 0).
+func readDescriptorSize(buf []byte) (size uint32, consumed int) {
+	var v uint32
+	for i := 0; i < len(buf) && i < 4; i++ {
+		b := buf[i]
+		v = (v << 7) | uint32(b&0x7F)
+		if b&0x80 == 0 {
+			return v, i + 1
+		}
+	}
+	return 0, 0
 }
 
 // isAudioSampleEntry returns true for atom types that are audio sample

--- a/internal/content/audio_mp4_esds_test.go
+++ b/internal/content/audio_mp4_esds_test.go
@@ -1,0 +1,128 @@
+package content
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// buildESDS returns an esds box body with the given avg / max bitrates
+// in bps. avgFlag controls whether the avgBitrate slot is populated
+// (false → 0 in the slot, exercising the maxBitrate fallback).
+//
+// Layout written:
+//
+//	4 bytes  version + flags (zero)
+//	1 byte   tag 0x03 (ES_DescrTag)
+//	4 bytes  long-form size (0x80 0x80 0x80 NN)
+//	2 bytes  ES_ID (0x0001)
+//	1 byte   flags (zero — no optional fields follow)
+//	1 byte   tag 0x04 (DecoderConfigDescrTag)
+//	4 bytes  long-form size
+//	1 byte   objectTypeIndication (0x40 = AAC LC)
+//	1 byte   streamType byte (0x15 = audio + reserved)
+//	3 bytes  bufferSizeDB (zero)
+//	4 bytes  maxBitrate
+//	4 bytes  avgBitrate
+func buildESDS(maxBitrate, avgBitrate uint32) []byte {
+	var b bytes.Buffer
+	b.Write([]byte{0x00, 0x00, 0x00, 0x00})         // version + flags
+	b.WriteByte(0x03)                                // ES_DescrTag
+	b.Write([]byte{0x80, 0x80, 0x80, 0x19})         // size (long form, 25 bytes follow)
+	b.Write([]byte{0x00, 0x01})                      // ES_ID
+	b.WriteByte(0x00)                                // ES_Descriptor flags
+	b.WriteByte(0x04)                                // DecoderConfigDescrTag
+	b.Write([]byte{0x80, 0x80, 0x80, 0x0D})         // size (long form, 13 bytes follow)
+	b.WriteByte(0x40)                                // objectTypeIndication (AAC LC)
+	b.WriteByte(0x15)                                // streamType + flags
+	b.Write([]byte{0x00, 0x00, 0x00})                // bufferSizeDB
+	var bb [4]byte
+	binary.BigEndian.PutUint32(bb[:], maxBitrate)
+	b.Write(bb[:])
+	binary.BigEndian.PutUint32(bb[:], avgBitrate)
+	b.Write(bb[:])
+	return b.Bytes()
+}
+
+func TestReadESDSBitrates(t *testing.T) {
+	cases := []struct {
+		name      string
+		maxBitrate uint32
+		avgBitrate uint32
+		wantOk    bool
+		wantAvg   uint32
+		wantMax   uint32
+	}{
+		{"avg + max both populated", 192_000, 184_000, true, 184_000, 192_000},
+		{"only max populated (avg = 0)", 64_000, 0, true, 0, 64_000},
+		{"only avg populated (max = 0)", 0, 128_000, true, 128_000, 0},
+		{"both zero — descriptor present but uninformative", 0, 0, true, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := buildESDS(tc.maxBitrate, tc.avgBitrate)
+			avg, maxBR, ok := readESDSBitrates(body)
+			if ok != tc.wantOk {
+				t.Errorf("ok = %v; want %v", ok, tc.wantOk)
+			}
+			if avg != tc.wantAvg {
+				t.Errorf("avg = %d; want %d", avg, tc.wantAvg)
+			}
+			if maxBR != tc.wantMax {
+				t.Errorf("max = %d; want %d", maxBR, tc.wantMax)
+			}
+		})
+	}
+}
+
+func TestReadESDSBitratesMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{"empty", nil},
+		{"too short for v+f", []byte{0, 0, 0}},
+		{"missing ES_DescrTag", []byte{0, 0, 0, 0, 0xFF}},
+		{"truncated after ES_DescrTag", []byte{0, 0, 0, 0, 0x03}},
+		{"missing DecoderConfigDescrTag", []byte{
+			0x00, 0x00, 0x00, 0x00, // v+f
+			0x03, 0x80, 0x80, 0x80, 0x10, // ES_DescrTag + size 16
+			0x00, 0x01, 0x00, // ES_ID + flags
+			0xFF, // wrong tag (expected 0x04)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, ok := readESDSBitrates(tc.body)
+			if ok {
+				t.Errorf("ok = true; want false (malformed input %q should not parse)", tc.name)
+			}
+		})
+	}
+}
+
+func TestReadDescriptorSize(t *testing.T) {
+	cases := []struct {
+		name        string
+		buf         []byte
+		wantSize    uint32
+		wantConsumed int
+	}{
+		{"single byte (no continuation)", []byte{0x25}, 0x25, 1},
+		{"long form (4 bytes, ffmpeg style)", []byte{0x80, 0x80, 0x80, 0x25}, 0x25, 4},
+		{"two-byte form", []byte{0x81, 0x40}, 0xC0, 2}, // (0x01 << 7) | 0x40 = 0xC0
+		// Spec caps at 4 bytes; longer streams of continuation bytes return 0,0.
+		{"5+ continuation bytes — malformed", []byte{0x80, 0x80, 0x80, 0x80, 0x25}, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSize, gotConsumed := readDescriptorSize(tc.buf)
+			if gotSize != tc.wantSize {
+				t.Errorf("size = %d; want %d", gotSize, tc.wantSize)
+			}
+			if gotConsumed != tc.wantConsumed {
+				t.Errorf("consumed = %d; want %d", gotConsumed, tc.wantConsumed)
+			}
+		})
+	}
+}

--- a/internal/content/fixtures_smoke_test.go
+++ b/internal/content/fixtures_smoke_test.go
@@ -233,6 +233,15 @@ func TestFixturesAttributeSpotChecks(t *testing.T) {
 				if bd, _ := a["bit_depth"].(int64); bd != 16 {
 					t.Errorf("bit_depth = %v; want 16 (AAC nominal)", a["bit_depth"])
 				}
+				// nominal_bitrate from esds is non-zero. The fixture is
+				// 1 second of silence encoded at -b:a 64k; ffmpeg writes
+				// maxBitrate=64000 (the encoder target) and a much lower
+				// avgBitrate (silence compresses to ~1.5 kbps). Our
+				// avg-first precedence picks avgBitrate, so the value
+				// is small but non-zero — that's the parser working.
+				if nb, _ := a["nominal_bitrate"].(int64); nb <= 0 {
+					t.Errorf("nominal_bitrate = %v; want > 0 (esds parse)", a["nominal_bitrate"])
+				}
 			},
 		},
 		{


### PR DESCRIPTION
Closes #58. Last hold-out for `nominal_bitrate` coverage — every other audio (#54: MP3, OGG) and video (#54: MP4 btrt, MKV Bitrate, AVI maxBytesPerSec) source already populated it.

## Where it lives

Inside the audio sample entry: `moov/trak/mdia/minf/stbl/stsd/mp4a/esds`. The esds is a long-form MPEG-4 Elementary Stream Descriptor with tag bytes + variable-length size encoding, nested two levels deep before reaching the bitrate fields.

```
4 bytes  version + flags
1 byte   tag 0x03 (ES_DescrTag)
N bytes  variable-length size (7 bits/byte, high-bit continuation)
2 bytes  ES_ID
1 byte   flags  (top 3 bits gate optional fields below)
[2 bytes dependsOn_ES_ID]      if streamDependenceFlag (0x80)
[1+L bytes URL]                if URL_Flag (0x40)
[2 bytes OCR_ES_ID]            if OCRstreamFlag (0x20)
1 byte   tag 0x04 (DecoderConfigDescrTag)
N bytes  variable-length size
1 byte   objectTypeIndication      (0x40 for AAC LC)
1 byte   streamType + upStream + reserved
3 bytes  bufferSizeDB
4 bytes  maxBitrate     ← we want this
4 bytes  avgBitrate     ← and this
```

References: ISO/IEC 14496-1 §7.2 (ES_Descriptor), 14496-14 (MP4 file format).

## Implementation

Three new functions in `internal/content/audio_mp4.go`:

- `readAudioSampleEntryChildren` — walks children of the AudioSampleEntry box (called from `readAudioSTSD` after the 28-byte preamble), looking for `esds`. Mirrors `readVisualSampleEntryChildren` from #54.
- `readESDSBitrates` — parses the descriptor chain, returning `(avg, max, ok)`. Handles the optional ES_Descriptor fields (streamDependence / URL / OCRstream) based on the flags byte.
- `readDescriptorSize` — decodes the MPEG-4 expandable-class length: 7 bits per byte with a continuation flag at the top. Spec-capped at 4 bytes; over-long inputs treated as malformed.

avg-first precedence (`avgBitrate > 0` → use it; else `maxBitrate`) matches the existing video `btrt` path. For the 1s silence test fixture this yields a small non-zero value (~1 kbps) because silence compresses well — real content has `avg ≈ max` so the precedence still gives sensible numbers.

## Tests

- `TestReadESDSBitrates` (4 cases): avg+max, max-only, avg-only, both-zero. All exercise ffmpeg's default long-form size encoding (`0x80 0x80 0x80 NN`).
- `TestReadESDSBitratesMalformed` (5 cases): empty, truncated, missing tags, wrong tags. Asserts graceful `ok=false` rather than panic / garbage reads.
- `TestReadDescriptorSize` (4 cases): single-byte, long-form (4 bytes), two-byte form, over-long (rejected).
- Fixture spot-check `sample.m4a`: asserts `nominal_bitrate > 0`.

## Docs

- `README.md` attribute table — M4A footnote updated from "[not yet, see #58]" to the actual parser source.
- `examples/audio.md` — prose updated, same swap.
- `celexpr.Schema()` doc string — same.

## Test plan

- [x] `go test -race ./...` — all five packages green
- [x] `go vet` / `golangci-lint` clean
- [x] `go fix` idempotent
- [x] CLI smoke: `./file-search-on attrs sample.m4a | grep nominal_bitrate` shows a non-zero value (1 kbps for the silence fixture; matches the encoder's actual avg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)