### PR TITLE
perf(celexpr): custom cel.Activation, drop per-call map allocation

### DIFF
--- a/internal/celexpr/activation.go
+++ b/internal/celexpr/activation.go
@@ -1,0 +1,180 @@
+package celexpr
+
+import (
+	"time"
+
+	"github.com/google/cel-go/cel"
+)
+
+// fileAttrsActivation is a cel.Activation backed directly by
+// *FileAttributes — no per-Evaluate map allocation. Replaces the
+// 100-entry map literal that dominated walker allocations after the
+// markdown scanner was right-sized (#90 + #91 profiles flagged
+// Evaluate as the next-biggest contributor at ~35%).
+//
+// Struct fields short-circuit first; Extra-driven attributes come
+// next; declared variables that the matched content-type family
+// didn't populate fall back to a static zero default.
+//
+// Sharing the zero defaults map across calls is safe: cel-go treats
+// activation inputs as read-only, so the immutable empty slice /
+// empty map sentinels never get mutated through it.
+type fileAttrsActivation struct {
+	attrs *FileAttributes
+}
+
+// ResolveName returns the CEL-visible value for the named variable.
+// Returns false only for names that aren't declared in the env —
+// which shouldn't happen since the env declares the full set up
+// front and the CEL compiler rejects expressions referencing
+// undeclared vars.
+func (a *fileAttrsActivation) ResolveName(name string) (any, bool) {
+	switch name {
+	case "name":
+		return a.attrs.Name, true
+	case "path":
+		return a.attrs.Path, true
+	case "dir":
+		return a.attrs.Dir, true
+	case "size":
+		return a.attrs.Size, true
+	case "ext":
+		return a.attrs.Ext, true
+	case "content_type":
+		return a.attrs.ContentType, true
+	case "is_markdown":
+		return a.attrs.IsMarkdown, true
+	case "is_json":
+		return a.attrs.IsJSON, true
+	case "is_xml":
+		return a.attrs.IsXML, true
+	case "is_html":
+		return a.attrs.IsHTML, true
+	case "is_pdf":
+		return a.attrs.IsPDF, true
+	case "is_image":
+		return a.attrs.IsImage, true
+	case "is_text":
+		return a.attrs.IsText, true
+	case "is_csv":
+		return a.attrs.IsCSV, true
+	case "is_epub":
+		return a.attrs.IsEPUB, true
+	case "is_office":
+		return a.attrs.IsOffice, true
+	case "is_audio":
+		return a.attrs.IsAudio, true
+	case "is_video":
+		return a.attrs.IsVideo, true
+	case "is_archive":
+		return a.attrs.IsArchive, true
+	case "is_binary":
+		return a.attrs.IsBinary, true
+	case "is_email":
+		return a.attrs.IsEmail, true
+	case "is_source":
+		return a.attrs.IsSource, true
+	case "is_notebook":
+		return a.attrs.IsNotebook, true
+	}
+	if v, ok := a.attrs.Extra[name]; ok {
+		return v, true
+	}
+	if v, ok := zeroDefaults[name]; ok {
+		return v, true
+	}
+	return nil, false
+}
+
+// Parent returns nil — fileAttrsActivation is a leaf binding, the
+// only activation cel-go sees per Evaluate call.
+func (a *fileAttrsActivation) Parent() cel.Activation {
+	return nil
+}
+
+// zeroDefaults holds the type-appropriate zero value for every
+// declared CEL variable that's populated through FileAttributes.Extra.
+// Built once at package init and never mutated.
+var zeroDefaults = map[string]any{
+	"title":                 "",
+	"body":                  "",
+	"word_count":            int64(0),
+	"line_count":            int64(0),
+	"column_count":          int64(0),
+	"csv_columns":           []string{},
+	"language":              "",
+	"page_count":            int64(0),
+	"author":                "",
+	"root_element":          "",
+	"json_kind":             "",
+	"img_width":             int64(0),
+	"img_height":            int64(0),
+	"camera_make":           "",
+	"camera_model":          "",
+	"lens":                  "",
+	"taken_at":              time.Time{},
+	"orientation":           int64(0),
+	"gps_lat":               float64(0),
+	"gps_lon":               float64(0),
+	"iso":                   int64(0),
+	"focal_length":          float64(0),
+	"f_stop":                float64(0),
+	"exposure_time":         float64(0),
+	"artist":                "",
+	"album":                 "",
+	"album_artist":          "",
+	"composer":              "",
+	"year":                  int64(0),
+	"track":                 int64(0),
+	"genre":                 "",
+	"duration":              float64(0),
+	"bitrate":               int64(0),
+	"sample_rate":           int64(0),
+	"channels":              int64(0),
+	"bit_depth":             int64(0),
+	"video_codec":           "",
+	"audio_codec":           "",
+	"video_width":           int64(0),
+	"video_height":          int64(0),
+	"frame_rate":            float64(0),
+	"rotation":              int64(0),
+	"nominal_bitrate":       int64(0),
+	"color_primaries":       "",
+	"color_transfer":        "",
+	"is_hdr":                false,
+	"subtitles":             false,
+	"subtitle_languages":    []string{},
+	"replaygain_track_gain": float64(0),
+	"replaygain_album_gain": float64(0),
+	"entry_count":           int64(0),
+	"uncompressed_size":     int64(0),
+	"top_level_entries":     []string{},
+	"has_root_dir":          false,
+	"architectures":         []string{},
+	"bitness":               int64(0),
+	"binary_format":         "",
+	"binary_type":           "",
+	"is_dynamically_linked": false,
+	"is_stripped":           false,
+	"entry_point":           int64(0),
+	"email_to":              []string{},
+	"email_cc":              []string{},
+	"email_message_id":      "",
+	"email_in_reply_to":     "",
+	"sent_at":               time.Time{},
+	"attachment_count":      int64(0),
+	"email_count":           int64(0),
+	"loc":                   int64(0),
+	"comment_loc":           int64(0),
+	"blank_loc":             int64(0),
+	"cell_count":            int64(0),
+	"code_cell_count":       int64(0),
+	"markdown_cell_count":   int64(0),
+	"kernel":                "",
+	"frontmatter":           map[string]any{},
+	"frontmatter_format":    "",
+	"tags":                  []string{},
+	"categories":            []string{},
+	"draft":                 false,
+	"date":                  time.Time{},
+}

--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"maps"
 	"path/filepath"
 	"strings"
 	"time"
@@ -179,121 +178,15 @@ func New(expr string) (*Evaluator, error) {
 }
 
 // Evaluate evaluates the expression against the given file attributes
+// Evaluate evaluates the expression against the given file attributes.
+// Uses a custom cel.Activation backed directly by *FileAttributes so
+// there's no per-call map allocation (was ~35% of walker allocations
+// per pprof before this).
 func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
-	activation := map[string]any{
-		"name":               attrs.Name,
-		"path":               attrs.Path,
-		"dir":                attrs.Dir,
-		"size":               attrs.Size,
-		"ext":                attrs.Ext,
-		"content_type":       attrs.ContentType,
-		"is_markdown":        attrs.IsMarkdown,
-		"is_json":            attrs.IsJSON,
-		"is_xml":             attrs.IsXML,
-		"is_html":            attrs.IsHTML,
-		"is_pdf":             attrs.IsPDF,
-		"is_image":           attrs.IsImage,
-		"is_text":            attrs.IsText,
-		"is_csv":             attrs.IsCSV,
-		"is_epub":            attrs.IsEPUB,
-		"is_office":          attrs.IsOffice,
-		"is_audio":           attrs.IsAudio,
-		"is_video":           attrs.IsVideo,
-		"is_archive":         attrs.IsArchive,
-		"is_binary":          attrs.IsBinary,
-		"is_email":           attrs.IsEmail,
-		"is_source":          attrs.IsSource,
-		"is_notebook":        attrs.IsNotebook,
-		"title":              "",
-		"body":               "",
-		"word_count":         int64(0),
-		"line_count":         int64(0),
-		"column_count":       int64(0),
-		"csv_columns":        []string{},
-		"language":           "",
-		"page_count":         int64(0),
-		"author":             "",
-		"root_element":       "",
-		"json_kind":          "",
-		"img_width":          int64(0),
-		"img_height":         int64(0),
-		"camera_make":        "",
-		"camera_model":       "",
-		"lens":               "",
-		"taken_at":           time.Time{},
-		"orientation":        int64(0),
-		"gps_lat":            float64(0),
-		"gps_lon":            float64(0),
-		"iso":                int64(0),
-		"focal_length":       float64(0),
-		"f_stop":             float64(0),
-		"exposure_time":      float64(0),
-		"artist":             "",
-		"album":              "",
-		"album_artist":       "",
-		"composer":           "",
-		"year":               int64(0),
-		"track":              int64(0),
-		"genre":              "",
-		"duration":           float64(0),
-		"bitrate":            int64(0),
-		"sample_rate":        int64(0),
-		"channels":           int64(0),
-		"bit_depth":          int64(0),
-		"video_codec":        "",
-		"audio_codec":        "",
-		"video_width":        int64(0),
-		"video_height":       int64(0),
-		"frame_rate":         float64(0),
-		"rotation":           int64(0),
-		"nominal_bitrate":    int64(0),
-		"color_primaries":    "",
-		"color_transfer":     "",
-		"is_hdr":             false,
-		"subtitles":          false,
-		"subtitle_languages": []string{},
-		"replaygain_track_gain": float64(0),
-		"replaygain_album_gain": float64(0),
-		"entry_count":           int64(0),
-		"uncompressed_size":     int64(0),
-		"top_level_entries":     []string{},
-		"has_root_dir":          false,
-		"architectures":         []string{},
-		"bitness":               int64(0),
-		"binary_format":         "",
-		"binary_type":           "",
-		"is_dynamically_linked": false,
-		"is_stripped":           false,
-		"entry_point":           int64(0),
-		"email_to":              []string{},
-		"email_cc":              []string{},
-		"email_message_id":      "",
-		"email_in_reply_to":     "",
-		"sent_at":               time.Time{},
-		"attachment_count":      int64(0),
-		"email_count":           int64(0),
-		"loc":                   int64(0),
-		"comment_loc":           int64(0),
-		"blank_loc":             int64(0),
-		"cell_count":            int64(0),
-		"code_cell_count":       int64(0),
-		"markdown_cell_count":   int64(0),
-		"kernel":                "",
-		"frontmatter":        map[string]any{},
-		"frontmatter_format": "",
-		"tags":               []string{},
-		"categories":         []string{},
-		"draft":              false,
-		"date":               time.Time{},
-	}
-
-	maps.Copy(activation, attrs.Extra)
-
-	out, _, err := e.prog.Eval(activation)
+	out, _, err := e.prog.Eval(&fileAttrsActivation{attrs: attrs})
 	if err != nil {
 		return false, fmt.Errorf("evaluating CEL expression: %w", err)
 	}
-
 	return out == types.True, nil
 }
 


### PR DESCRIPTION
## Summary

After #91 the walker profile flagged `Evaluate` as the biggest remaining allocator (~35% of total): every call built a 100-entry map literal from FileAttributes struct fields + Extra + zero defaults, then handed it to cel-go which wrapped it in `mapActivation`.

`cel.Activation` is an interface — we can implement it directly, backed by `*FileAttributes`, with **no map allocation at all**. Struct fields short-circuit; Extra-driven attributes come next; declared variables that the matched family didn't populate fall back to a single **static `zeroDefaults` map** (built once at init, shared safely since cel-go treats activation inputs as read-only).

### Benchmark deltas

200-file synthesized tree, Apple M4 Max, `-benchtime=2s`:

| | Post-#91 | **This PR** | Δ |
|---|---:|---:|---:|
| `BenchmarkWalk_WithAttrs` time | 3.7 ms | **3.4 ms** | −8% |
| `BenchmarkWalk_WithAttrs` mem | 3.0 MB | **1.9 MB** | −37% |
| `BenchmarkWalk_WithAttrs` allocs | 19,753 | **16,199** | −18% |

**Cumulative from pre-#90 baseline:**

| | Pre-#90 | **Now** | Δ |
|---|---:|---:|---:|
| Time | 14.3 ms | 3.4 ms | **−76%** |
| Memory | 213 MB | 1.9 MB | **−99.1%** |

### Code

The new `Evaluate` is 5 lines:

\`\`\`go
func (e *Evaluator) Evaluate(attrs *FileAttributes) (bool, error) {
    out, _, err := e.prog.Eval(&fileAttrsActivation{attrs: attrs})
    if err != nil {
        return false, fmt.Errorf("evaluating CEL expression: %w", err)
    }
    return out == types.True, nil
}
\`\`\`

The 100-line map literal moves into `activation.go`'s `zeroDefaults` table, where it's also the canonical list of declared-but-Extra-driven CEL variables — adding a new attribute now requires updating: `cel.Variable()` in `New()`, `zeroDefaults` in `activation.go`, `AttributeDoc` in `schema.go`. Net diff: `+185 / -112`.

### Post-PR profile

Evaluate is gone from the top. Remaining leaders:
- YAML frontmatter parsing: 33.44%
- `bytes.Fields` (word counting in markdown): 18.07%
- Registry.Detect (content-type detection): 15.35%

## Test plan

- [x] \`go build ./...\`
- [x] \`go test -race ./...\` — all green (existing evaluator tests cover the substitution end-to-end)
- [x] \`go vet ./...\`
- [x] \`golangci-lint run\` — 0 issues
- [x] Benchmarks confirm allocation reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)