### PR TITLE
fix(semantic): validate embedding model on cache hit (closes #154)

### DIFF
--- a/examples/semantic-search.md
+++ b/examples/semantic-search.md
@@ -155,7 +155,7 @@ Note: image files only have semantic-search-friendly content when they carry tex
 - **First call against a tree**: dominated by Ollama embedding latency. ~50-200ms per file depending on body length + model size. A 1000-file tree with `nomic-embed-text` typically completes in 1-3 minutes cold.
 - **Repeat calls against unchanged trees**: vector cache hits skip Ollama entirely. The bottleneck moves to body extraction (which is itself cached from PR #142). Sub-second for the same 1000-file tree.
 - **Different queries against the same tree**: query embedding is one extra Ollama call (~50ms), per-file work is a dot product (microseconds). Sub-second after the first warm-up.
-- **Switching models**: changes the vector dimension and invalidates the entire vector cache. Plan accordingly — pick one model per index file.
+- **Switching models** (e.g. `nomic-embed-text` → `mxbai-embed-large`): each cache entry records which model produced its vector. The next walk under the new model detects the mismatch, re-embeds, and stamps the new model name — no manual rebuild needed, no silently-wrong scores. The `embed_model_mismatches` counter in `index_stats` reports how many files were re-embedded vs. genuinely missed. Switching back and forth between models is correct but not free: each switch re-embeds the touched files.
 
 ## Out of scope (for now)
 

--- a/internal/celexpr/body.go
+++ b/internal/celexpr/body.go
@@ -87,6 +87,10 @@ func canExtractBody(name string) bool {
 //   - "miss": cached Vector missing, Embedder call attempted
 //   - "put": cached Vector freshly stored
 //   - "error": Embedder.Embed returned a non-nil error
+//   - "model_mismatch": cached Vector existed but EmbedModel differs
+//     from opts.Embedder.Model() (or EmbedModel is empty — unknown
+//     provenance, never trust). Falls through to re-embed; does NOT
+//     also bump "miss" (the model mismatch IS the miss reason).
 func populateSimilarity(ctx context.Context, fsys fs.FS, fsPath, displayPath, cacheKey string, info fs.FileInfo, cached *index.Entry, attrs *FileAttributes, opts BuildOptions) {
 	if attrs == nil {
 		return
@@ -98,28 +102,47 @@ func populateSimilarity(ctx context.Context, fsys fs.FS, fsPath, displayPath, ca
 		return
 	}
 
-	// Cache hit: cached Vector is the file's embedding, already
-	// normalised (we normalise at insert time). Dot == cosine.
+	currentModel := opts.Embedder.Model()
+
+	// Cache hit path — three sub-cases:
+	//
+	//   1. Vector + EmbedModel match the current model → reuse, Dot
+	//      gives cosine (both pre-normalised). "hit".
+	//   2. Vector present but EmbedModel differs (or is empty —
+	//      pre-#154 provenance) → bump "model_mismatch" and fall
+	//      through to re-embed. We can't trust the cached vector
+	//      because dimensions and/or coordinate systems differ across
+	//      models; computing a dot product would return either 0
+	//      (length mismatch) or nonsense (same dim, different model).
+	//   3. Vector empty → bump "miss" below in the re-embed path.
 	if cached != nil && len(cached.Vector) > 0 {
-		attrs.Similarity = embed.Dot(opts.SemanticQueryEmbedding, cached.Vector)
-		if opts.Index != nil {
-			opts.Index.BumpEmbedStat("hit")
+		if cached.EmbedModel == currentModel && currentModel != "" {
+			attrs.Similarity = embed.Dot(opts.SemanticQueryEmbedding, cached.Vector)
+			if opts.Index != nil {
+				opts.Index.BumpEmbedStat("hit")
+			}
+			return
 		}
-		return
+		if opts.Index != nil {
+			opts.Index.BumpEmbedStat("model_mismatch")
+		}
+		// fall through to re-embed; don't also bump "miss".
 	}
 
-	// Cache miss. Extract the body via the existing body-cache-aware
-	// reader so we share the body cache with anything else asking
-	// for it in this walk. Empty body → no signal → leave Similarity
-	// at 0.
+	// Re-embed path. Extract the body via the body-cache-aware reader
+	// so we share the body cache with anything else asking for it in
+	// this walk. Empty body → no signal → leave Similarity at 0.
 	body, err := readBody(ctx, fsys, fsPath, attrs.ContentType, opts.BodyMaxBytes)
 	if err != nil || body == "" {
-		if opts.Index != nil {
+		if opts.Index != nil && (cached == nil || len(cached.Vector) == 0) {
+			// Pure cache-miss (no Vector at all). When we got here
+			// via model_mismatch we've already bumped that counter
+			// and shouldn't also bump "miss".
 			opts.Index.BumpEmbedStat("miss")
 		}
 		return
 	}
-	if opts.Index != nil {
+	if opts.Index != nil && (cached == nil || len(cached.Vector) == 0) {
 		opts.Index.BumpEmbedStat("miss")
 	}
 	vec, err := opts.Embedder.Embed(ctx, body)
@@ -133,9 +156,10 @@ func populateSimilarity(ctx context.Context, fsys fs.FS, fsPath, displayPath, ca
 	attrs.Similarity = embed.Dot(opts.SemanticQueryEmbedding, vec)
 
 	// Write the freshly-computed vector back to the cache so the
-	// next walk against the same (size, mtime) skips the Embedder
-	// call. Always-write semantics: even on a cache hit for other
-	// attrs, we now have a Vector to record.
+	// next walk against the same (size, mtime, model) skips the
+	// Embedder call. Stamp EmbedModel so future calls with a
+	// different model surface as model_mismatch instead of silently
+	// returning wrong scores.
 	if opts.Index != nil && cacheKey != "" {
 		entry := cached
 		if entry == nil {
@@ -146,6 +170,7 @@ func populateSimilarity(ctx context.Context, fsys fs.FS, fsPath, displayPath, ca
 			}
 		}
 		entry.Vector = vec
+		entry.EmbedModel = currentModel
 		_ = opts.Index.Put(cacheKey, entry)
 		opts.Index.BumpEmbedStat("put")
 	}

--- a/internal/celexpr/similarity_test.go
+++ b/internal/celexpr/similarity_test.go
@@ -141,6 +141,152 @@ func TestBuildAttributesWith_Similarity_CacheHit(t *testing.T) {
 	}
 }
 
+// TestBuildAttributesWith_Similarity_ModelMismatch confirms that
+// switching the embedding model between two walks invalidates the
+// cached vector — the second walk bumps EmbedModelMismatches and
+// re-embeds, rather than silently returning a Dot product against a
+// vector from the wrong coordinate system.
+func TestBuildAttributesWith_Similarity_ModelMismatch(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.md")
+	mustWrite(t, path, "content for model A then model B\n")
+
+	abs, _ := filepath.Abs(path)
+	base := filepath.Base(abs)
+	parent := filepath.Dir(abs)
+
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		// Same vector either way — the test cares about the model
+		// identity check, not vector content.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"embeddings": [][]float32{{0.6, 0.8}},
+		})
+	}))
+	defer srv.Close()
+
+	idx := index.NewMemory()
+	defer func() { _ = idx.Close() }()
+	queryVec := []float32{0.6, 0.8}
+
+	// Walk 1: populate cache with model A.
+	embedderA := embed.NewOllama(srv.URL, "model-a")
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), celexpr.BuildOptions{
+		Index:                  idx,
+		Embedder:               embedderA,
+		SemanticQueryEmbedding: queryVec,
+	}); err != nil {
+		t.Fatalf("walk A: %v", err)
+	}
+	if idx.Stats().EmbedPuts != 1 {
+		t.Fatalf("after walk A: EmbedPuts=%d want 1; stats=%+v", idx.Stats().EmbedPuts, idx.Stats())
+	}
+
+	// Walk 2: same tree, different model. Must NOT report a hit;
+	// must bump EmbedModelMismatches and re-embed.
+	embedderB := embed.NewOllama(srv.URL, "model-b")
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), celexpr.BuildOptions{
+		Index:                  idx,
+		Embedder:               embedderB,
+		SemanticQueryEmbedding: queryVec,
+	}); err != nil {
+		t.Fatalf("walk B: %v", err)
+	}
+	st := idx.Stats()
+	if st.EmbedModelMismatches != 1 {
+		t.Errorf("EmbedModelMismatches=%d want 1; stats=%+v", st.EmbedModelMismatches, st)
+	}
+	if st.EmbedHits != 0 {
+		t.Errorf("EmbedHits=%d want 0 (model changed, must not hit); stats=%+v", st.EmbedHits, st)
+	}
+	if st.EmbedPuts != 2 {
+		t.Errorf("EmbedPuts=%d want 2 (re-embed under model B); stats=%+v", st.EmbedPuts, st)
+	}
+	if calls != 2 {
+		t.Errorf("Ollama calls=%d want 2 (one per walk); model mismatch should force re-embed", calls)
+	}
+
+	// Walk 3: back to model A. Cache now holds model B's vector, so
+	// this is ANOTHER mismatch. Demonstrates the cache holds only
+	// one model at a time per file — switching back and forth is
+	// not free, but at least it's correct.
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), celexpr.BuildOptions{
+		Index:                  idx,
+		Embedder:               embedderA,
+		SemanticQueryEmbedding: queryVec,
+	}); err != nil {
+		t.Fatalf("walk A again: %v", err)
+	}
+	st = idx.Stats()
+	if st.EmbedModelMismatches != 2 {
+		t.Errorf("EmbedModelMismatches=%d want 2; stats=%+v", st.EmbedModelMismatches, st)
+	}
+}
+
+// TestBuildAttributesWith_Similarity_PreV154EntryRejected exercises
+// the upgrade path: an Entry that pre-dates #154 has Vector populated
+// but EmbedModel="". We must NOT trust such a vector (we don't know
+// what produced it) — treat it as a model mismatch and re-embed.
+func TestBuildAttributesWith_Similarity_PreV154EntryRejected(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.md")
+	mustWrite(t, path, "legacy cache entry simulation\n")
+
+	abs, _ := filepath.Abs(path)
+	base := filepath.Base(abs)
+	parent := filepath.Dir(abs)
+
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"embeddings": [][]float32{{0.6, 0.8}},
+		})
+	}))
+	defer srv.Close()
+
+	idx := index.NewMemory()
+	defer func() { _ = idx.Close() }()
+
+	// Manually seed the cache with a pre-#154-shaped entry: Vector
+	// populated, EmbedModel empty (simulating a gob decode from a
+	// cache file written before this PR).
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheKey, _ := filepath.Abs(path)
+	_ = idx.Put(cacheKey, &index.Entry{
+		Size:            info.Size(),
+		ModTimeUnixNano: info.ModTime().UnixNano(),
+		ContentType:     "markdown",
+		Vector:          []float32{0.6, 0.8},
+		EmbedModel:      "", // pre-#154 entries have empty EmbedModel
+	})
+
+	embedder := embed.NewOllama(srv.URL, "mock")
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), celexpr.BuildOptions{
+		Index:                  idx,
+		Embedder:               embedder,
+		SemanticQueryEmbedding: []float32{0.6, 0.8},
+	}); err != nil {
+		t.Fatalf("BuildAttributesWith: %v", err)
+	}
+	st := idx.Stats()
+	if st.EmbedModelMismatches != 1 {
+		t.Errorf("EmbedModelMismatches=%d want 1 (pre-#154 vector should be rejected); stats=%+v", st.EmbedModelMismatches, st)
+	}
+	if calls != 1 {
+		t.Errorf("Ollama calls=%d want 1 (re-embed under the new model)", calls)
+	}
+	if st.EmbedHits != 0 {
+		t.Errorf("EmbedHits=%d want 0 (must not trust empty-EmbedModel vector); stats=%+v", st.EmbedHits, st)
+	}
+}
+
 // TestEvaluate_SimilarityFilter exercises the CEL predicate from a
 // synthesised FileAttributes.
 func TestEvaluate_SimilarityFilter(t *testing.T) {

--- a/internal/index/bbolt.go
+++ b/internal/index/bbolt.go
@@ -345,10 +345,11 @@ func (b *boltIndex) Stats() Stats {
 		BodyEvictions: b.stats.bodyEvictions.Load(),
 		BodyOversize:  b.stats.bodyOversize.Load(),
 		BodyErrors:    b.stats.bodyErrors.Load(),
-		EmbedHits:     b.stats.embedHits.Load(),
-		EmbedMisses:   b.stats.embedMisses.Load(),
-		EmbedPuts:     b.stats.embedPuts.Load(),
-		EmbedErrors:   b.stats.embedErrors.Load(),
+		EmbedHits:            b.stats.embedHits.Load(),
+		EmbedMisses:          b.stats.embedMisses.Load(),
+		EmbedPuts:            b.stats.embedPuts.Load(),
+		EmbedErrors:          b.stats.embedErrors.Load(),
+		EmbedModelMismatches: b.stats.embedModelMismatches.Load(),
 	}
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -68,12 +68,19 @@ type Entry struct {
 	// (issue #151). Cached under the same (size, mtime) validation
 	// tuple as the rest of the entry. The dimension depends on the
 	// embedding model (768 for nomic-embed-text, 1024 for
-	// mxbai-embed-large, etc.) — callers are responsible for
-	// consistency: switching models on a tree that was previously
-	// embedded with a different model produces gibberish similarity
-	// scores. gob-additive: pre-#151 entries decode with empty
-	// Vector and the next semantic walk repopulates them.
+	// mxbai-embed-large, etc.) — switching models on a tree that
+	// was previously embedded with a different model would produce
+	// nonsensical similarity scores, so populateSimilarity validates
+	// EmbedModel below before reusing the cached vector. gob-additive:
+	// pre-#151 entries decode with empty Vector and the next
+	// semantic walk repopulates them.
 	Vector []float32
+	// EmbedModel is the model name that produced Vector. Empty when
+	// Vector is empty OR when the vector came from a pre-#154 cache
+	// entry (in which case populateSimilarity treats it as a
+	// mismatch and re-embeds — we never trust a vector of unknown
+	// provenance). gob-additive.
+	EmbedModel string
 	// Fingerprint is the 64-bit Charikar SimHash of the file's
 	// extracted body, computed by internal/fingerprint. Zero unless
 	// the near-duplicates pipeline asked for it. Like Hash, it's
@@ -161,10 +168,11 @@ type Stats struct {
 	// Embed* counters track the embedding cache (PR for #151).
 	// Embed cache lives in index.Entry.Vector alongside the other
 	// per-file fields and uses the same (size, mtime) validation.
-	EmbedHits   uint64 // successful Vector reuse from cache
-	EmbedMisses uint64 // cache had no Vector → had to call the Embedder
-	EmbedPuts   uint64 // freshly-computed vector stored back to cache
-	EmbedErrors uint64 // Embedder.Embed call failed (Ollama unreachable, model missing, etc.)
+	EmbedHits            uint64 // successful Vector reuse from cache
+	EmbedMisses          uint64 // cache had no Vector → had to call the Embedder
+	EmbedPuts            uint64 // freshly-computed vector stored back to cache
+	EmbedErrors          uint64 // Embedder.Embed call failed (Ollama unreachable, model missing, etc.)
+	EmbedModelMismatches uint64 // cached Vector existed but came from a different embedding model → treated as miss, re-embedded
 }
 
 // Index is the surface every cache implementation honours.

--- a/internal/index/memory.go
+++ b/internal/index/memory.go
@@ -28,10 +28,11 @@ type memoryStats struct {
 	bodyOversize  atomic.Uint64
 	bodyErrors    atomic.Uint64
 
-	embedHits   atomic.Uint64
-	embedMisses atomic.Uint64
-	embedPuts   atomic.Uint64
-	embedErrors atomic.Uint64
+	embedHits            atomic.Uint64
+	embedMisses          atomic.Uint64
+	embedPuts            atomic.Uint64
+	embedErrors          atomic.Uint64
+	embedModelMismatches atomic.Uint64
 }
 
 func newMemoryIndex() *memoryIndex {
@@ -126,10 +127,11 @@ func (m *memoryIndex) Stats() Stats {
 		BodyEvictions: m.stats.bodyEvictions.Load(),
 		BodyOversize:  m.stats.bodyOversize.Load(),
 		BodyErrors:    m.stats.bodyErrors.Load(),
-		EmbedHits:     m.stats.embedHits.Load(),
-		EmbedMisses:   m.stats.embedMisses.Load(),
-		EmbedPuts:     m.stats.embedPuts.Load(),
-		EmbedErrors:   m.stats.embedErrors.Load(),
+		EmbedHits:            m.stats.embedHits.Load(),
+		EmbedMisses:          m.stats.embedMisses.Load(),
+		EmbedPuts:            m.stats.embedPuts.Load(),
+		EmbedErrors:          m.stats.embedErrors.Load(),
+		EmbedModelMismatches: m.stats.embedModelMismatches.Load(),
 	}
 }
 
@@ -148,6 +150,8 @@ func bumpEmbedStat(s *memoryStats, kind string) {
 		s.embedPuts.Add(1)
 	case "error":
 		s.embedErrors.Add(1)
+	case "model_mismatch":
+		s.embedModelMismatches.Add(1)
 	}
 }
 

--- a/internal/mcpserver/index_stats_tool.go
+++ b/internal/mcpserver/index_stats_tool.go
@@ -28,10 +28,11 @@ type IndexStatsOutput struct {
 	BodyOversize  uint64 `json:"body_oversize"`
 	BodyErrors    uint64 `json:"body_errors"`
 
-	EmbedHits   uint64 `json:"embed_hits"`
-	EmbedMisses uint64 `json:"embed_misses"`
-	EmbedPuts   uint64 `json:"embed_puts"`
-	EmbedErrors uint64 `json:"embed_errors"`
+	EmbedHits            uint64 `json:"embed_hits"`
+	EmbedMisses          uint64 `json:"embed_misses"`
+	EmbedPuts            uint64 `json:"embed_puts"`
+	EmbedErrors          uint64 `json:"embed_errors"`
+	EmbedModelMismatches uint64 `json:"embed_model_mismatches"`
 }
 
 func (h *handlers) indexStatsHandler(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, IndexStatsOutput, error) {
@@ -52,9 +53,10 @@ func (h *handlers) indexStatsHandler(_ context.Context, _ *mcp.CallToolRequest, 
 		BodyEvictions: st.BodyEvictions,
 		BodyOversize:  st.BodyOversize,
 		BodyErrors:    st.BodyErrors,
-		EmbedHits:     st.EmbedHits,
-		EmbedMisses:   st.EmbedMisses,
-		EmbedPuts:     st.EmbedPuts,
-		EmbedErrors:   st.EmbedErrors,
+		EmbedHits:            st.EmbedHits,
+		EmbedMisses:          st.EmbedMisses,
+		EmbedPuts:            st.EmbedPuts,
+		EmbedErrors:          st.EmbedErrors,
+		EmbedModelMismatches: st.EmbedModelMismatches,
 	}, nil
 }


### PR DESCRIPTION
## Summary

Fixes #154. The semantic-search vector cache (shipped in v0.39.0 / #152) stored per-file embeddings without recording which Ollama model produced them. Switching models silently produced wrong similarity scores:

- **Different dimensions** (e.g. `nomic-embed-text` 768 → `mxbai-embed-large` 1024) → `embed.Dot` returns 0 every time → user sees "no matches above threshold" with no error.
- **Same dimension, different model** → `embed.Dot` returns *some* float against two unrelated coordinate systems → user sees ranked results that look plausible but encode no semantic signal.

Either way: silent. No log, no counter, no warning.

## Fix

`index.Entry` gains a gob-additive `EmbedModel string` field recording the model that produced `Vector`. `populateSimilarity` validates on every cache-hit:

| Cached state | Action |
|---|---|
| Vector populated, `EmbedModel == currentModel` | reuse, `Dot == cosine`, bump `EmbedHits` |
| Vector populated, EmbedModel **differs** | bump `EmbedModelMismatches`, re-embed, re-store with current model |
| Vector populated, EmbedModel **empty** *(pre-#154 entries)* | same as differs — unknown provenance, never trust |
| Vector empty | normal cache-miss path, bump `EmbedMisses` |

The re-embed write-back stamps `entry.EmbedModel = currentModel` so the next walk under the same model hits cleanly. Switching back and forth between models is correct but not free — each switch re-embeds the touched files.

## New counter

`index.Stats.EmbedModelMismatches` alongside the existing `EmbedHits / EmbedMisses / EmbedPuts / EmbedErrors`. Surfaces as `embed_model_mismatches` in the `index_stats` MCP tool.

## Tests

Two cases in `internal/celexpr/similarity_test.go`:

- **`TestBuildAttributesWith_Similarity_ModelMismatch`** — walks A then B then A again, asserts mismatches + put counts. Walk B reports `EmbedModelMismatches==1`, `EmbedPuts==2`, `EmbedHits==0`. Walk A again (cache now holds B's vector) reports `EmbedModelMismatches==2`.

- **`TestBuildAttributesWith_Similarity_PreV154EntryRejected`** — hand-seeds an `Entry` with `Vector` populated but `EmbedModel=""` (simulates gob decode from a pre-#154 cache file). Confirms the next walk rejects it via the mismatch branch — never trust unknown provenance.

## Docs

`examples/semantic-search.md` — "Switching models" bullet rewritten to describe the new contract: no manual rebuild needed, no silently-wrong scores, switching back and forth re-embeds each time.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go fix -diff ./...` — empty
- [x] `go test -race ./...` — all packages green
- [x] `golangci-lint run` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)