### PR TITLE
fix(stats): detect wrapped ctx errors so Cancelled flag fires on timeout

### DIFF
--- a/internal/search/stats.go
+++ b/internal/search/stats.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -231,12 +232,17 @@ func ComputeStats(ctx context.Context, opts Options, registry *content.Registry)
 	}
 
 	if walkErr != nil {
-		switch walkErr {
-		case context.Canceled:
+		// errors.Is unwraps — the producer in walker.go joins ctx.Err()
+		// via errors.Join, so direct equality (switch walkErr) misses
+		// the wrapped DeadlineExceeded / Canceled and we silently drop
+		// the Cancelled flag. Bug surfaced via CLI smoke against
+		// ~/Library with --timeout 100ms.
+		switch {
+		case errors.Is(walkErr, context.Canceled):
 			stats.Cancelled = true
 			stats.CancellationReason = "client_cancel"
 			return stats, nil
-		case context.DeadlineExceeded:
+		case errors.Is(walkErr, context.DeadlineExceeded):
 			stats.Cancelled = true
 			stats.CancellationReason = "timeout"
 			return stats, nil

--- a/internal/search/stats_cancel_test.go
+++ b/internal/search/stats_cancel_test.go
@@ -1,0 +1,91 @@
+package search_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// TestComputeStats_TimeoutSurfacesCancelled is the regression test
+// for the wrapped-error bug found via CLI smoke against ~/Library
+// with --timeout 100ms. Symptom: stats.Cancelled stayed false even
+// though the walk stopped early, so the CLI lost its "timed out"
+// message, suggestions, and exit-code-124 path. Root cause:
+// walker.go:600 wraps the producer's ctx error via errors.Join, so
+// stats.go's direct equality `switch walkErr { case context.X }` no
+// longer matched. Fix: switch to `errors.Is(walkErr, context.X)`.
+//
+// Test strategy: pre-cancel the ctx, then call ComputeStats. The
+// producer's first WalkDir callback sees ctx.Done() immediately,
+// returns ctx.Err() (Canceled), which errors.Join wraps. Pre-fix
+// this returned (stats, walkErr) with Cancelled=false. Post-fix it
+// sets Cancelled=true + reason=client_cancel.
+func TestComputeStats_TimeoutSurfacesCancelled(t *testing.T) {
+	dir := t.TempDir()
+	// Populate the dir with enough files that the walker has work
+	// to do — though we cancel pre-emptively below.
+	for i := range 50 {
+		mustWriteFile(t, filepath.Join(dir, fmt.Sprintf("f%d.md", i)), "# x\n")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // fire before ComputeStats sees the ctx
+
+	stats, err := search.ComputeStats(ctx, search.Options{
+		Root: dir,
+		Expr: "true",
+	}, content.DefaultRegistry())
+
+	if err != nil {
+		t.Fatalf("ComputeStats returned err on cancelled ctx (should swallow): %v", err)
+	}
+	if stats == nil {
+		t.Fatal("stats is nil on cancellation; expected partial-result struct")
+	}
+	if !stats.Cancelled {
+		t.Errorf("stats.Cancelled = false; expected true (bug: errors.Join wraps the ctx error, direct equality fails)")
+	}
+	if stats.CancellationReason != "client_cancel" {
+		t.Errorf("stats.CancellationReason = %q, want %q", stats.CancellationReason, "client_cancel")
+	}
+}
+
+// TestComputeStats_DeadlineExceededSurfacesTimeout mirrors the above
+// for the timeout path. Sets a 1ms deadline; the producer trips it
+// almost immediately. Pre-fix bug: reason stayed empty.
+func TestComputeStats_DeadlineExceededSurfacesTimeout(t *testing.T) {
+	dir := t.TempDir()
+	for i := range 200 {
+		mustWriteFile(t, filepath.Join(dir, fmt.Sprintf("f%d.md", i)), "# x\n")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	// Tiny sleep to ensure the deadline has actually fired before
+	// ComputeStats kicks off — defends against fast machines where
+	// 1ms might not have ticked by the time we enter ComputeStats.
+	time.Sleep(2 * time.Millisecond)
+
+	stats, err := search.ComputeStats(ctx, search.Options{
+		Root: dir,
+		Expr: "true",
+	}, content.DefaultRegistry())
+
+	if err != nil {
+		t.Fatalf("ComputeStats returned err on timeout (should swallow): %v", err)
+	}
+	if stats == nil {
+		t.Fatal("stats is nil on timeout; expected partial-result struct")
+	}
+	if !stats.Cancelled {
+		t.Errorf("stats.Cancelled = false; expected true on deadline-exceeded")
+	}
+	if stats.CancellationReason != "timeout" {
+		t.Errorf("stats.CancellationReason = %q, want %q", stats.CancellationReason, "timeout")
+	}
+}


### PR DESCRIPTION
## Bug

\`file-search-on stats 'true' -d ~/Library --timeout 100ms\` printed a partial histogram but exited 0, with no \"timed out\" message, no Suggestions, and no \`cancelled: true\` in the JSON output.

Surfaced via a casual smoke test running the CLI against a real tree.

## Root cause

\`walker.go:600\` wraps the producer's ctx error via \`errors.Join\`:

\`\`\`go
walkErr := errors.Join(walkErrs...)
\`\`\`

But \`stats.go\` used direct equality on the returned error:

\`\`\`go
switch walkErr {
case context.Canceled:        // never matches — walkErr is *errors.joinError
case context.DeadlineExceeded:
}
\`\`\`

The CLI's \`isCancellation()\` uses \`errors.Is\`, so the \"stats failed\" path was correctly skipped — but \`Stats.Cancelled\` was never set, which meant the entire partial-result UX (footer message, suggestions, exit code 124) silently dropped.

## Fix

Replace the switch with \`errors.Is\`:

\`\`\`go
switch {
case errors.Is(walkErr, context.Canceled):
case errors.Is(walkErr, context.DeadlineExceeded):
}
\`\`\`

Two-line change.

## Regression test

\`internal/search/stats_cancel_test.go\` covers both paths:

- \`TestComputeStats_TimeoutSurfacesCancelled\` — pre-cancelled ctx → \`Cancelled=true\` + \`CancellationReason=client_cancel\`
- \`TestComputeStats_DeadlineExceededSurfacesTimeout\` — 1ms deadline → \`Cancelled=true\` + \`CancellationReason=timeout\`

Verified to fail on pre-fix code via \`git stash\` round-trip.

## Smoke verification

After fix:

\`\`\`
$ file-search-on stats 'true' -d ~/Library --timeout 100ms
content_type                        count      total_size
unknown                                 4     3,666,480 B
database/sqlite                         2       311,296 B
system/macos-localized                  1             0 B
---                                   ---             ---
TOTAL                                   7     3,977,776 B
(partial — timeout)
stats timed out after 100ms; counts above may be incomplete
Suggestions:
  • Walk hit the timeout at 0.2s. Pass --timeout 1s (≈2x current) for a longer run.
  • No --exclude or --respect-gitignore is set. ...
  • The CEL filter is empty or 'true' — every file is walked. ...
$ echo \$?
124
\`\`\`

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` / \`go test -race ./...\` — all pass
- [x] \`golangci-lint run\` — 0 issues
- [x] New regression test \`TestComputeStats_TimeoutSurfacesCancelled\` + \`...DeadlineExceeded...\` pass
- [x] Regression test verified to FAIL on pre-fix code via \`git stash\` round-trip
- [x] CLI smoke against \`~/Library\` with \`--timeout 100ms\`: timeout message + suggestions + exit code 124 all surface correctly

## Scope

- Bug has been live since \`errors.Join\` was introduced in \`walker.go\` (the multi-root walker landing). Only surfaced now because the user ran the CLI against a tree large enough to actually trip the timeout.
- Patch-level fix; no API change, no new attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)