### PR TITLE
test(search): add walker benchmark suite

### DIFF
--- a/internal/search/walker_bench_test.go
+++ b/internal/search/walker_bench_test.go
@@ -1,0 +1,146 @@
+package search_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// seedBenchTree writes a fixed, deterministic tree of markdown files
+// to b.TempDir() and returns the root path. The shape is tuned to be
+// large enough to amortise walker setup (~200 files) yet small enough
+// that a single iteration finishes in tens of ms on typical hardware,
+// so `go test -bench=. -benchtime=1s` collects a few hundred samples.
+func seedBenchTree(b *testing.B) string {
+	b.Helper()
+	root := b.TempDir()
+	for i := range 200 {
+		// Varied content sizes so the body-read / line-count paths
+		// see realistic input. Frontmatter on a third of the files so
+		// markdown parsing exercises the YAML path too.
+		body := fmt.Sprintf("# Title %d\n\nParagraph one.\n\nParagraph two with %d words of filler %s\n",
+			i, i*10, repeat("lorem ipsum dolor sit amet ", i%20+1))
+		if i%3 == 0 {
+			body = "---\ntitle: Doc " + fmt.Sprint(i) + "\ndraft: true\ntags: [a, b, c]\n---\n" + body
+		}
+		path := filepath.Join(root, fmt.Sprintf("doc-%03d.md", i))
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return root
+}
+
+func repeat(s string, n int) string {
+	out := make([]byte, 0, len(s)*n)
+	for range n {
+		out = append(out, s...)
+	}
+	return string(out)
+}
+
+// BenchmarkWalk_Bare is the cheap path: match every file, return
+// just (path, content_type, size) — no full FileAttributes pointer
+// is retained. Measures pure walker + content-type-detection
+// overhead.
+func BenchmarkWalk_Bare(b *testing.B) {
+	root := seedBenchTree(b)
+	reg := content.DefaultRegistry()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := search.Walk(context.Background(), search.Options{
+			Root: root,
+			Expr: "true",
+		}, reg)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkWalk_Predicate uses a type predicate but skips the
+// attribute payload. This is the typical "find me all markdown
+// files" shape — minimal per-file work beyond detection.
+func BenchmarkWalk_Predicate(b *testing.B) {
+	root := seedBenchTree(b)
+	reg := content.DefaultRegistry()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := search.Walk(context.Background(), search.Options{
+			Root: root,
+			Expr: "is_markdown",
+		}, reg)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkWalk_WithAttrs forces the full parse path: markdown
+// frontmatter + word count for every match. This is what the MCP
+// search tool does (it always sets IncludeAttributes=true) and what
+// `-o verbose|json` uses on the CLI side.
+func BenchmarkWalk_WithAttrs(b *testing.B) {
+	root := seedBenchTree(b)
+	reg := content.DefaultRegistry()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := search.Walk(context.Background(), search.Options{
+			Root:              root,
+			Expr:              "is_markdown && word_count > 10",
+			IncludeAttributes: true,
+		}, reg)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkComputeStats measures the histogram aggregation path —
+// same per-file work as Walk_WithAttrs (ComputeStats forces
+// IncludeAttributes internally) plus the bucket-tallying loop.
+func BenchmarkComputeStats(b *testing.B) {
+	root := seedBenchTree(b)
+	reg := content.DefaultRegistry()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := search.ComputeStats(context.Background(), search.Options{
+			Root:    root,
+			Expr:    "true",
+			GroupBy: "content_type",
+		}, reg)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFindDuplicates exercises the two-pass dedup path: size
+// bucketing (every file) + sha256 hashing of size-collision groups.
+// On the seeded tree most files have unique sizes so only a handful
+// reach the hash pass — this is the common "what's in this folder"
+// case, not the pathological all-files-identical case.
+func BenchmarkFindDuplicates(b *testing.B) {
+	root := seedBenchTree(b)
+	reg := content.DefaultRegistry()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := search.FindDuplicates(context.Background(), search.Options{
+			Root: root,
+			Expr: "true",
+		}, reg)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds five benchmarks against a deterministic 200-file markdown tree:

| Benchmark | What it measures |
| --- | --- |
| `BenchmarkWalk_Bare` | Walk + content-type detection, no attrs |
| `BenchmarkWalk_Predicate` | Walk with `is_markdown` filter |
| `BenchmarkWalk_WithAttrs` | Walk with full FileAttributes payload (what the MCP `search` tool does) |
| `BenchmarkComputeStats` | histogram aggregation by content_type |
| `BenchmarkFindDuplicates` | two-pass size-bucket + sha256 dedup |

Documents current perf characteristics after the recent walker churn (cancellation fix, multi-dir, body filter, `ComputeStats` group_by, `FindDuplicates`) so future regressions are catchable. Run with:

\`\`\`sh
go test -bench=. ./internal/search/
go test -bench=BenchmarkWalk_WithAttrs -benchmem -count=5 ./internal/search/   # compare reps
\`\`\`

Baseline on M4 Max (200 files, `go test -bench=. -benchtime=500ms`):

\`\`\`
BenchmarkWalk_Bare-10         	      39	  14,979,824 ns/op	212,676,645 B/op	  20,743 allocs/op
BenchmarkWalk_Predicate-10    	      42	  14,382,246 ns/op	212,681,391 B/op	  20,631 allocs/op
BenchmarkWalk_WithAttrs-10    	      38	  14,298,899 ns/op	212,687,785 B/op	  20,778 allocs/op
BenchmarkComputeStats-10      	      43	  14,027,022 ns/op	212,661,329 B/op	  20,592 allocs/op
BenchmarkFindDuplicates-10    	      33	  15,778,398 ns/op	212,788,781 B/op	  22,006 allocs/op
\`\`\`

No CI integration in this PR — benchmarks are local-run; a scheduled measurement workflow can follow if desired (mirroring the `fuzz.yml` pattern).

## Test plan

- [x] \`go test -race ./...\` — green (benchmarks are skipped by default)
- [x] \`go test -bench=. -benchtime=1x -run='^\$' ./internal/search/\` — all benchmarks compile and run
- [x] \`go vet ./...\`
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)