### PR TITLE
perf(content): right-size markdown scanner buffer

### DIFF
--- a/internal/content/markdown.go
+++ b/internal/content/markdown.go
@@ -34,7 +34,7 @@ func (m *markdownType) Attributes(ctx context.Context, fsys fs.FS, path string) 
 	var title string
 	var wordCount int
 	scanner := bufio.NewScanner(bytes.NewReader(body))
-	scanner.Buffer(make([]byte, 1024*1024), 8*1024*1024)
+	scanner.Buffer(make([]byte, 64*1024), MaxLineBytes())
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

`markdownType.Attributes` allocated a **1 MiB initial scanner buffer per file** with a hardcoded **8 MiB cap** — both wildly out of line with the `64 KiB` / `MaxLineBytes()` pattern used by every other line-scanning content type (text, csv, html, source, mbox). For typical markdown (short lines) the upfront 1 MiB is pure waste; per the walker benchmark profile it accounted for **~190 MB of the 213 MB total allocations** on a 200-file tree.

Also a small **bug fix**: the hardcoded 8 MiB cap ignored the user-tunable `SetMaxLineBytes` / `--max-line-bytes` CLI flag, so a caller asking for a tighter cap got it for every content type except markdown. Aligning to `MaxLineBytes()` closes that gap.

### Benchmark deltas

200-file synthesized markdown tree, Apple M4 Max, `-benchtime=2s`:

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `BenchmarkWalk_Bare` | 15.0ms / 213 MB | **7.8ms / 16 MB** | **−48% / −92%** |
| `BenchmarkWalk_Predicate` | 14.4ms / 213 MB | **7.6ms / 16 MB** | −47% / −92% |
| `BenchmarkWalk_WithAttrs` | 14.3ms / 213 MB | **7.4ms / 16 MB** | −48% / −92% |
| `BenchmarkComputeStats` | 14.0ms / 213 MB | **7.0ms / 16 MB** | −50% / −92% |
| `BenchmarkFindDuplicates` | 15.8ms / 213 MB | **8.9ms / 16 MB** | −44% / −92% |

Allocation _count_ is essentially unchanged (~20,600); each allocation is just much smaller now.

### Diff

\`\`\`diff
- 	scanner.Buffer(make([]byte, 1024*1024), 8*1024*1024)
+ 	scanner.Buffer(make([]byte, 64*1024), MaxLineBytes())
\`\`\`

That's the whole change — one line.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test -race ./...\` — all green
- [x] \`go vet ./...\`
- [x] \`golangci-lint run\` — 0 issues
- [x] Benchmarks confirm 48% time / 92% allocation reduction across the suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)