### PR TITLE
test(content): fuzz targets for body extractors (XML walker + HTML stripper)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,7 +2,8 @@ name: Fuzz
 
 # Native Go fuzzing — go.dev/doc/security/fuzz — discovers panics
 # and timeouts in parsers (frontmatter, MP3 headers, EBML, MP4
-# boxes, CEL expressions, gob decoder) by mutating seed corpora.
+# boxes, office/EPUB body extractors, CEL expressions, gob decoder)
+# by mutating seed corpora.
 #
 # This workflow runs each target for a few minutes nightly. Found
 # crashes land in testdata/fuzz/<FuzzName>/ inside the failed run's
@@ -50,6 +51,12 @@ jobs:
           - name: ReadMP4VideoInfo
             pkg: ./internal/content/
             func: FuzzReadMP4VideoInfo
+          - name: ExtractXMLText
+            pkg: ./internal/content/
+            func: FuzzExtractXMLText
+          - name: ExtractHTMLText
+            pkg: ./internal/content/
+            func: FuzzExtractHTMLText
           - name: CELCompile
             pkg: ./internal/celexpr/
             func: FuzzCELCompile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ If `Expr` is empty it defaults to `"true"` (matches all files). Worker count def
 
 ### Fuzz testing
 
-The high-risk parsers — frontmatter (YAML/TOML/JSON), MP3 ID3v2 + Xing/Info, MKV EBML, MP4 box walker, CEL expression compile, and the index's gob decoder — have native Go [fuzz targets](https://go.dev/doc/security/fuzz) (`FuzzXxx` functions in `*_fuzz_test.go`).
+The high-risk parsers — frontmatter (YAML/TOML/JSON), MP3 ID3v2 + Xing/Info, MKV EBML, MP4 box walker, office/EPUB body extractors (XML + permissive HTML), CEL expression compile, and the index's gob decoder — have native Go [fuzz targets](https://go.dev/doc/security/fuzz) (`FuzzXxx` functions in `*_fuzz_test.go`).
 
 Workflows:
 

--- a/internal/content/body_fuzz_test.go
+++ b/internal/content/body_fuzz_test.go
@@ -1,0 +1,119 @@
+package content
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// FuzzExtractXMLText targets the shared XML walker that DOCX / XLSX /
+// PPTX / ODT all funnel through. The walker takes (paraElem, textElem)
+// as the per-format shape parameters; we fuzz the input bytes with a
+// representative element-pair so the same target exercises every
+// format's wire grammar.
+//
+// Risk model: Go's encoding/xml package has had CVEs around deeply
+// nested elements, entity recursion, and namespace handling
+// (CVE-2020-29509 / CVE-2020-29510 / CVE-2021-27918). Our walker
+// adds parameterised collection state on top — a paragraph depth
+// counter, a text-element depth counter, and string builders bounded
+// by maxBytes. The contract:
+//
+//   - never panic, even on malformed XML, deeply nested input, or
+//     truncated streams
+//   - output never exceeds 2 × maxBytes (we allow some slack for the
+//     "stop at next paragraph after cap" semantic)
+//   - ctx.Done() honoured: a cancelled ctx terminates the walk within
+//     a small bounded number of tokens
+//
+// We don't assert content equality — corrupt input legitimately
+// produces empty output. The contract is "doesn't crash, doesn't run
+// forever, respects the cap".
+func FuzzExtractXMLText(f *testing.F) {
+	seeds := [][]byte{
+		[]byte(""),
+		[]byte("not xml"),
+		// Minimal well-formed snippet for the DOCX/PPTX shape (p/t).
+		[]byte(`<w:p xmlns:w="x"><w:r><w:t>hello</w:t></w:r></w:p>`),
+		// XLSX sharedStrings shape (si/t).
+		[]byte(`<sst xmlns="x"><si><t>revenue</t></si></sst>`),
+		// ODT shape (p / direct CharData).
+		[]byte(`<text:p xmlns:text="x">direct text</text:p>`),
+		// Nested paragraphs (real docs have <w:p>/<w:tc>/<w:p>).
+		[]byte(`<a><p><p>nested</p></p></a>`),
+		// Adversarial: claim huge depth via repeated open tags.
+		[]byte(`<p><p><p><p><p><p><p><p>x`),
+		// Entity-expansion bomb shape (we don't define entities so
+		// this should error cleanly, not expand).
+		[]byte(`<!DOCTYPE x [<!ENTITY a "aaaa">]><p>&a;&a;&a;</p>`),
+		// Truncated mid-element.
+		[]byte(`<w:p><w:t>part`),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	// One target, two passes — DOCX/PPTX shape (textElem set) and ODT
+	// shape (textElem empty, scoped to paraElem). Captures both
+	// extractor modes from a single fuzz function.
+	f.Fuzz(func(t *testing.T, data []byte) {
+		const maxBytes = 4096
+		ctx := context.Background()
+
+		// Scoped mode (DOCX / XLSX / PPTX).
+		out, _ := extractXMLText(ctx, bytes.NewReader(data), "p", "t", maxBytes)
+		if len(out) > 2*maxBytes {
+			t.Fatalf("scoped mode: output %d bytes exceeds 2× cap (%d)", len(out), maxBytes)
+		}
+		// Unscoped mode (ODT).
+		out, _ = extractXMLText(ctx, bytes.NewReader(data), "p", "", maxBytes)
+		if len(out) > 2*maxBytes {
+			t.Fatalf("unscoped mode: output %d bytes exceeds 2× cap (%d)", len(out), maxBytes)
+		}
+	})
+}
+
+// FuzzExtractHTMLText targets the EPUB chapter extractor — the
+// permissive HTML reader that runs encoding/xml in non-strict mode
+// with our custom auto-close list and entity map. This is the highest-
+// leverage surface in the body extractor: permissive parsing of
+// untrusted markup is exactly the territory where parser bugs hide.
+//
+// Same contract as FuzzExtractXMLText: no panic, output bounded.
+func FuzzExtractHTMLText(f *testing.F) {
+	seeds := [][]byte{
+		[]byte(""),
+		[]byte(`<p>hello</p>`),
+		[]byte(`<html><body><h1>Title</h1><p>Para one.</p><p>Para two.</p></body></html>`),
+		// XHTML self-closing void elements.
+		[]byte(`<p>before<br/>after</p>`),
+		// Script/style content must be skipped.
+		[]byte(`<script>alert("xss")</script><p>visible</p>`),
+		[]byte(`<style>p{color:red}</style><p>visible</p>`),
+		// Custom entities (in our map).
+		[]byte(`<p>&nbsp;copy &copy; &mdash; &rsquo;</p>`),
+		// Unknown entity — should error cleanly inside the decoder.
+		[]byte(`<p>&unknown;</p>`),
+		// Adversarial nesting.
+		[]byte(`<div><div><div><div><div>nested</div></div></div></div></div>`),
+		// Mismatched tags (HTML5 tolerance).
+		[]byte(`<p><b>bold</p></b>`),
+		// Truncated mid-tag.
+		[]byte(`<p>text`),
+		// Numeric character references.
+		[]byte(`<p>&#65;&#x42;</p>`),
+		// Comment + CDATA + processing instruction.
+		[]byte(`<?xml version="1.0"?><!-- comment --><![CDATA[verbatim]]><p>tail</p>`),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		const maxBytes = 4096
+		out, _ := extractHTMLText(context.Background(), bytes.NewReader(data), maxBytes)
+		if len(out) > 2*maxBytes {
+			t.Fatalf("output %d bytes exceeds 2× cap (%d)", len(out), maxBytes)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds fuzz coverage for the two adversarial-input surfaces introduced by #123 (office/EPUB body extraction): the parameterised XML walker and the permissive HTML stripper. Both are exactly the kind of code where parser bugs hide — `encoding/xml` has historical CVEs around deeply nested elements + entity recursion, and the HTML reader runs in non-strict mode with a custom auto-close list and entity map.

**Targets the PR adds:**

1. **`FuzzExtractXMLText`** — feeds random bytes through the shared `extractXMLText` walker in BOTH modes (DOCX/XLSX/PPTX shape with `paraElem=\"p\"` + `textElem=\"t\"`, AND ODT shape with `paraElem=\"p\"` + `textElem=\"\"` for the direct-CharData-inside-paraElem path). One target covers every OOXML/ODT extractor.
2. **`FuzzExtractHTMLText`** — feeds random bytes through the EPUB chapter HTML stripper. Seeds cover void self-closing elements, script/style skip semantics, custom entities (`&nbsp;` / `&copy;` / `&mdash;` / smart quotes), unknown entities, deep nesting, mismatched tags, numeric character references, comments + CDATA + processing instructions.

Both targets assert **no panic** and that **output is bounded** at 2× `maxBytes` (some slack for the \"stop at next paragraph after cap\" semantic in the walker).

## Verified locally

20-second mutate-fuzz against each new target:

```
FuzzExtractXMLText:  1.36M execs, no crashes (147 interesting inputs found)
FuzzExtractHTMLText: 970K execs, no crashes (170 interesting inputs found)
```

Both seed corpora pass on regular `go test ./...`.

## Workflow

- `.github/workflows/fuzz.yml` — two new matrix entries (`ExtractXMLText`, `ExtractHTMLText`) alongside the existing 6 targets, so both run for 5 minutes in the nightly scheduled fuzz job. Pattern matches the existing entries exactly.
- `CLAUDE.md` — fuzz-testing intro updated to mention the new targets.

## Depends on

#123 — introduces the extractors. This PR targets that branch as the base, so it can merge as soon as #123 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)