### PR TITLE
chore(deps): migrate to imagemeta v1.0.0 nested IFD layout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.2
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
-	github.com/evanoberholster/imagemeta v0.3.1
+	github.com/evanoberholster/imagemeta v1.0.0
 	github.com/google/cel-go v0.28.1
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/modelcontextprotocol/go-sdk v1.6.0
@@ -22,12 +22,12 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
-	github.com/philhofer/fwd v1.1.2 // indirect
+	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rs/zerolog v1.29.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
-	github.com/tinylib/msgp v1.1.8 // indirect
+	github.com/tinylib/msgp v1.6.3 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8 h1:OtSeLS5y0Uy01jaKK4m
 github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8/go.mod h1:apkPC/CR3s48O2D7Y++n1XWEpgPNNCjXYga3PPbJe2E=
 github.com/evanoberholster/imagemeta v0.3.1 h1:E4GUjXcvlVMjP9joN25+bBNf3Al3MTTfMqCrDOCW+LE=
 github.com/evanoberholster/imagemeta v0.3.1/go.mod h1:V0vtDJmjTqvwAYO8r+u33NRVIMXQb0qSqEfImoKEiXM=
+github.com/evanoberholster/imagemeta v1.0.0 h1:FlSihlsjkWIoS83wmgPOP3CbAxlRpxM8jQGZgLu+MWQ=
+github.com/evanoberholster/imagemeta v1.0.0/go.mod h1:2ITZJjD1ygzWIhepvn8coRvpaFcnDNk3E6hx6v7z8DU=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
@@ -42,6 +44,8 @@ github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7ol
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
 github.com/philhofer/fwd v1.1.2/go.mod h1:qkPdfjR2SIEbspLqpe1tO4n5yICnr2DY7mqEx2tUTP0=
+github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
+github.com/philhofer/fwd v1.2.0/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -59,8 +63,11 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
+github.com/tinylib/msgp v1.6.3 h1:bCSxiTz386UTgyT1i0MSCvdbWjVW+8sG3PjkGsZQt4s=
+github.com/tinylib/msgp v1.6.3/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/content/imagetype.go
+++ b/internal/content/imagetype.go
@@ -10,7 +10,7 @@ import (
 	"io/fs"
 
 	"github.com/evanoberholster/imagemeta"
-	"github.com/evanoberholster/imagemeta/exif2"
+	"github.com/evanoberholster/imagemeta/meta/exif"
 )
 
 func init() {
@@ -87,34 +87,33 @@ func supportsEXIF(name string) bool {
 
 // populateEXIF copies the curated set of EXIF fields onto attrs. Zero-value
 // fields are left out so callers see "absent" rather than "unset" defaults.
-func populateEXIF(attrs Attributes, e exif2.Exif) {
-	if e.ImageWidth > 0 {
-		attrs["img_width"] = int64(e.ImageWidth)
+//
+// imagemeta v1.0.0 splits the flat exif2.Exif into nested IFD0 / ExifIFD / GPS
+// sub-structs (see meta/exif/model.go); the field mapping below preserves the
+// v0.3.1 attribute set against the new shape.
+func populateEXIF(attrs Attributes, e exif.Exif) {
+	if e.IFD0.ImageWidth > 0 {
+		attrs["img_width"] = int64(e.IFD0.ImageWidth)
 	}
-	if e.ImageHeight > 0 {
-		attrs["img_height"] = int64(e.ImageHeight)
+	if e.IFD0.ImageHeight > 0 {
+		attrs["img_height"] = int64(e.IFD0.ImageHeight)
 	}
-	if e.Make != "" {
-		attrs["camera_make"] = e.Make
+	if e.IFD0.Make != "" {
+		attrs["camera_make"] = e.IFD0.Make
 	}
-	if e.Model != "" {
-		attrs["camera_model"] = e.Model
+	if e.IFD0.Model != "" {
+		attrs["camera_model"] = e.IFD0.Model
 	}
-	if e.LensModel != "" {
-		attrs["lens"] = e.LensModel
+	if e.ExifIFD.LensModel != "" {
+		attrs["lens"] = e.ExifIFD.LensModel
 	}
-	// Prefer DateTimeOriginal (capture time); fall back to CreateDate, then
-	// ModifyDate. Real photos usually set all three identically; scanned or
-	// edited images may carry only ModifyDate.
-	if t := e.DateTimeOriginal(); !t.IsZero() {
+	// SelectedDate prefers DateTimeOriginal, then CreateDate, then ModifyDate
+	// — same precedence as the v0.3.1 manual fallback.
+	if t := e.SelectedDate(); !t.IsZero() {
 		attrs["taken_at"] = t
-	} else if t := e.CreateDate(); !t.IsZero() {
-		attrs["taken_at"] = t
-	} else if t := e.ModifyDate(); !t.IsZero() {
-		attrs["taken_at"] = t
 	}
-	if e.Orientation > 0 {
-		attrs["orientation"] = int64(e.Orientation)
+	if e.IFD0.Orientation > 0 {
+		attrs["orientation"] = int64(e.IFD0.Orientation)
 	}
 	if lat := e.GPS.Latitude(); lat != 0 {
 		attrs["gps_lat"] = lat
@@ -122,18 +121,16 @@ func populateEXIF(attrs Attributes, e exif2.Exif) {
 	if lon := e.GPS.Longitude(); lon != 0 {
 		attrs["gps_lon"] = lon
 	}
-	if e.ISOSpeed > 0 {
-		attrs["iso"] = int64(e.ISOSpeed)
-	} else if e.ISO > 0 {
-		attrs["iso"] = int64(e.ISO)
+	if e.ExifIFD.ISOSpeedRatings > 0 {
+		attrs["iso"] = int64(e.ExifIFD.ISOSpeedRatings)
 	}
-	if e.FocalLength > 0 {
-		attrs["focal_length"] = float64(e.FocalLength)
+	if e.ExifIFD.FocalLength > 0 {
+		attrs["focal_length"] = float64(e.ExifIFD.FocalLength)
 	}
-	if e.FNumber > 0 {
-		attrs["f_stop"] = float64(e.FNumber)
+	if e.ExifIFD.FNumber > 0 {
+		attrs["f_stop"] = float64(e.ExifIFD.FNumber)
 	}
-	if e.ExposureTime > 0 {
-		attrs["exposure_time"] = float64(e.ExposureTime)
+	if e.ExifIFD.ExposureTime > 0 {
+		attrs["exposure_time"] = float64(e.ExifIFD.ExposureTime)
 	}
 }


### PR DESCRIPTION
## Summary

- Update `github.com/evanoberholster/imagemeta` from v0.3.1 → v1.0.0.
- Repoint `internal/content/imagetype.go`'s `populateEXIF` from the removed flat `exif2.Exif` onto the new nested `exif.Exif{GPS, IFD0, ExifIFD}` shape introduced in v1.0.0 (`meta/exif/model.go`).
- Use `Exif.SelectedDate()` in place of the manual `DateTimeOriginal → CreateDate → ModifyDate` fallback chain — same precedence, one call.

The CEL-visible attribute set is unchanged. Verified against `internal/content/testdata/exif-light.jpg`: `img_width`/`img_height`/`taken_at` still extracted, TIFF `orientation` still extracted.

Closes #110. Supersedes #109 (Dependabot bare version-bump PR, closed because the API restructure can't be solved by version pinning alone).

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` (0 issues)
- [x] `go fix -diff ./...` (empty)
- [x] Manual smoke: `go run ./cmd/file-search-on 'is_image' -d ./internal/content/testdata -o json` — EXIF round-trips match v0.3.1 output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)