### PR TITLE
chore(ci): bump artifact actions to Node 24 (upload-artifact@v7, download-artifact@v8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           strip -x file-search-on-ocr-helper
           file file-search-on-ocr-helper
           ls -la file-search-on-ocr-helper
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ocr-helper
           path: file-search-on-ocr-helper
@@ -47,7 +47,7 @@ jobs:
           go-version: "1.26.2"
           cache: true
       - name: Download OCR helper artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ocr-helper
           path: dist-extra/


### PR DESCRIPTION
## Summary

GitHub is retiring the Node 20 runtime on Actions runners — default flips to Node 24 on **2026-06-02**, Node 20 fully removed **2026-09-16**. Our v0.54.0 and v0.54.1 release runs surfaced deprecation warnings for the two Node-20-era references in the repo: \`actions/upload-artifact@v4\` and \`actions/download-artifact@v4\`. This PR bumps both to the Node-24-default majors.

| Action | Before | After |
|---|---|---|
| \`actions/upload-artifact\` | \`v4\` | \`v7\` |
| \`actions/download-artifact\` | \`v4\` | \`v8\` |

## Breaking-change review

Both bumps cross multiple majors. Checked release notes for v5–v8 of each; our usage (single named artifact, no \`archive: false\`, no digest manipulation) is unaffected:

**upload-artifact:**
- v5: Node 24 support added (optional).
- v6: Default to Node 24; requires runner ≥ 2.327.1 (hosted runners auto-update).
- v7: ESM module (transparent), optional direct-file uploads via \`archive: false\` (we don't use it).

**download-artifact:**
- v5: Path-behavior change for downloads-by-ID (we download by name — not affected).
- v6: Node 24 added (optional).
- v7: Default Node 24.
- v8: ESM module, hash-mismatch errors by default (we don't manipulate digests), \`skip-decompress\` option for direct downloads (we don't use it).

## Audit

\`\`\`
$ python3 .claude/skills/gh-actions-node24-migration/scripts/audit.py .
Summary: 15 node24
\`\`\`

All 15 \`uses:\` references in our workflows are now on Node 24.

## Pin style

Used tag-major (\`@v7\`, \`@v8\`) rather than full patch — matches the surrounding workflows including \`fuzz.yml\`'s existing \`actions/upload-artifact@v7\`. Dependabot's existing config will auto-bump within the major.

## Test plan

- [ ] CI green on this PR.
- [ ] Post-merge, the next release tag exercises both actions; confirm the workflow runs cleanly without the Node 20 deprecation annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)