### PR TITLE
feat(cli): config-paths subcommand prints platform config search paths

### DIFF
--- a/cmd/file-search-on/configpaths_test.go
+++ b/cmd/file-search-on/configpaths_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/projecttype"
+)
+
+// TestPrintConfigPaths_ExistenceMarker verifies the leading marker
+// (`*` for present, ` ` for absent) so users can see at a glance
+// whether their config is in the right place.
+func TestPrintConfigPaths_ExistenceMarker(t *testing.T) {
+	tmp := t.TempDir()
+	presentDir := filepath.Join(tmp, "present")
+	if err := os.MkdirAll(presentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	presentPath := filepath.Join(presentDir, "project-types.yaml")
+	if err := os.WriteFile(presentPath, []byte("project_types: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	missingPath := filepath.Join(tmp, "missing", "project-types.yaml")
+
+	entries := []projecttype.DiscoveryEntry{
+		{Scope: "user-wide", Path: presentPath},
+		{Scope: "per-project", Path: missingPath},
+	}
+
+	var buf bytes.Buffer
+	printConfigPaths(&buf, entries)
+	got := buf.String()
+
+	if !strings.Contains(got, "* user-wide") {
+		t.Errorf("present entry should have `* ` prefix; got:\n%s", got)
+	}
+	if !strings.Contains(got, "  per-project") {
+		t.Errorf("missing entry should have `  ` prefix; got:\n%s", got)
+	}
+	if !strings.Contains(got, presentPath) || !strings.Contains(got, missingPath) {
+		t.Errorf("paths missing from output:\n%s", got)
+	}
+}
+
+// TestPrintConfigPathsJSON_ShapeAndExists verifies the JSON output
+// carries scope + path + exists, suitable for piping to jq.
+func TestPrintConfigPathsJSON_ShapeAndExists(t *testing.T) {
+	tmp := t.TempDir()
+	present := filepath.Join(tmp, "x.yaml")
+	if err := os.WriteFile(present, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(tmp, "absent.yaml")
+
+	entries := []projecttype.DiscoveryEntry{
+		{Scope: "user-wide", Path: present},
+		{Scope: "per-project", Path: missing},
+	}
+
+	var buf bytes.Buffer
+	if err := printConfigPathsJSON(&buf, entries); err != nil {
+		t.Fatal(err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("got %d entries, want 2", len(decoded))
+	}
+	if decoded[0]["scope"] != "user-wide" || decoded[0]["exists"] != true {
+		t.Errorf("entry 0: scope/exists wrong: %+v", decoded[0])
+	}
+	if decoded[1]["scope"] != "per-project" || decoded[1]["exists"] != false {
+		t.Errorf("entry 1: scope/exists wrong: %+v", decoded[1])
+	}
+}
+
+// TestPrintConfigPaths_EmptyEntries surfaces a clear message when
+// DiscoveryEntries returns empty (no anchor resolvable — never
+// happens in practice but worth covering for robustness).
+func TestPrintConfigPaths_EmptyEntries(t *testing.T) {
+	var buf bytes.Buffer
+	printConfigPaths(&buf, nil)
+	got := buf.String()
+	if !strings.Contains(got, "no discovery paths") {
+		t.Errorf("empty entries should print explanatory line; got: %q", got)
+	}
+}

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -58,8 +58,9 @@ var CLI struct {
 	Stats      StatsCmd         `cmd:"" name:"stats" help:"Aggregate content-type counts and total sizes for a directory tree."`
 	Lines      LinesCmd         `cmd:"" name:"lines" help:"Print a range of lines from a single file (no walk, no CEL)."`
 	Duplicates DuplicatesCmd    `cmd:"" name:"duplicates" help:"Find groups of byte-identical files by sha256 hash."`
-	Detect     DetectProjectCmd `cmd:"" name:"detect-project" help:"Identify project type(s) (go / node / rust / …) for a directory by checking canonical indicator files."`
-	Projects   FindProjectsCmd  `cmd:"" name:"find-projects" help:"Walk a root and list every project subdirectory under it."`
+	Detect      DetectProjectCmd `cmd:"" name:"detect-project" help:"Identify project type(s) (go / node / rust / …) for a directory by checking canonical indicator files."`
+	Projects    FindProjectsCmd  `cmd:"" name:"find-projects" help:"Walk a root and list every project subdirectory under it."`
+	ConfigPaths ConfigPathsCmd   `cmd:"" name:"config-paths" help:"Print the project-type config search paths for this platform. Use to discover where to drop your user-wide config (mkdir -p \"$(file-search-on config-paths -o bare | head -1 | xargs dirname)\")."`
 	MCP        MCPCmd           `cmd:"" name:"mcp" help:"Run as a Model Context Protocol server (stdio, http, or sse)."`
 	Version    kong.VersionFlag `short:"V" help:"Print version and exit."`
 }
@@ -307,6 +308,31 @@ func (d *DuplicatesCmd) Run(ctx context.Context) error {
 			fmt.Fprintf(os.Stderr, "duplicates timed out after %s; results above may be incomplete\n", d.Timeout)
 			return &exitCodeError{code: 124, msg: "timeout"}
 		}
+	}
+	return nil
+}
+
+// ConfigPathsCmd prints the project-type config search paths for
+// the current platform. Pairs with PR #101's auto-discovery — users
+// can run this to find out where to drop a ~/Library/Application
+// Support/file-search-on/project-types.yaml (macOS) /
+// ~/.config/file-search-on/project-types.yaml (Linux) / %AppData%
+// equivalent without remembering platform conventions.
+type ConfigPathsCmd struct {
+	Output string `short:"o" name:"output" enum:"default,bare,json" default:"default" help:"Output format: default (path + scope + existence marker), bare (one path per line — shell-friendly), or json."`
+}
+
+func (c *ConfigPathsCmd) Run(_ context.Context) error {
+	entries := projecttype.DiscoveryEntries()
+	switch c.Output {
+	case "bare":
+		for _, e := range entries {
+			fpn(os.Stdout, e.Path)
+		}
+	case "json":
+		return printConfigPathsJSON(os.Stdout, entries)
+	default:
+		printConfigPaths(os.Stdout, entries)
 	}
 	return nil
 }

--- a/cmd/file-search-on/output.go
+++ b/cmd/file-search-on/output.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"text/template"
 
@@ -387,6 +388,39 @@ func printDuplicatesJSON(w io.Writer, d *search.Duplicates) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(d)
+}
+
+// printConfigPaths renders the project-type config search paths as
+// a human-readable table. Each entry shows existence (`*` for
+// present, ` ` for missing) so users can see whether their config
+// is in the right place at a glance.
+func printConfigPaths(w io.Writer, entries []projecttype.DiscoveryEntry) {
+	for _, e := range entries {
+		marker := " "
+		if _, err := os.Stat(e.Path); err == nil {
+			marker = "*"
+		}
+		fp(w, "%s %-12s  %s\n", marker, e.Scope, e.Path)
+	}
+	if len(entries) == 0 {
+		fp(w, "(no discovery paths resolvable on this platform)\n")
+	}
+}
+
+func printConfigPathsJSON(w io.Writer, entries []projecttype.DiscoveryEntry) error {
+	type entryJSON struct {
+		Scope  string `json:"scope"`
+		Path   string `json:"path"`
+		Exists bool   `json:"exists"`
+	}
+	out := make([]entryJSON, len(entries))
+	for i, e := range entries {
+		_, err := os.Stat(e.Path)
+		out[i] = entryJSON{Scope: e.Scope, Path: e.Path, Exists: err == nil}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
 }
 
 // printDetectProject renders one directory's project-type matches as

--- a/examples/projects.md
+++ b/examples/projects.md
@@ -130,6 +130,16 @@ Two locations are searched, in this load order (later layers register on top of 
 
 Both are optional; missing files are silently skipped. Pass `--no-config-search` to disable auto-discovery for hermetic invocations (tests, CI).
 
+**Find your platform's paths** without remembering conventions:
+
+```sh
+$ file-search-on config-paths
+* user-wide     /Users/me/Library/Application Support/file-search-on/project-types.yaml
+  per-project   /Users/me/Code/foo/.file-search-on/project-types.yaml
+```
+
+`*` marks paths whose file exists; ` ` marks missing. `-o bare` prints paths only (shell-friendly: `mkdir -p "$(file-search-on config-paths -o bare | head -1 | xargs dirname)"`); `-o json` for tooling.
+
 ### CEL vocabulary
 
 CEL expressions evaluate against two list-of-string variables: `files` (basenames of files in the inspected dir) and `subdirs` (basenames of immediate subdirectories).

--- a/internal/projecttype/discovery.go
+++ b/internal/projecttype/discovery.go
@@ -27,25 +27,47 @@ const ConfigDirName = "file-search-on"
 // directory only — git-style ancestor walk-up is a follow-up.
 const PerProjectDirName = ".file-search-on"
 
-// DiscoveryPaths returns the project-type config paths to search,
-// in load order (later layers register on top of earlier ones).
-//
-//  1. User-wide: os.UserConfigDir() / file-search-on / project-types.yaml
-//  2. Per-project (CWD only): ./.file-search-on/project-types.yaml
-//
-// Both are optional. Missing files are skipped silently by
-// LoadDiscovered. Paths whose anchor can't be resolved
-// (UserConfigDir unset, Getwd fails) are omitted entirely so the
-// caller never sees an empty / suspicious entry.
-func DiscoveryPaths() []string {
-	var paths []string
+// DiscoveryEntry annotates a single discovery path with its scope
+// ("user-wide" or "per-project") so consumers can label / order
+// without re-deriving the meaning from the path itself.
+type DiscoveryEntry struct {
+	Scope string // "user-wide" | "per-project"
+	Path  string
+}
+
+// DiscoveryEntries returns the project-type config search locations
+// in load order (later layers register on top of earlier), each
+// annotated with its scope. Paths whose anchor can't be resolved
+// (UserConfigDir unset, Getwd fails) are omitted so the caller
+// never sees an empty / suspicious entry.
+func DiscoveryEntries() []DiscoveryEntry {
+	var out []DiscoveryEntry
 	if cfgDir, err := os.UserConfigDir(); err == nil {
-		paths = append(paths, filepath.Join(cfgDir, ConfigDirName, ConfigFileName))
+		out = append(out, DiscoveryEntry{
+			Scope: "user-wide",
+			Path:  filepath.Join(cfgDir, ConfigDirName, ConfigFileName),
+		})
 	}
 	if cwd, err := os.Getwd(); err == nil {
-		paths = append(paths, filepath.Join(cwd, PerProjectDirName, ConfigFileName))
+		out = append(out, DiscoveryEntry{
+			Scope: "per-project",
+			Path:  filepath.Join(cwd, PerProjectDirName, ConfigFileName),
+		})
 	}
-	return paths
+	return out
+}
+
+// DiscoveryPaths is the legacy plain-paths shortcut over
+// DiscoveryEntries — kept because LoadDiscovered (and external
+// callers) only need the path strings. New code that wants scope
+// labels should call DiscoveryEntries directly.
+func DiscoveryPaths() []string {
+	entries := DiscoveryEntries()
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Path
+	}
+	return out
 }
 
 // LoadDiscovered loads every project-type config found via


### PR DESCRIPTION
Closes #102.

## Summary

Pairs with the auto-discovery layer from #101 — users can now ask the tool where to drop their project-type config without remembering platform conventions (XDG vs `~/Library/Application Support` vs `%AppData%`).

```sh
$ file-search-on config-paths
* user-wide     /Users/me/Library/Application Support/file-search-on/project-types.yaml
  per-project   /Users/me/Code/foo/.file-search-on/project-types.yaml
```

`*` marks paths whose file exists; ` ` marks missing — handy for "is my config actually in the right place" sanity checks.

## Output modes

| Flag | Output |
|---|---|
| (default) | Scope label + existence marker + path, human-readable |
| `-o bare` | Path only, one per line — shell-friendly (`mkdir -p "$(file-search-on config-paths -o bare \| head -1 \| xargs dirname)"`) |
| `-o json` | `[{scope, path, exists}]` for tooling |

## Implementation

- Adds `projecttype.DiscoveryEntries()` returning `{Scope, Path}` pairs. Keeps `DiscoveryPaths()` as the plain-path shortcut over `DiscoveryEntries()` so `LoadDiscovered` (and external callers) don't break.
- New `ConfigPathsCmd` struct in `cmd/file-search-on/main.go` + `Run` method.
- `printConfigPaths` / `printConfigPathsJSON` in `output.go`.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` — green, including new `configpaths_test.go`:
  - `TestPrintConfigPaths_ExistenceMarker` — `*` for present, ` ` for absent
  - `TestPrintConfigPathsJSON_ShapeAndExists` — scope/path/exists correct in JSON
  - `TestPrintConfigPaths_EmptyEntries` — explanatory line when no paths resolvable
- [x] `go vet ./...`
- [x] `golangci-lint run` — 0 issues
- [x] End-to-end CLI smoke: all three output modes work; existence marker fires when file is created

Diff: **+202 / -17 LOC** across 5 files (1 new test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
