### PR TITLE
fix(index): cap concurrent gob.Decode goroutines to prevent fuzz-OOM

### DIFF
--- a/internal/index/codec.go
+++ b/internal/index/codec.go
@@ -3,6 +3,7 @@ package index
 import (
 	"bytes"
 	"encoding/gob"
+	"runtime"
 	"time"
 )
 
@@ -11,10 +12,14 @@ import (
 // historically prone to crafted-input allocation attacks (CVE-2022-30631
 // and friends). Legitimate Entry decodes complete in microseconds —
 // 500 ms is generous and tight enough to be a useful DoS guard for
-// corrupted or hand-edited index files. A goroutine that exceeds the
-// budget keeps running until gob.Decode returns (the input is bounded
-// to maxEntryBytes so it can't allocate unboundedly); the caller's
-// request unblocks immediately.
+// corrupted or hand-edited index files.
+//
+// Enforcement is via a goroutine + select-on-time.After: gob.Decode
+// runs all its CPU work between Read calls, so a deadline-aware Reader
+// can't terminate it externally. We accept that the goroutine keeps
+// running until gob.Decode actually returns; the caller unblocks at
+// the deadline. concurrentDecodeLimit caps how many such zombies can
+// exist at once so a fuzz / DoS workload can't OOM the process.
 const decodeTimeout = 500 * time.Millisecond
 
 // errDecodeTimeout signals that gob.Decode exceeded decodeTimeout —
@@ -23,6 +28,30 @@ const decodeTimeout = 500 * time.Millisecond
 // decode error (Stats.Errors increment, drop the cached entry, treat
 // as cache miss).
 var errDecodeTimeout = encodingError("gob decode exceeded budget")
+
+// errDecodeOverloaded is returned when too many decodeEntry calls are
+// already in-flight with leaked gob.Decode goroutines. The caller
+// treats it as a cache miss — the file will simply be re-extracted.
+// Defends against the fuzz / DoS scenario where many adversarial
+// inputs in quick succession would otherwise spawn unbounded zombie
+// goroutines and OOM the process.
+var errDecodeOverloaded = encodingError("too many concurrent decodes in flight")
+
+// concurrentDecodeLimit bounds in-flight gob.Decode goroutines. Each
+// goroutine that exceeds decodeTimeout keeps running (gob can't be
+// cancelled mid-call) until its own decode finishes. With this cap,
+// the worst-case memory footprint is concurrentDecodeLimit *
+// maxEntryBytes plus gob's internal state per call — a few hundred
+// KiB. Without the cap, the fuzzer accumulates zombies and OOMs the
+// runner. NumCPU*2 leaves real cache lookups headroom even when half
+// the slots are zombies.
+var concurrentDecodeLimit = max(8, runtime.NumCPU()*2)
+
+// decodeSem is a counting semaphore via buffered channel — sends
+// "acquire", receives "release". Capacity is concurrentDecodeLimit.
+// Package-level so the cap is shared across every decodeEntry caller
+// in the process (CLI search workers + MCP handlers + tests).
+var decodeSem = make(chan struct{}, concurrentDecodeLimit)
 
 // maxEntryBytes is a soft cap on the encoded form of one Entry. Pathological
 // frontmatter or absurdly long lists could otherwise bloat the on-disk file.
@@ -64,18 +93,33 @@ func encodeEntry(e *Entry) ([]byte, error) {
 // nested maps/slices are freshly allocated by gob, so the caller may pass
 // the value into the CEL activation without risk of cross-call mutation.
 //
-// Defends against two adversarial-input shapes:
+// Defends against three adversarial-input shapes:
 //   - Oversized inputs (> maxEntryBytes) are rejected up-front so a
 //     hand-edited / corrupted index file can't tie up the decoder on
 //     megabytes of garbage.
 //   - Inputs that compile to slow / pathological gob decode paths are
-//     bounded by a wall-clock budget (decodeTimeout). The fuzzer
-//     (FuzzDecodeEntry) found a ~161-byte input that consumed >1m of
-//     CPU before the test framework killed it; the budget catches that
-//     class of failure in production too.
+//     bounded by a wall-clock budget (decodeTimeout) enforced via a
+//     goroutine. The fuzzer (FuzzDecodeEntry) found a ~161-byte input
+//     that consumed >1m of CPU before the test framework killed it;
+//     the budget catches that class of failure in production too.
+//   - Bursts of adversarial inputs that would otherwise accumulate
+//     zombie goroutines (gob.Decode can't be cancelled mid-call, so
+//     each timed-out goroutine keeps running until its decode
+//     completes) are throttled by a semaphore. When the cap is hit,
+//     new callers return errDecodeOverloaded immediately rather than
+//     blocking — the caller treats it as a cache miss. Defends
+//     against the fuzz / DoS scenario where many slow inputs in
+//     quick succession would OOM the process.
 func decodeEntry(b []byte) (*Entry, error) {
 	if len(b) > maxEntryBytes {
 		return nil, errEntryTooLarge
+	}
+	// Non-blocking acquire — if the cap is hit, the caller takes a
+	// cache miss rather than waiting in line behind zombie decodes.
+	select {
+	case decodeSem <- struct{}{}:
+	default:
+		return nil, errDecodeOverloaded
 	}
 	type result struct {
 		e   *Entry
@@ -83,6 +127,7 @@ func decodeEntry(b []byte) (*Entry, error) {
 	}
 	ch := make(chan result, 1)
 	go func() {
+		defer func() { <-decodeSem }() // release when decode actually finishes
 		var e Entry
 		dec := gob.NewDecoder(bytes.NewReader(b))
 		ch <- result{e: &e, err: dec.Decode(&e)}
@@ -94,9 +139,9 @@ func decodeEntry(b []byte) (*Entry, error) {
 		}
 		return r.e, nil
 	case <-time.After(decodeTimeout):
-		// Goroutine leaks until gob.Decode returns. Bounded by
-		// the maxEntryBytes input cap above — worst case is one
-		// transient memory spike, not an unbounded leak. Acceptable.
+		// The goroutine keeps running (gob can't be cancelled
+		// mid-call) and holds its semaphore slot until gob.Decode
+		// actually returns. The caller unblocks now.
 		return nil, errDecodeTimeout
 	}
 }

--- a/internal/index/codec_test.go
+++ b/internal/index/codec_test.go
@@ -93,3 +93,65 @@ func TestCodecRejectsOversize(t *testing.T) {
 		t.Fatalf("expected encodeEntry to reject oversize payload")
 	}
 }
+
+// TestCodecDecodeBudgetCancelled verifies that adversarial inputs known
+// to push gob.Decode into a multi-second compile path are bounded by
+// decodeTimeout. The committed regression seed (testdata/fuzz/
+// FuzzDecodeEntry/13d945203058feae) is the same shape that hung the
+// fuzz workflow before the goroutine + select-on-time.After guard
+// landed in #100. This test re-runs that input directly via
+// decodeEntry and asserts the call returns within a generous window —
+// the goroutine is allowed to keep running afterwards, but the caller
+// must unblock.
+func TestCodecDecodeBudgetCancelled(t *testing.T) {
+	// Bytes copied from testdata/fuzz/FuzzDecodeEntry/13d945203058feae.
+	// Keep in sync with that seed; it's the canonical "slow input".
+	slow := []byte("S\x7f\x03\x01\x01\x0500000\x01\xff0\x00\x01\x05\x01\x040000\x01\x04\x00\x01\x0f000000000000000\x01\x04\x00\x01\v00000000000\x01\f\x00\x01\x05Extra\x01\xff\x82\x00\x01\x040000\x01\f\x00\x00\x00'\xff\x81\x04\x01\x01\x1700000000000000000000000\x01\xff0\x00\x01\f\x01\x10\x00\x000\xff\x80\x03\n0000000000\x01\xfa\x00\x00\xfa000000\t0000000000000000000000")
+
+	start := time.Now()
+	_, err := decodeEntry(slow)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Errorf("decodeEntry should have errored on the known-adversarial seed; got success")
+	}
+	// Allow up to 3x the timeout for slack (CI runners, GC).
+	if elapsed > 3*decodeTimeout {
+		t.Errorf("decodeEntry blocked %v, want < %v (timeout=%v)", elapsed, 3*decodeTimeout, decodeTimeout)
+	}
+}
+
+// TestCodecDecodeOverloaded verifies the concurrent-decode cap rejects
+// excess callers when the semaphore is full. Defends against the
+// fuzz-OOM scenario where zombie goroutines would otherwise accumulate.
+//
+// Earlier tests in this package may have spawned still-running zombie
+// gob.Decode goroutines that hold semaphore slots; acquire
+// non-blockingly so we don't deadlock waiting for them.
+func TestCodecDecodeOverloaded(t *testing.T) {
+	held := 0
+	for range concurrentDecodeLimit {
+		select {
+		case decodeSem <- struct{}{}:
+			held++
+		default:
+			// Slot already held by an earlier test's zombie — fine,
+			// we just need the semaphore full overall.
+		}
+	}
+	defer func() {
+		for range held {
+			<-decodeSem
+		}
+	}()
+
+	// Any non-oversize input will do; the call should fast-fail on
+	// the semaphore before hitting gob at all.
+	_, err := decodeEntry([]byte{0x01, 0x02, 0x03})
+	if err == nil {
+		t.Fatal("expected errDecodeOverloaded, got nil")
+	}
+	if err != errDecodeOverloaded {
+		t.Errorf("err=%v, want errDecodeOverloaded", err)
+	}
+}


### PR DESCRIPTION
## Summary

The scheduled fuzz workflow's `FuzzDecodeEntry` target was getting SIGTERM-killed at ~3:45 of its 5-minute budget — see [run 25842258036](https://github.com/richardwooding/file-search-on/actions/runs/25842258036). The log shows the fuzzer's exec rate dropping from ~18k/sec to 0/sec for ~2:40 wall-clock before partial recovery, then SIGTERM with no crash artifact uploaded.

Root cause: each adversarial input that tripped the 500ms `decodeTimeout` spawned a zombie `gob.Decode` goroutine (gob can't be cancelled mid-call, and the slow path is pure CPU compile work between Read calls — a deadline-aware Reader is ineffective). Under continuous fuzz load these zombies accumulated, each holding ~256 KiB of input + gob's internal state, until the cgroup OOM-killed the process.

## Fix

Bound in-flight `decodeEntry` goroutines via a semaphore (capacity = `max(8, NumCPU*2)`). Callers acquire **non-blockingly** — if the cap is hit, `decodeEntry` returns `errDecodeOverloaded` immediately and the caller treats it as a cache miss (recoverable; the file is just re-extracted on the next walk). Zombie goroutines hold their slot until `gob.Decode` actually returns, so worst-case memory is bounded at `concurrentDecodeLimit * (maxEntryBytes + gob state)` — a few hundred KiB.

## Production impact

The cap is generous (16 slots on a typical 8-core box), far above legitimate concurrent cache-lookup levels. The overloaded-error path only fires under deliberate / adversarial pressure — same recoverable failure mode as the existing decode-timeout path.

## Tests

- `TestCodecDecodeBudgetCancelled` — re-runs the committed regression seed (`testdata/fuzz/FuzzDecodeEntry/13d945203058feae`) directly through `decodeEntry` and asserts the call returns within 3x `decodeTimeout`.
- `TestCodecDecodeOverloaded` — fills the semaphore (non-blockingly, in case earlier-test zombies hold slots) and asserts a fresh `decodeEntry` call sees `errDecodeOverloaded`.

## Verified

- [x] `go build ./...`
- [x] `go test -race ./...` (full suite green)
- [x] `go vet ./...`
- [x] `go fix -diff ./...` (empty)
- [x] `golangci-lint run` (0 issues)
- [x] `go test -fuzz=FuzzDecodeEntry -fuzztime=60s ./internal/index/` — runs to completion, no crash, no SIGTERM. Exec rate degrades as adversarial inputs fill semaphore slots, but the test process never OOMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)