### PR TITLE
chore: open-source-prep — community files, issue/PR templates, dependabot, hygiene

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[*.{yaml,yml,json,toml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Normalise line endings on commit; check out as-is so test fixtures
+# (which intentionally include CRLF / mixed endings) round-trip cleanly.
+* text=auto eol=lf
+
+# Always LF, regardless of platform.
+*.go         text eol=lf
+*.md         text eol=lf
+*.yaml       text eol=lf
+*.yml        text eol=lf
+*.sh         text eol=lf
+*.toml       text eol=lf
+Dockerfile   text eol=lf
+
+# Test fixtures: keep bytes exactly as committed (some intentionally
+# carry CRLF, BOM, embedded NULs, or specific byte patterns). The walker
+# parses them; git shouldn't massage them.
+internal/content/testdata/** binary
+internal/index/testdata/**   binary
+
+# Generated artefacts shouldn't show up in PR diffs by default.
+go.sum       linguist-generated=true
+
+# Mark documentation files for GitHub Linguist.
+*.md         linguist-documentation=true
+CLAUDE.md    linguist-documentation=true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Something isn't behaving as expected
+title: ''
+labels: bug
+---
+
+## What you expected to happen
+
+<!-- One sentence; the behaviour you were trying to get. -->
+
+## What actually happened
+
+<!-- One sentence; what file-search-on did instead. Stack traces or error
+text in a code fence here help a lot. -->
+
+## Reproducer
+
+<!-- A minimal command + the file shapes involved, ideally something we can
+run without your filesystem. -->
+
+```sh
+file-search-on '...' -d /path/to/example
+```
+
+If the issue is with a specific file format, attach a minimal sample (or describe how to synthesise one).
+
+## Version + platform
+
+- `file-search-on --version`:
+- OS / architecture:
+- Install method (Homebrew / `go install` / Docker / pre-built archive):
+
+## Anything else
+
+<!-- Workarounds tried, related issues, screenshots if it's about output. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/richardwooding/file-search-on/security/policy
+    about: Please report security issues privately, not as a public GitHub issue. See SECURITY.md for details.
+  - name: Question or usage help
+    url: https://github.com/richardwooding/file-search-on/discussions
+    about: For questions about CEL syntax, attribute coverage, MCP integration, or recipes — Discussions is the better forum than Issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature request
+about: Suggest a new content type, CEL function, MCP tool, or behaviour
+title: ''
+labels: enhancement
+---
+
+## Use case
+
+<!-- What are you trying to accomplish? A search query you want to write,
+a workflow you want to automate, a metadata field you want to filter on.
+The "why" matters more than the "what" — multiple shapes might work. -->
+
+## Concrete shape you have in mind
+
+<!-- Sketch what the CLI / MCP / CEL surface would look like:
+
+  file-search-on '<expression>' -d /path
+
+or
+
+  {"name": "mcp__file-search-on__<tool>", "arguments": {...}}
+
+Doesn't have to be final — we'll iterate. -->
+
+## Alternatives considered
+
+<!-- Anything you tried first (existing flags, CEL combinations, external
+tools) that didn't quite work. Helps us decide whether this is a missing
+primitive or just a recipe waiting to be documented. -->
+
+## Anything else
+
+<!-- Reference issues / PRs / external standards (e.g. RFC, file-format
+spec) that would help us understand the request. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- One paragraph: what changes and why. The "why" is the part future
+readers will care about — link issues if relevant ("closes #123"). -->
+
+## Test plan
+
+<!-- Tick the boxes that apply. Add custom checks if the change has
+something unusual (benchmark, new fuzz target, MCP smoke, …). -->
+
+- [ ] `go build ./...`
+- [ ] `go test -race ./...`
+- [ ] `go vet ./...`
+- [ ] `golangci-lint run`
+- [ ] `go fix -diff ./...` (empty)
+- [ ] If the change touches a parser: relevant fuzz target re-run (`go test -fuzz=Fuzz<Name> -fuzztime=30s ./<pkg>`)
+- [ ] If the change adds a CEL attribute: `go test ./internal/celexpr/` (README parity guard)
+- [ ] If the change is user-facing: README / examples / CLAUDE.md updated
+
+## Notes for the reviewer
+
+<!-- Optional: where to look first, design choices you flagged for
+discussion, what's intentionally out of scope. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Go module dependencies.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Africa/Johannesburg
+    labels:
+      - dependencies
+      - go
+    open-pull-requests-limit: 5
+    groups:
+      # Batch minor/patch bumps to cut PR noise; security updates still
+      # come as separate, prioritised PRs by default.
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used in .github/workflows.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Africa/Johannesburg
+    labels:
+      - dependencies
+      - github-actions
+    open-pull-requests-limit: 3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for considering a contribution! The project is small enough to read in an afternoon and welcoming to first-time contributors. This document covers how to set up the project, the conventions for branches and commits, and how PRs get reviewed.
 
-By participating, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).
+Be respectful, assume good intent, and help others learn. Disagreements about technical direction are healthy — disrespect isn't.
 
 ## Reporting bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing to file-search-on
+
+Thanks for considering a contribution! The project is small enough to read in an afternoon and welcoming to first-time contributors. This document covers how to set up the project, the conventions for branches and commits, and how PRs get reviewed.
+
+By participating, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Reporting bugs
+
+Open a [GitHub issue](https://github.com/richardwooding/file-search-on/issues) using the bug report template. Please include:
+
+- What you expected to happen.
+- What actually happened.
+- The version (`file-search-on --version`).
+- A minimal repro if possible.
+
+For **security issues**, do **not** open a public issue. See [SECURITY.md](SECURITY.md) for the private reporting channel.
+
+## Suggesting features
+
+Open a feature-request issue describing the use case before writing code — that's the cheapest way to avoid two-week PRs that turn out to be the wrong shape. The maintainers are happy to discuss direction in the issue before any code is written.
+
+Easy entry points: open issues filtered by [`good first issue`](https://github.com/richardwooding/file-search-on/labels/good%20first%20issue), [`help wanted`](https://github.com/richardwooding/file-search-on/labels/help%20wanted), or [`enhancement`](https://github.com/richardwooding/file-search-on/labels/enhancement).
+
+## Development setup
+
+Requires Go 1.26.2 or newer.
+
+```sh
+git clone https://github.com/richardwooding/file-search-on.git
+cd file-search-on
+go build ./...
+go test -race ./...
+```
+
+That's the whole setup — no environment variables, no fixtures to download, no services to run locally. Tests are fully hermetic (the content-type test suite uses on-disk fixtures under `internal/content/testdata/fixtures/` that are committed to the repo).
+
+## Architecture map
+
+[CLAUDE.md](./CLAUDE.md) is the canonical architecture map — five internal packages, the CEL evaluator's data shape, the walker's cancellation contract, the MCP server's tool surface, the release pipeline, and where every gotcha is documented. Written for both human and LLM contributors; either audience should find it readable.
+
+For repetitive contributions (adding a content type, extending the CEL schema, adding an MCP tool, cutting a release), the repo ships step-by-step templates under [`.claude/skills/`](./.claude/skills/). Useful whether you're working solo or pairing with an LLM agent.
+
+## Branching and commits
+
+- Work off **`main`**. Feature branches use `<type>/<short-name>` — e.g. `feat/yaml-content-type`, `fix/exif-orientation`, `perf/markdown-scanner`, `docs/readme-cleanup`.
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`, `perf:`. First line is a short summary scoped if relevant (e.g. `feat(content): add YAML detection`); the body (optional) explains *why*, not *what*.
+- Sign-off (`git commit -s`) is appreciated but not required.
+
+## Pull requests
+
+1. Open a draft PR early if you'd like feedback on direction.
+2. Make sure the full CI matrix passes locally before marking ready for review:
+   ```sh
+   go build ./...
+   go test -race ./...
+   go vet ./...
+   golangci-lint run
+   go fix -diff ./...   # CI enforces an empty diff
+   ```
+3. CI must be green: build, tests, lint, modernizer-diff.
+4. PRs are squash-merged unless the change history is genuinely worth preserving.
+
+PRs should:
+
+- Include tests for new behaviour. The race detector is always on; new code that's not covered is rare and intentional.
+- Update docs if user-facing behaviour changed. The `examples/*.md` tree is the home for per-feature recipes; the README points at it.
+- Update the README schema-coverage test stays green — every attribute and CEL function declared in `celexpr.Schema()` must appear backticked somewhere in `README.md`. `go test ./internal/celexpr/` is the guard.
+
+## Code style
+
+```sh
+go fmt ./...
+golangci-lint run
+go fix -diff ./...
+```
+
+Run before pushing. CI will fail otherwise.
+
+## Fuzz testing
+
+High-risk parsers (frontmatter, MP3, MKV, MP4, CEL compile, gob decoder) have native [Go fuzz targets](https://go.dev/doc/security/fuzz). The seed corpus runs on every CI build; a scheduled workflow (`.github/workflows/fuzz.yml`) runs each target for 5 minutes nightly to discover new failures. Crashes get committed back to `testdata/fuzz/<FuzzName>/` as regression coverage.
+
+Run locally:
+
+```sh
+go test -run=FuzzSplitFrontmatter ./internal/content/                # seed corpus only (fast)
+go test -fuzz=FuzzSplitFrontmatter -fuzztime=30s ./internal/content/ # mutate for 30 seconds
+```
+
+If you add a new parser, please add a matching fuzz target — see [CLAUDE.md § Fuzz testing](./CLAUDE.md#fuzz-testing) for the pattern.
+
+## License of contributions
+
+By submitting a PR, you agree your contribution is licensed under the same license as the project — see [LICENSE](LICENSE) (MIT).

--- a/README.md
+++ b/README.md
@@ -362,20 +362,20 @@ Built on [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcont
 
 ## Contributing
 
-The project is small enough to read in an afternoon and welcoming to first-time contributors. A few places to start:
+The project is small enough to read in an afternoon and welcoming to first-time contributors. See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, branch/commit conventions, the local CI matrix, and PR expectations. A few quick entry points:
 
 - Open issues filtered by [`good first issue`](https://github.com/richardwooding/file-search-on/labels/good%20first%20issue), [`help wanted`](https://github.com/richardwooding/file-search-on/labels/help%20wanted), [`enhancement`](https://github.com/richardwooding/file-search-on/labels/enhancement).
-- New content type or CEL function? [CLAUDE.md](./CLAUDE.md) has step-by-step recipes for both — search the file for "Adding a new content type" and "Adding a CEL function".
-- Bug reports and feature requests are appreciated whether or not you have a fix in mind. No PR template gating; describe what you want and we'll figure it out together.
+- New content type or CEL function? [CLAUDE.md](./CLAUDE.md) has step-by-step recipes — search for "Adding a new content type" and "Adding a CEL function".
+- Security issue? Please don't open a public issue — see [SECURITY.md](./SECURITY.md) for the private reporting channel.
 
-### Local development
+Local CI matrix:
 
 ```sh
 go build ./...
 go test -race ./...
 go vet ./...
 golangci-lint run
-go fix -diff ./...   # preview Go 1.26 modernizer suggestions (CI enforces empty diff)
+go fix -diff ./...   # CI enforces empty diff
 ```
 
 That's the whole CI matrix locally. Tests run in under 10 seconds; the race detector is on by default.
@@ -384,18 +384,7 @@ That's the whole CI matrix locally. Tests run in under 10 seconds; the race dete
 
 [CLAUDE.md](./CLAUDE.md) is the canonical architecture map — five internal packages, the CEL evaluator's data shape, the walker's cancellation contract, the MCP server's tool surface, the release pipeline, and where every gotcha is documented. Written for both human and LLM contributors; either audience should find it readable.
 
-### Skills (templated recipes)
-
-The repo ships with [`.claude/skills/`](./.claude/skills/) — step-by-step templates for the repetitive contributions: adding a content type, extending the CEL schema, adding an MCP tool, cutting a release. Useful whether you're working solo or pairing with an LLM agent.
-
-### Fuzz testing
-
-High-risk parsers (frontmatter, MP3, MKV, MP4, CEL compile, gob decoder) have native [Go fuzz targets](https://go.dev/doc/security/fuzz). Seed corpora run on every CI build; a scheduled workflow runs each target for 5 minutes nightly to find new failures. Crashes get committed back to `testdata/fuzz/` as regression coverage. Run locally:
-
-```sh
-go test -run=FuzzSplitFrontmatter ./internal/content/                # seed corpus only (fast)
-go test -fuzz=FuzzSplitFrontmatter -fuzztime=30s ./internal/content/ # mutate for 30 seconds
-```
+The repo also ships with [`.claude/skills/`](./.claude/skills/) — step-by-step templates for the repetitive contributions: adding a content type, extending the CEL schema, adding an MCP tool, cutting a release. Useful whether you're working solo or pairing with an LLM agent.
 
 ### Releases
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,18 +2,20 @@
 
 ## Supported versions
 
-Only the latest minor release receives security fixes. The project is pre-1.0; backporting fixes to older minor versions isn't sustainable for a small team. If you need a fix on an older version, please pin to that version and apply the patch locally, or upgrade.
+Only the latest minor release receives security fixes. The project is pre-1.0; backporting fixes to older minor versions
+isn't sustainable for a small team. If you need a fix on an older version, please pin to that version and apply the
+patch locally, or upgrade.
 
-| Version | Supported |
-|---|---|
-| Latest `v0.x.y` | ✅ |
-| Older `v0.x.y` | ❌ |
+| Version          | Supported |
+|------------------|-----------|
+| Latest `v0.26.0` | ✅        |
+| Older `v0.25.0`  | ❌        |
 
 ## Reporting a vulnerability
 
 **Please do NOT open a public GitHub issue for security problems.**
 
-Email <richard.wooding@spandigital.com> with:
+Email <richard.wooding@gmail.com> with:
 
 - A description of the vulnerability.
 - Steps to reproduce, or a proof-of-concept input.
@@ -21,7 +23,8 @@ Email <richard.wooding@spandigital.com> with:
 - The platform (OS, architecture).
 - Whether you've shared this with anyone else.
 
-You should expect an acknowledgement within **3 working days** and, where the report is valid, a patch + coordinated disclosure within **30 days**. Larger windows happen — if I'm slow, please email again; it's not on purpose.
+You should expect an acknowledgement within **3 working days** and, where the report is valid, a patch + coordinated
+disclosure within **30 days**. Larger windows happen — if I'm slow, please email again; it's not on purpose.
 
 You'll be credited in the release notes unless you ask not to be.
 
@@ -29,14 +32,17 @@ You'll be credited in the release notes unless you ask not to be.
 
 In scope:
 
-- Crashes / hangs / OOMs in parsers (markdown frontmatter, MP3, MP4, MKV, OGG, FLAC, image EXIF, archives, binaries, email, gob index decoder) given adversarial input — the fuzz suite covers the known surface; new findings are welcome.
+- Crashes / hangs / OOMs in parsers (markdown frontmatter, MP3, MP4, MKV, OGG, FLAC, image EXIF, archives, binaries,
+  email, gob index decoder) given adversarial input — the fuzz suite covers the known surface; new findings are welcome.
 - Crashes / hangs in the CEL evaluator given crafted expressions.
 - Crashes / hangs in the MCP server given crafted protocol input.
 - Path traversal, directory escape, or other filesystem boundary violations in the walker.
-- Memory exhaustion via crafted inputs (e.g. malformed archive headers, gob length prefixes, MP4 box sizes — see [PR #100](https://github.com/richardwooding/file-search-on/pull/100) for the kind of issues we want reported).
+- Memory exhaustion via crafted inputs (e.g. malformed archive headers, gob length prefixes, MP4 box sizes —
+  see [PR #100](https://github.com/richardwooding/file-search-on/pull/100) for the kind of issues we want reported).
 
 Out of scope:
 
 - Vulnerabilities in dependencies — please report upstream (Dependabot tracks these for us).
 - Denial-of-service via legitimately huge filesystems (we provide `--timeout` and `--workers` flags; tune them).
-- Social engineering, physical access, or supply-chain attacks on the build pipeline (those go to GitHub Security directly).
+- Social engineering, physical access, or supply-chain attacks on the build pipeline (those go to GitHub Security
+  directly).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest minor release receives security fixes. The project is pre-1.0; backporting fixes to older minor versions isn't sustainable for a small team. If you need a fix on an older version, please pin to that version and apply the patch locally, or upgrade.
+
+| Version | Supported |
+|---|---|
+| Latest `v0.x.y` | ✅ |
+| Older `v0.x.y` | ❌ |
+
+## Reporting a vulnerability
+
+**Please do NOT open a public GitHub issue for security problems.**
+
+Email <richard.wooding@spandigital.com> with:
+
+- A description of the vulnerability.
+- Steps to reproduce, or a proof-of-concept input.
+- The version (`file-search-on --version`).
+- The platform (OS, architecture).
+- Whether you've shared this with anyone else.
+
+You should expect an acknowledgement within **3 working days** and, where the report is valid, a patch + coordinated disclosure within **30 days**. Larger windows happen — if I'm slow, please email again; it's not on purpose.
+
+You'll be credited in the release notes unless you ask not to be.
+
+## Scope
+
+In scope:
+
+- Crashes / hangs / OOMs in parsers (markdown frontmatter, MP3, MP4, MKV, OGG, FLAC, image EXIF, archives, binaries, email, gob index decoder) given adversarial input — the fuzz suite covers the known surface; new findings are welcome.
+- Crashes / hangs in the CEL evaluator given crafted expressions.
+- Crashes / hangs in the MCP server given crafted protocol input.
+- Path traversal, directory escape, or other filesystem boundary violations in the walker.
+- Memory exhaustion via crafted inputs (e.g. malformed archive headers, gob length prefixes, MP4 box sizes — see [PR #100](https://github.com/richardwooding/file-search-on/pull/100) for the kind of issues we want reported).
+
+Out of scope:
+
+- Vulnerabilities in dependencies — please report upstream (Dependabot tracks these for us).
+- Denial-of-service via legitimately huge filesystems (we provide `--timeout` and `--workers` flags; tune them).
+- Social engineering, physical access, or supply-chain attacks on the build pipeline (those go to GitHub Security directly).


### PR DESCRIPTION
## Summary

Audit run via `.claude/skills/open-source-prep` took the readiness punch-list from **10 missing → 3 missing**. The 3 remaining (`CODE_OF_CONDUCT.md`, `CHANGELOG.md`, `FUNDING.yml`) were explicitly skipped per the design discussion (CoC: not now; CHANGELOG: GitHub Releases is the source of truth; FUNDING: not now).

## Files added

| Path | Purpose |
|---|---|
| `CONTRIBUTING.md` | First-time contributor on-ramp: setup, branch / commit conventions (Conventional Commits), local CI matrix, PR expectations, fuzz workflow, pointers to `CLAUDE.md` + `.claude/skills/`. |
| `SECURITY.md` | Private reporting channel (`richard.wooding@spandigital.com`), 3-day ack / 30-day patch SLA, scope (in: parser crashes / CEL crashes / path traversal / memory exhaustion; out: dependency CVEs, legitimate "huge filesystem" DoS, supply chain). |
| `.github/ISSUE_TEMPLATE/bug_report.md` | Structured bug template — expected/actual, reproducer, version/platform. |
| `.github/ISSUE_TEMPLATE/feature_request.md` | Structured feature template — use case, concrete shape, alternatives considered. |
| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank issues; surfaces SECURITY policy + Discussions as contact links. |
| `.github/PULL_REQUEST_TEMPLATE.md` | Test-plan checklist matching the local CI matrix + parser-specific fuzz re-run + README schema-coverage parity check. |
| `.github/dependabot.yml` | Weekly `gomod` + `github-actions` updates, Monday 06:00 SAST, minor/patch grouped to cut PR noise. |
| `.editorconfig` | Go tabs, YAML/JSON/TOML 2 spaces, LF endings, trailing-whitespace trim (markdown exempt). |
| `.gitattributes` | `eol=lf` normalisation, `testdata/` marked binary so fuzz seeds and content fixtures round-trip without git massaging, `go.sum` marked generated, `*.md` flagged for Linguist. |

## Files updated

- `CONTRIBUTING.md` — dropped Code-of-Conduct reference (we're skipping that file); replaced with a one-liner about respect / good intent.
- `README.md` — `## Contributing` section trimmed to a pointer at `CONTRIBUTING.md` + `SECURITY.md` so the new files become the canonical doc rather than competing copies.

## Repo metadata (already applied)

Topics set via `gh repo edit`: `go`, `cli`, `file-search`, `content-detection`, `mcp`, `mcp-server`, `cel`.

## Test plan

- [x] `python3 .claude/skills/open-source-prep/scripts/audit.py` — 10 → 3 missing (the 3 remaining are intentionally deferred).
- [x] `go build ./...`
- [x] `go test -race ./...` — all packages green.
- [x] `go vet ./...`
- [x] `golangci-lint run` — 0 issues.
- [x] README schema-coverage parity (`schema_docs_test.go`) — green.

Diff: **+325 / -18 LOC** across 12 files (9 new community/hygiene files + CONTRIBUTING.md + README.md + this PR template's prior commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
