### PR TITLE
refactor(mcp): DRY timeout resolution across tool handlers

### DIFF
--- a/internal/mcpserver/find_duplicates_tool.go
+++ b/internal/mcpserver/find_duplicates_tool.go
@@ -59,16 +59,9 @@ func (h *handlers) findDuplicatesHandler(ctx context.Context, _ *mcp.CallToolReq
 		dir = "."
 	}
 
-	// Same timeout resolution as the other walking tools.
-	timeout := h.defaultTimeout
-	if in.TimeoutSeconds != nil {
-		timeout = time.Duration(*in.TimeoutSeconds * float64(time.Second))
-	}
-	if timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
+	var cancel context.CancelFunc
+	ctx, cancel = h.resolveTimeout(ctx, in.TimeoutSeconds)
+	defer cancel()
 
 	start := time.Now()
 	dups, err := search.FindDuplicates(ctx, search.Options{

--- a/internal/mcpserver/read_attributes_tool.go
+++ b/internal/mcpserver/read_attributes_tool.go
@@ -34,11 +34,10 @@ func (h *handlers) readAttributesHandler(ctx context.Context, _ *mcp.CallToolReq
 	// Single-file extraction is bounded but not free (markdown reads
 	// the whole file; PDFs / EXIF are header-only). Apply the server
 	// default timeout so a pathological file can't wedge the server.
-	if h.defaultTimeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, h.defaultTimeout)
-		defer cancel()
-	}
+	// No per-call override on this tool — pass nil.
+	var cancel context.CancelFunc
+	ctx, cancel = h.resolveTimeout(ctx, nil)
+	defer cancel()
 
 	attrs, err := celexpr.BuildAttributesWith(ctx, os.DirFS(dir), base, abs, content.DefaultRegistry(), celexpr.BuildOptions{Index: h.idx})
 	if err != nil {

--- a/internal/mcpserver/read_lines_tool.go
+++ b/internal/mcpserver/read_lines_tool.go
@@ -45,12 +45,11 @@ func (h *handlers) readLinesHandler(ctx context.Context, _ *mcp.CallToolRequest,
 	// Honour the server's default timeout so a pathological file
 	// (multi-gigabyte log) can't wedge the server. read_lines is
 	// bounded by max_lines too, but the line scanner can still
-	// take real time on huge files.
-	if h.defaultTimeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, h.defaultTimeout)
-		defer cancel()
-	}
+	// take real time on huge files. No per-call override on this
+	// tool — pass nil.
+	var cancel context.CancelFunc
+	ctx, cancel = h.resolveTimeout(ctx, nil)
+	defer cancel()
 
 	res, err := search.ReadLines(ctx, os.DirFS(dir), base, in.StartLine, in.EndLine, in.MaxLines)
 	if err != nil {

--- a/internal/mcpserver/search_tool.go
+++ b/internal/mcpserver/search_tool.go
@@ -466,22 +466,13 @@ func (h *handlers) searchHandler(ctx context.Context, req *mcp.CallToolRequest, 
 		dir = "."
 	}
 
-	// Resolve the effective timeout: per-call override > server default.
-	// A nil pointer inherits the default; an explicit 0 means "no
-	// timeout for this call" (the parent ctx still applies). We track
-	// the parent ctx separately so we can distinguish a server-level
-	// cancellation (transport close, parent ctx) from our own
-	// timeout firing.
+	// parentCtx is captured before the timeout wrap so we can later
+	// distinguish a server-level cancellation (transport close, parent
+	// ctx) from our own timeout firing.
 	parentCtx := ctx
-	timeout := h.defaultTimeout
-	if in.TimeoutSeconds != nil {
-		timeout = time.Duration(*in.TimeoutSeconds * float64(time.Second))
-	}
-	if timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
+	var cancel context.CancelFunc
+	ctx, cancel = h.resolveTimeout(ctx, in.TimeoutSeconds)
+	defer cancel()
 
 	start := time.Now()
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -25,6 +25,25 @@ type handlers struct {
 	defaultTimeout time.Duration
 }
 
+// resolveTimeout returns a child ctx bounded by the effective per-call
+// timeout, plus a cancel func the caller must defer. Precedence:
+// timeoutSeconds (positive) > h.defaultTimeout (positive) > none.
+// Passing &v with v <= 0 disables the timeout for this call (the
+// parent ctx still applies). Tools without a per-call override (e.g.
+// read_attributes, read_lines) pass nil to fall through to the server
+// default. When the resolved timeout is <= 0 the original ctx and a
+// no-op cancel are returned.
+func (h *handlers) resolveTimeout(ctx context.Context, timeoutSeconds *float64) (context.Context, context.CancelFunc) {
+	timeout := h.defaultTimeout
+	if timeoutSeconds != nil {
+		timeout = time.Duration(*timeoutSeconds * float64(time.Second))
+	}
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
 // serverInstructions is the text sent to MCP clients during initialize
 // (via ServerOptions.Instructions). Clients like Claude Code surface
 // this as system context, so the agent knows the predicate vocabulary

--- a/internal/mcpserver/stats_tool.go
+++ b/internal/mcpserver/stats_tool.go
@@ -67,20 +67,12 @@ func (h *handlers) statsHandler(ctx context.Context, _ *mcp.CallToolRequest, in 
 		dir = "."
 	}
 
-	// Same timeout resolution as searchHandler: per-call > server
-	// default > none. parentCtx separation isn't needed because
-	// ComputeStats itself surfaces cancelled=true via the Stats
-	// struct rather than via the ctx — we just need to apply the
-	// deadline.
-	timeout := h.defaultTimeout
-	if in.TimeoutSeconds != nil {
-		timeout = time.Duration(*in.TimeoutSeconds * float64(time.Second))
-	}
-	if timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
+	// parentCtx separation isn't needed because ComputeStats itself
+	// surfaces cancelled=true via the Stats struct rather than via the
+	// ctx — we just need to apply the deadline.
+	var cancel context.CancelFunc
+	ctx, cancel = h.resolveTimeout(ctx, in.TimeoutSeconds)
+	defer cancel()
 
 	start := time.Now()
 	stats, err := search.ComputeStats(ctx, search.Options{


### PR DESCRIPTION
## Summary

After the per-tool split (#84), the duplicate timeout-resolution boilerplate became visible — five handlers (`search`, `stats`, `find_duplicates`, `read_attributes`, `read_lines`) each repeated some flavour of:

\`\`\`go
timeout := h.defaultTimeout
if in.TimeoutSeconds != nil {
    timeout = time.Duration(*in.TimeoutSeconds * float64(time.Second))
}
if timeout > 0 {
    var cancel context.CancelFunc
    ctx, cancel = context.WithTimeout(ctx, timeout)
    defer cancel()
}
\`\`\`

Extracts to a single `handlers.resolveTimeout(ctx, timeoutSeconds *float64)` method. Tools with a per-call override pass `&in.TimeoutSeconds`; tools without one (`read_attributes`, `read_lines`) pass `nil` and fall through to the server default. Precedence stays unchanged: per-call (positive) > server default (positive) > none.

Net change: **+43 / -50 lines**. No behaviour change, no public API change.

## Test plan

- [x] `go test -race ./...` — all green
- [x] `go vet ./...`
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)