### PR TITLE
fix(ci): VHDX fuzz assertion + cut-release orphaned-run docs

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -33,10 +33,13 @@ goreleaser check                    # validates .goreleaser.yaml
 git tag -a v0.X.Y -m "v0.X.Y — <one-line summary>"
 git push origin v0.X.Y
 
-# 4. Watch the workflow
-gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId -q '.[0].databaseId')" --exit-status
+# 4. Watch the workflow — bounded by a hard timeout so an orphaned
+#    runner can't block forever (see "Orphaned runs" below).
+RUN_ID=$(gh run list --workflow=release.yml --limit 1 --json databaseId -q '.[0].databaseId')
+timeout 600 gh run watch "$RUN_ID" --exit-status || echo "watch exited (timeout or run failed); checking artifacts directly"
 
-# 5. Verify all three publish targets
+# 5. Verify all three publish targets — THIS is the source of truth,
+#    not the workflow status.
 bash .claude/skills/cut-release/scripts/verify_release.sh v0.X.Y
 ```
 
@@ -71,20 +74,33 @@ Use `git tag -a` (annotated), not lightweight tags. The release workflow does no
 ## Watch the workflow
 
 ```sh
-gh run watch <run-id> --exit-status
+RUN_ID=$(gh run list --workflow=release.yml --limit 1 --json databaseId -q '.[0].databaseId')
+timeout 600 gh run watch "$RUN_ID" --exit-status || true
 ```
 
-To find the run-id of the just-triggered release run:
+Always wrap `gh run watch` in `timeout` — the command has no built-in timeout and will block indefinitely if the runner orphans (see below). 10 minutes is generous for a workflow that typically completes in 2–3.
 
-```sh
-gh run list --workflow=release.yml --limit 1 --json databaseId,status -q '.[0]'
-```
+Typical duration: 2–3 minutes. If `gh run watch` returns non-zero (real failure OR timeout), don't trust the workflow status — verify directly via `verify_release.sh`. The artifacts are the source of truth; the workflow is bookkeeping.
 
-Typical duration: 2–3 minutes. If it fails, the tag is already pushed — see the rollback section.
+## Orphaned runs
+
+GitHub Actions occasionally orphans a hosted runner — every step inside the job reports `success` (including the final `Complete job` step) but the outer job's `status` stays `in_progress` and `conclusion` is `null` forever. Symptom: `gh run watch` blocks past the typical duration; `gh api repos/<owner>/<repo>/actions/jobs/<id>` shows all steps green but the job in-progress.
+
+This is a runner-agent failure to send the final job-status PATCH back to GitHub. Nothing on our side caused it. The release artifacts ARE published when the GoReleaser step shows `success` — only the workflow bookkeeping is stuck.
+
+**Handling**:
+
+1. **Trust `verify_release.sh`, not the workflow status.** If it passes, the release is real and users can install it.
+2. **Try to cancel the orphan**: `gh run cancel <run-id>`. If that returns HTTP 500, try `gh api -X POST repos/<owner>/<repo>/actions/runs/<run-id>/force-cancel`. If that ALSO returns 500, GitHub's bookkeeping is too wedged to cancel — the run will self-terminate at the 6-hour max-job-duration limit. Move on.
+3. **Don't re-tag or re-release.** The artifacts shipped; doing it again would either no-op (tag already exists on remote) or require deleting+re-pushing the tag which confuses ghcr / Homebrew caches.
+
+A workaround for the runner-agent flakiness itself isn't in our hands (it's GitHub-side), but bounded watches + artifact-first verification (the Quick Start above) make it a 10-minute annoyance instead of a blocker.
 
 ## Verify
 
 **Run** `bash .claude/skills/cut-release/scripts/verify_release.sh v0.X.Y` from the repo root — checks the GitHub Release has the six expected archives + checksums.txt, the Homebrew tap got an auto-commit referencing the version, and (if Docker is installed) the OCI image manifest is published. Exits non-zero on any failure.
+
+**This is the authoritative check.** A green `verify_release.sh` means the release shipped, regardless of whether `gh run watch` returned cleanly. A failing one is the trigger for rollback.
 
 If a target fails verification, jump to rollback before the user reports it.
 

--- a/internal/content/diskimage_fuzz_test.go
+++ b/internal/content/diskimage_fuzz_test.go
@@ -120,15 +120,15 @@ func FuzzReadVHDXMetadata(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// findVHDXMetadataRegion — input is a region-table sized
-		// buffer; if shorter, the function should reject.
-		off, length := findVHDXMetadataRegion(data)
+		// buffer; if shorter, the function should reject. The length
+		// it returns is the value the file claims; the walker is
+		// responsible for bounds-checking before reading. A large
+		// uint32 length is a legitimate value, not corruption — we
+		// only assert against negative offsets here (which would
+		// indicate the parser dropped its int64(uint64) guard).
+		off, _ := findVHDXMetadataRegion(data)
 		if off < 0 {
 			t.Fatalf("findVHDXMetadataRegion returned negative offset: %d", off)
-		}
-		if length > 1<<30 {
-			// Length is a uint32 — sanity-check that no logic
-			// returns an absurdly large value despite truncation.
-			t.Fatalf("findVHDXMetadataRegion length = %d looks corrupt", length)
 		}
 
 		// findVHDXVirtualDiskSize — feed the same bytes; the walker

--- a/internal/content/testdata/fuzz/FuzzReadVHDXMetadata/665e555bbbefc77f
+++ b/internal/content/testdata/fuzz/FuzzReadVHDXMetadata/665e555bbbefc77f
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("regi00000\x00\x00\x000000\x06\xa2|\x8b\x90G\x9aK\xb8\xfeW_\x05\x0f\x88n00000000000A0000")


### PR DESCRIPTION
## Summary

Two CI-hygiene fixes bundled together:

### 1. `fix(fuzz): remove over-eager length-cap assertion in FuzzReadVHDXMetadata`

Last night's scheduled fuzz run ([25900820009](https://github.com/richardwooding/file-search-on/actions/runs/25900820009)) failed on seed `665e555bbbefc77f` — a valid-shaped VHDX region table with `Length=0x41205070` (~1.09 GiB).

**Not a parser bug.** `findVHDXMetadataRegion`'s contract is "return what the file claims; the walker bounds-checks." The walker (`readVHDXVirtualSize`) already enforces:
- `metaOffset + int64(metaLength) > size` → reject the entry
- `readLen` capped at 16 MiB before `make()`

The failure was the test assertion `length > 1<<30 → fatal`, which conflated "uint32 happens to be > 1 GiB" with "behaviour is unsafe." Removed; the remaining assertions (negative offset, negative size) capture the real contract.

The failing seed is committed under `internal/content/testdata/fuzz/FuzzReadVHDXMetadata/665e555bbbefc77f` so Go's regular seed-corpus run locks in regression coverage.

### 2. `docs(cut-release): handle orphaned GitHub Actions runs`

We hit a GitHub Actions runner orphan on the v0.32.0 release run ([25906719138](https://github.com/richardwooding/file-search-on/actions/runs/25906719138)): every step reported success, artifacts published, but the outer job status stayed `in_progress`. Both `gh run cancel` and `gh api -X POST .../force-cancel` returned HTTP 500.

Patches to `.claude/skills/cut-release/SKILL.md`:
- Wrap `gh run watch` in `timeout 600` in the Quick Start
- Treat `verify_release.sh` as the source of truth, not the workflow status
- New "Orphaned runs" section documenting symptom, cancel-ladder, and the "don't re-tag" rule

Operational docs only — no behaviour change.

## Test plan

- [x] `go test -run=FuzzReadVHDXMetadata ./internal/content/` — passes including the new regression seed
- [x] `go test -fuzz=FuzzReadVHDXMetadata -fuzztime=30s -run='^$' ./internal/content/` — 781k execs, 0 new interesting, no crashes
- [x] `go build ./... && go test -race ./...` clean
- [x] `go vet ./...` + `golangci-lint run` clean
- [x] Pre-existing `FuzzReadMP4VideoInfo` regression seed preserved (no other seed corpus regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)