### PR TITLE
fix(search): surface ctx cancellation from WalkStream

### DIFF
--- a/internal/search/walker.go
+++ b/internal/search/walker.go
@@ -256,5 +256,19 @@ func WalkStream(ctx context.Context, opts Options, registry *content.Registry, o
 	close(jobs)
 	wg.Wait()
 
+	// Workers exit on ctx.Done() without surfacing an error of their
+	// own, so a fast producer + tightly-deadlined ctx can leave
+	// walkErr=nil even though the walk was cancelled mid-flight:
+	// fs.WalkDir finished queueing 5 small files cleanly, workers
+	// drained ctx.Done() before ever processing them, and the
+	// "return nil" from the WalkDir callback travelled all the way
+	// back up. Surface ctx.Err() here so callers (CLI exit codes,
+	// MCP partial-result flags) reliably detect that the walk was
+	// cancelled rather than complete-but-empty.
+	if walkErr == nil {
+		if err := ctx.Err(); err != nil {
+			walkErr = err
+		}
+	}
 	return walkErr
 }

--- a/internal/search/walker_cancel_test.go
+++ b/internal/search/walker_cancel_test.go
@@ -1,0 +1,73 @@
+package search_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// TestWalkStream_CancelledCtxSurfacesError is a regression test for
+// the silent-cancellation bug fixed alongside this test. When the
+// producer (fs.WalkDir) completes cleanly faster than the workers
+// drain the job channel, the workers exit on ctx.Done() WITHOUT
+// returning an error from their goroutine, and fs.WalkDir's callback
+// also returns nil — so without the post-wg.Wait() ctx.Err() check
+// in WalkStream, the function would return nil and callers would
+// think the walk completed normally.
+//
+// We feed an already-cancelled ctx so the race is forced: workers
+// see ctx.Done() immediately. The contract being pinned: WalkStream
+// returns a non-nil error (specifically a context cancellation
+// error) whenever ctx was cancelled, regardless of which goroutine
+// noticed first.
+func TestWalkStream_CancelledCtxSurfacesError(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "a.md"), "# a\n")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // already-done before walk starts
+
+	out := make(chan search.Result, 16)
+	err := search.WalkStream(ctx, search.Options{
+		Root: dir,
+		Expr: "is_markdown",
+	}, content.DefaultRegistry(), out)
+
+	// Drain the channel so we don't leave a goroutine blocked.
+	for range out {
+	}
+
+	if err == nil {
+		t.Fatal("WalkStream returned nil for already-cancelled ctx; want a cancellation error so callers can distinguish 'walk done' from 'walk cancelled'")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("WalkStream err=%v; want context.Canceled", err)
+	}
+}
+
+// TestWalk_CancelledCtxReturnsPartialAndError mirrors the above for
+// the buffered Walk wrapper — partial results land in the slice,
+// the error reports cancellation.
+func TestWalk_CancelledCtxReturnsPartialAndError(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "a.md"), "# a\n")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := search.Walk(ctx, search.Options{
+		Root: dir,
+		Expr: "is_markdown",
+	}, content.DefaultRegistry())
+
+	if err == nil {
+		t.Fatal("Walk returned nil err for already-cancelled ctx; want a cancellation error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Walk err=%v; want context.Canceled", err)
+	}
+}


### PR DESCRIPTION
## Diagnosis

PR #79's CI flaked: \`TestCLITimeoutExitCode\` failed on the \`push\`-triggered run and passed on the \`pull_request\`-triggered run, both on the same commit \`532a7f2\`. Failure mode: \`expected non-zero exit on --timeout 1ns; got 0 with output \"\"\`.

Root cause is in \`internal/search/walker.go\` \`WalkStream\`, not the test:

1. \`--timeout 1ns\` makes \`ctx\` deadline-exceeded immediately.
2. \`fs.WalkDir\` iterates 5 small \`.md\` files. Each callback's \`select { case <-ctx.Done(): return ctx.Err(); case jobs <- ...: }\` could race either way; on a fast CI machine the **producer finishes queuing all 5 files before \`ctx.Done()\` fires on the producer goroutine**.
3. \`fs.WalkDir\` returns nil (no callback returned an error).
4. \`close(jobs)\`; \`wg.Wait()\` blocks on workers.
5. Workers see \`ctx.Done()\` in their outer select and \`return\` **without surfacing an error of their own**:
   \`\`\`go
   case <-ctx.Done():
       return  // ← worker bails silently
   \`\`\`
6. \`wg.Wait()\` returns; \`WalkStream\` returns \`walkErr = nil\`.
7. Caller thinks the walk succeeded with no matches, exits 0.

Match emission was silently lost. This is broader than the CLI test — MCP \`search\` is affected too: its \`cancelled\` / \`cancellation_reason\` fields would lie about completion in the same race.

## Fix

One small addition to \`WalkStream\` after \`wg.Wait()\`:

\`\`\`go
if walkErr == nil {
    if err := ctx.Err(); err != nil {
        walkErr = err
    }
}
\`\`\`

Surgical; no false positives (\`ctx.Err()\` is nil unless ctx was actually cancelled); matches the semantics every other cancellation site in the codebase already assumes.

## Test plan

- [x] \`go test -race -count=20 -run TestCLITimeoutExitCode ./cmd/file-search-on/\` passes **20/20** locally (was flaky before)
- [x] \`go test -race ./...\` passes
- [x] \`go vet ./...\` clean
- [x] \`go fix -diff ./...\` empty
- [x] \`golangci-lint run\` clean
- [x] New regression tests in \`internal/search/walker_cancel_test.go\` pin the contract for both \`WalkStream\` and \`Walk\` via an already-cancelled ctx (forces the race deterministically)

## Relationship to #79

#79 (\`feat(search): body-content CEL filtering + stats tool\`) hit this same flake. This is a separate small fix branched off main so it can be reviewed / merged independently. Once it lands, rebasing #79 onto new main should make its CI go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)