### PR TITLE
feat(cmd): organize subcommand — templated symlink/copy trees (closes #209)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ file-search-on -d .                                   # empty expression matches
 | `archive-contents <path> [--expr]` | List or filter entries inside ZIP / TAR / TAR.GZ / GZIP — full CEL vocabulary on per-entry attributes | [examples/archive-search.md](./examples/archive-search.md) |
 | `archive-read <path> <entry>` | Read a single entry's bytes out of an archive without extracting | [examples/archive-search.md](./examples/archive-search.md) |
 | `find-matches <re> --expr <cel> -C N` | Line-level regex hits with context | [examples/find-matches.md](./examples/find-matches.md) |
+| `organize <expr> --link-into <template>` | Build a templated symlink / copy tree from results — `{raw_vendor}/{taken_at_year}/{basename}` etc. | [examples/organize.md](./examples/organize.md) |
 | `lines <path> --start --end` | Print a line range | [examples/read-lines.md](./examples/read-lines.md) |
 | `detect-project [dir]` | Identify project type(s) of a directory | [examples/projects.md](./examples/projects.md) |
 | `find-projects [root]` | Walk a tree listing every project subdirectory | [examples/projects.md](./examples/projects.md) |
@@ -266,6 +267,7 @@ Focused recipe collections live under [`examples/`](./examples/):
 | [`examples/read-lines.md`](./examples/read-lines.md) | Print a specific line range from a file — pairs with `search` to fetch match context |
 | [`examples/duplicates.md`](./examples/duplicates.md) | Find byte-identical files by sha256 — `file-search-on duplicates [--min-size N]` |
 | [`examples/near-duplicates.md`](./examples/near-duplicates.md) | Find SIMILAR files by SimHash fingerprint — `file-search-on near-duplicates --threshold 0.85` |
+| [`examples/organize.md`](./examples/organize.md) | Organize by query — templated symlink / copy trees from search results (`organize … --link-into '{raw_vendor}/{taken_at_year}/{basename}'`) |
 
 A handful of representative one-liners:
 

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -58,6 +58,7 @@ var CLI struct {
 	ArchiveContents ArchiveContentsCmd `cmd:"" name:"archive-contents" help:"List or filter entries inside a ZIP / TAR / TAR.GZ / GZIP archive. Per-entry CEL evaluation against the SAME vocabulary the top-level search uses — every is_X predicate and per-family attribute applies inside archives."`
 	ArchiveRead     ArchiveReadCmd     `cmd:"" name:"archive-read" help:"Read a single file's content out of a ZIP / TAR / TAR.GZ / GZIP archive without extracting. Returns the bytes plus detected content_type + attributes."`
 	FindMatches     FindMatchesCmd     `cmd:"" name:"find-matches" help:"Scan text files for an RE2 regex; report line-level hits with optional context windows (combines CEL type-pruning with grep-style output)."`
+	Organize        OrganizeCmd        `cmd:"" name:"organize" help:"Build a templated symlink (or copy) tree from search results — a virtual organized view of a flat directory without moving the originals. e.g. organize 'is_raw_photo' --link-into '~/sorted/{raw_vendor}/{mtime_year}/{basename}'."`
 	Detect          DetectProjectCmd   `cmd:"" name:"detect-project" help:"Identify project type(s) (go / node / rust / …) for a directory by checking canonical indicator files."`
 	Projects        FindProjectsCmd    `cmd:"" name:"find-projects" help:"Walk a root and list every project subdirectory under it."`
 	WhichProject    WhichProjectCmd    `cmd:"" name:"which-project" help:"Given a file or directory path, walk up the chain and identify the nearest enclosing project root and type(s)."`

--- a/cmd/file-search-on/organize_cmd.go
+++ b/cmd/file-search-on/organize_cmd.go
@@ -1,0 +1,356 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	contentpkg "github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// OrganizeCmd builds a templated symlink (or copy) tree from search
+// results — a "virtual organized view" of a flat directory without
+// touching the originals. Issue #209.
+//
+//	file-search-on organize 'is_raw_photo' \
+//	  --link-into '~/sorted/{raw_vendor}/{mtime_year}/{basename}' -d ~/Pictures
+//
+// The --link-into template uses {token} brace syntax (friendlier than
+// Go text/template for paths). Tokens resolve against the matched
+// file's attributes; literal "/" in the template are real path
+// separators, while substituted token VALUES are sanitised so a
+// stray slash (e.g. in content_type) can't inject extra nesting.
+type OrganizeCmd struct {
+	Expr     string   `arg:"" optional:"" help:"CEL expression selecting which files to organize (e.g. 'is_raw_photo'). Empty matches everything."`
+	LinkInto string   `name:"link-into" required:"" help:"Destination path template using {token} placeholders. Tokens: {basename} {stem} {ext} {dir} {content_type} {size}; time buckets {mtime_year|month|day} {taken_at_year|month|day} {created_at_*} {sent_at_*}; and any file attribute by its CEL name ({camera_make}, {raw_vendor}, {language}, {ocr_language}, …). Empty / missing tokens become 'unknown'. A leading ~/ expands to your home dir. Example: '~/sorted/{raw_vendor}/{mtime_year}/{basename}'."`
+	Dir      []string `short:"d" name:"dir" default:"." help:"Directory to search. Repeatable."`
+	DryRun   bool     `name:"dry-run" help:"Print the planned source → target actions without creating anything."`
+	Copy     bool     `name:"copy-instead" help:"Copy file contents instead of symlinking. Uses real disk; the default symlink view is free and resolves back to the original."`
+	OnConflict string `name:"on-conflict" enum:"skip,overwrite,number" default:"skip" help:"What to do when the target path already exists: skip (leave it, default) | overwrite (replace) | number (append ' (1)', ' (2)', … before the extension)."`
+
+	Workers          int      `short:"w" name:"workers" default:"0" help:"Parallel walker workers. 0 = NumCPU."`
+	IndexPath        string   `name:"index-path" help:"Persistent attribute index (bbolt) — speeds repeat organizes over the same tree."`
+	Exclude          []string `name:"exclude" help:"Basename glob to prune from the walk. Repeatable."`
+	RespectGitignore bool     `name:"respect-gitignore" help:"Honour a .gitignore at each walk root."`
+	PruneArtefacts   bool     `name:"prune-build-artefacts" help:"Prune vendor / node_modules / target / __pycache__ etc. for detected project types."`
+	FollowSymlinks   bool     `name:"follow-symlinks" help:"Descend through directory symlinks during the walk."`
+	OCR              bool     `name:"ocr" help:"Run OCR over images so {ocr_language} / {ocr_confidence} tokens resolve (macOS Vision). No-op where no OCR provider is registered."`
+	WithPHash        bool     `name:"with-phash" help:"Compute perceptual hashes so {phash} resolves."`
+	Body             bool     `name:"body" help:"Read file bodies (needed only if the selecting expression uses body.contains / has_secrets / etc.)."`
+	Output           string   `short:"o" name:"output" enum:"default,bare" default:"default" help:"default (per-action lines + summary footer) | bare (target paths only)."`
+}
+
+// tokenPattern matches {snake_case_token} placeholders in the template.
+var tokenPattern = regexp.MustCompile(`\{([a-zA-Z0-9_]+)\}`)
+
+func (o *OrganizeCmd) Run(ctx context.Context) error {
+	expr := o.Expr
+	if expr == "" {
+		expr = "true"
+	}
+
+	idx, err := openIndex(o.IndexPath, index.BodyCacheCap{})
+	if err != nil {
+		return err
+	}
+	if idx != nil {
+		defer func() { _ = idx.Close() }()
+	}
+
+	opts := search.Options{
+		Roots:               o.Dir,
+		Expr:                expr,
+		Workers:             o.Workers,
+		IncludeAttributes:   true, // organize needs Extra for template tokens
+		Index:               idx,
+		IncludeBody:         o.Body,
+		OCRImages:           o.OCR,
+		WithPHash:           o.WithPHash || strings.Contains(expr, "image_similar_to"),
+		Excludes:            o.Exclude,
+		RespectGitignore:    o.RespectGitignore,
+		FollowSymlinks:      o.FollowSymlinks,
+		PruneBuildArtefacts: o.PruneArtefacts,
+	}
+
+	results, err := search.Walk(ctx, opts, contentpkg.DefaultRegistry())
+	if err != nil {
+		return err
+	}
+
+	var created, skipped, failed int
+	for _, r := range results {
+		target, terr := o.renderTarget(r)
+		if terr != nil {
+			fmt.Fprintf(os.Stderr, "skip (template): %s: %v\n", r.Path, terr)
+			failed++
+			continue
+		}
+
+		// Resolve the final target, applying the conflict policy.
+		finalTarget, action := o.resolveConflict(target)
+		if action == actionSkip {
+			if o.Output != "bare" {
+				fmt.Fprintf(os.Stderr, "skip (exists): %s\n", target)
+			}
+			skipped++
+			continue
+		}
+
+		if o.DryRun {
+			o.printAction(r.Path, finalTarget, true)
+			created++
+			continue
+		}
+
+		if err := o.materialize(r.Path, finalTarget, action); err != nil {
+			fmt.Fprintf(os.Stderr, "fail: %s -> %s: %v\n", r.Path, finalTarget, err)
+			failed++
+			continue
+		}
+		o.printAction(r.Path, finalTarget, false)
+		created++
+	}
+
+	var verb string
+	switch {
+	case o.DryRun && o.Copy:
+		verb = "would copy"
+	case o.DryRun:
+		verb = "would link"
+	case o.Copy:
+		verb = "copied"
+	default:
+		verb = "linked"
+	}
+	fmt.Fprintf(os.Stderr, "%s %d, skipped %d, failed %d\n", verb, created, skipped, failed)
+	if failed > 0 {
+		return &exitCodeError{code: 1}
+	}
+	return nil
+}
+
+func (o *OrganizeCmd) printAction(src, target string, dry bool) {
+	if o.Output == "bare" {
+		fmt.Println(target)
+		return
+	}
+	arrow := "->"
+	prefix := ""
+	if dry {
+		prefix = "[dry-run] "
+	}
+	fmt.Printf("%s%s %s %s\n", prefix, src, arrow, target)
+}
+
+// renderTarget expands the --link-into template against a single
+// result, substituting + sanitising {token} placeholders and
+// expanding a leading ~/.
+func (o *OrganizeCmd) renderTarget(r search.Result) (string, error) {
+	out := tokenPattern.ReplaceAllStringFunc(o.LinkInto, func(tok string) string {
+		name := tok[1 : len(tok)-1] // strip { }
+		return sanitizeComponent(resolveToken(name, r))
+	})
+	if out == "" {
+		return "", fmt.Errorf("template rendered to empty path")
+	}
+	return expandHome(out), nil
+}
+
+// resolveToken maps a template token to its string value for a given
+// result. Unknown / empty tokens return "" (the caller sanitises that
+// to "unknown").
+func resolveToken(name string, r search.Result) string {
+	base := filepath.Base(r.Path)
+	switch name {
+	case "basename":
+		return base
+	case "ext":
+		e := strings.TrimPrefix(filepath.Ext(base), ".")
+		if e == "" {
+			return "none"
+		}
+		return e
+	case "stem":
+		return strings.TrimSuffix(base, filepath.Ext(base))
+	case "dir":
+		return filepath.Base(filepath.Dir(r.Path))
+	case "content_type":
+		return r.ContentType
+	case "size":
+		return fmt.Sprintf("%d", r.Size)
+	}
+	// Time buckets — mtime_year, taken_at_month, created_at_day, …
+	if attr, layout, ok := organizeTimeBucket(name); ok {
+		t := pullResultTime(r, attr)
+		if t.IsZero() {
+			return ""
+		}
+		return t.Format(layout)
+	}
+	// Anything else: look it up in the attribute Extra map.
+	if r.Attrs != nil && r.Attrs.Extra != nil {
+		if v, ok := r.Attrs.Extra[name]; ok {
+			return fmt.Sprintf("%v", v)
+		}
+	}
+	return ""
+}
+
+// organizeTimeBucket mirrors search.timeBucketSpec (unexported there)
+// for the template token vocabulary: <attr>_<year|month|day>.
+func organizeTimeBucket(name string) (attr, layout string, ok bool) {
+	for _, prefix := range []string{"mtime", "created_at", "metadata_changed_at", "taken_at", "sent_at", "date"} {
+		for _, g := range []struct{ suffix, layout string }{
+			{"_year", "2006"},
+			{"_month", "2006-01"},
+			{"_day", "2006-01-02"},
+		} {
+			if name == prefix+g.suffix {
+				return prefix, g.layout, true
+			}
+		}
+	}
+	return "", "", false
+}
+
+// pullResultTime resolves a named time attribute on a result. mtime /
+// created_at / metadata_changed_at read FileAttributes fields directly;
+// taken_at / sent_at / date come from the Extra map as time.Time.
+func pullResultTime(r search.Result, attr string) time.Time {
+	if r.Attrs == nil {
+		return time.Time{}
+	}
+	switch attr {
+	case "mtime":
+		return r.Attrs.ModTime
+	case "created_at":
+		return r.Attrs.CreatedAt
+	case "metadata_changed_at":
+		return r.Attrs.MetadataChangedAt
+	}
+	if r.Attrs.Extra == nil {
+		return time.Time{}
+	}
+	if t, ok := r.Attrs.Extra[attr].(time.Time); ok {
+		return t
+	}
+	return time.Time{}
+}
+
+// sanitizeComponent makes a resolved token value safe as a single
+// path component: empty -> "unknown", path separators -> "-", and
+// trailing/leading dots that would create hidden / traversal segments
+// neutralised.
+func sanitizeComponent(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "unknown"
+	}
+	s = strings.ReplaceAll(s, "/", "-")
+	s = strings.ReplaceAll(s, string(os.PathSeparator), "-")
+	s = strings.ReplaceAll(s, "\x00", "")
+	if s == "." || s == ".." {
+		return "unknown"
+	}
+	return s
+}
+
+// expandHome expands a leading ~/ to the user's home directory.
+func expandHome(path string) string {
+	if path == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return path
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}
+
+type conflictAction int
+
+const (
+	actionCreate conflictAction = iota
+	actionOverwrite
+	actionSkip
+)
+
+// resolveConflict inspects the target path and returns the (possibly
+// adjusted) final path + the action to take per the --on-conflict
+// policy.
+func (o *OrganizeCmd) resolveConflict(target string) (string, conflictAction) {
+	if _, err := os.Lstat(target); err != nil {
+		return target, actionCreate // doesn't exist
+	}
+	switch o.OnConflict {
+	case "overwrite":
+		return target, actionOverwrite
+	case "number":
+		return numberedPath(target), actionCreate
+	default: // skip
+		return target, actionSkip
+	}
+}
+
+// numberedPath finds the first non-existent "<stem> (N)<ext>" variant.
+func numberedPath(target string) string {
+	ext := filepath.Ext(target)
+	stem := strings.TrimSuffix(target, ext)
+	for n := 1; n < 100000; n++ {
+		cand := fmt.Sprintf("%s (%d)%s", stem, n, ext)
+		if _, err := os.Lstat(cand); err != nil {
+			return cand
+		}
+	}
+	return target // pathological; let materialize fail loudly
+}
+
+// materialize creates the parent directory then the symlink / copy.
+func (o *OrganizeCmd) materialize(src, target string, action conflictAction) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+	if action == actionOverwrite {
+		if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if o.Copy {
+		return copyFile(src, target)
+	}
+	// Symlink with an ABSOLUTE source so the link resolves regardless
+	// of where the target tree lives relative to the source.
+	absSrc, err := filepath.Abs(src)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(absSrc, target)
+}
+
+func copyFile(src, target string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.Create(target)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/cmd/file-search-on/organize_cmd_test.go
+++ b/cmd/file-search-on/organize_cmd_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+func TestResolveToken(t *testing.T) {
+	mod := time.Date(2024, 7, 15, 10, 30, 0, 0, time.UTC)
+	taken := time.Date(2019, 3, 2, 8, 0, 0, 0, time.UTC)
+	r := search.Result{
+		Path:        "/photos/IMG_1234.HEIC",
+		ContentType: "image/heic",
+		Size:        4096,
+		Attrs: &celexpr.FileAttributes{
+			ModTime: mod,
+			Extra: map[string]any{
+				"camera_make": "Canon",
+				"taken_at":    taken,
+			},
+		},
+	}
+	cases := []struct {
+		token, want string
+	}{
+		{"basename", "IMG_1234.HEIC"},
+		{"stem", "IMG_1234"},
+		{"ext", "HEIC"},
+		{"dir", "photos"},
+		{"content_type", "image/heic"}, // sanitised by caller, not here
+		{"size", "4096"},
+		{"mtime_year", "2024"},
+		{"mtime_month", "2024-07"},
+		{"mtime_day", "2024-07-15"},
+		{"taken_at_year", "2019"},
+		{"camera_make", "Canon"},
+		{"nonexistent", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.token, func(t *testing.T) {
+			if got := resolveToken(tc.token, r); got != tc.want {
+				t.Errorf("resolveToken(%q) = %q, want %q", tc.token, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeComponent(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Canon", "Canon"},
+		{"", "unknown"},
+		{"   ", "unknown"},
+		{"image/heic", "image-heic"},
+		{".", "unknown"},
+		{"..", "unknown"},
+		{"a/b/c", "a-b-c"},
+	}
+	for _, tc := range cases {
+		if got := sanitizeComponent(tc.in); got != tc.want {
+			t.Errorf("sanitizeComponent(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRenderTarget(t *testing.T) {
+	o := &OrganizeCmd{LinkInto: "/out/{camera_make}/{mtime_year}/{basename}"}
+	r := search.Result{
+		Path: "/photos/shot.jpg",
+		Attrs: &celexpr.FileAttributes{
+			ModTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			Extra:   map[string]any{"camera_make": "Nikon"},
+		},
+	}
+	got, err := o.renderTarget(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "/out/Nikon/2024/shot.jpg"
+	if got != want {
+		t.Errorf("renderTarget = %q, want %q", got, want)
+	}
+
+	// Missing camera_make → "unknown" bucket.
+	r2 := search.Result{Path: "/photos/x.jpg", Attrs: &celexpr.FileAttributes{ModTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), Extra: map[string]any{}}}
+	got2, _ := o.renderTarget(r2)
+	if got2 != "/out/unknown/2024/x.jpg" {
+		t.Errorf("renderTarget (missing) = %q, want /out/unknown/2024/x.jpg", got2)
+	}
+}
+
+// TestOrganizeEndToEnd walks a synthetic tree and confirms the symlink
+// view is created with the templated structure.
+func TestOrganizeEndToEnd(t *testing.T) {
+	src := t.TempDir()
+	// Two markdown files, one JSON.
+	mustWrite(t, filepath.Join(src, "a.md"), "# A\n")
+	mustWrite(t, filepath.Join(src, "b.md"), "# B\n")
+	mustWrite(t, filepath.Join(src, "c.json"), `{"x":1}`)
+
+	out := t.TempDir()
+	o := &OrganizeCmd{
+		Expr:       "is_markdown",
+		LinkInto:   filepath.Join(out, "{content_type}", "{basename}"),
+		Dir:        []string{src},
+		OnConflict: "skip",
+		Output:     "default",
+	}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Two markdown files should be linked under out/markdown/.
+	for _, name := range []string{"a.md", "b.md"} {
+		link := filepath.Join(out, "markdown", name)
+		fi, err := os.Lstat(link)
+		if err != nil {
+			t.Errorf("expected symlink %s: %v", link, err)
+			continue
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("%s is not a symlink", link)
+		}
+		// Resolves back to the original.
+		resolved, err := filepath.EvalSymlinks(link)
+		if err != nil {
+			t.Errorf("EvalSymlinks(%s): %v", link, err)
+			continue
+		}
+		wantSrc, _ := filepath.EvalSymlinks(filepath.Join(src, name))
+		if resolved != wantSrc {
+			t.Errorf("%s resolves to %s, want %s", link, resolved, wantSrc)
+		}
+	}
+
+	// The JSON file should NOT be organized (filtered out by is_markdown).
+	if _, err := os.Lstat(filepath.Join(out, "json", "c.json")); err == nil {
+		t.Errorf("c.json should not have been organized")
+	}
+}
+
+func TestOrganizeDryRunCreatesNothing(t *testing.T) {
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "a.md"), "# A\n")
+	out := t.TempDir()
+
+	o := &OrganizeCmd{
+		Expr:     "is_markdown",
+		LinkInto: filepath.Join(out, "{basename}"),
+		Dir:      []string{src},
+		DryRun:   true,
+		Output:   "default",
+	}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(out, "a.md")); err == nil {
+		t.Errorf("dry-run should not create the symlink")
+	}
+}
+
+func TestOrganizeCopyInstead(t *testing.T) {
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "a.md"), "# hello\n")
+	out := t.TempDir()
+
+	o := &OrganizeCmd{
+		Expr:     "is_markdown",
+		LinkInto: filepath.Join(out, "{basename}"),
+		Dir:      []string{src},
+		Copy:     true,
+		Output:   "default",
+	}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	target := filepath.Join(out, "a.md")
+	fi, err := os.Lstat(target)
+	if err != nil {
+		t.Fatalf("expected copied file: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("--copy-instead produced a symlink, want a regular file")
+	}
+	data, _ := os.ReadFile(target)
+	if string(data) != "# hello\n" {
+		t.Errorf("copied content = %q, want %q", data, "# hello\n")
+	}
+}
+
+func TestOrganizeConflictNumber(t *testing.T) {
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "a.md"), "# A\n")
+	out := t.TempDir()
+	// Pre-create the target so the first link collides.
+	collide := filepath.Join(out, "a.md")
+	mustWrite(t, collide, "existing\n")
+
+	o := &OrganizeCmd{
+		Expr:       "is_markdown",
+		LinkInto:   filepath.Join(out, "{basename}"),
+		Dir:        []string{src},
+		OnConflict: "number",
+		Output:     "default",
+	}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Original untouched; numbered variant created.
+	if data, _ := os.ReadFile(collide); string(data) != "existing\n" {
+		t.Errorf("original target was clobbered")
+	}
+	if _, err := os.Lstat(filepath.Join(out, "a (1).md")); err != nil {
+		t.Errorf("expected numbered variant 'a (1).md': %v", err)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/examples/organize.md
+++ b/examples/organize.md
@@ -1,0 +1,121 @@
+# Recipes — Organize by query
+
+`file-search-on organize` builds a **templated symlink (or copy) tree** from search results — a virtual organized *view* of a flat directory without moving or touching the originals. Git-safe, undo-safe (delete the view, the source is untouched), and cheap (symlinks are free).
+
+```sh
+file-search-on organize '<expr>' --link-into '<template>' [flags] -d <root>
+```
+
+## The `--link-into` template
+
+The destination is a `{token}` brace template. Literal `/` are real path separators; `{token}` placeholders are substituted per file. Token values are sanitised (a `/` inside a value becomes `-`, empty values become `unknown`) so a stray separator can't inject extra nesting. A leading `~/` expands to your home directory.
+
+**Path / file tokens:**
+
+| Token | Value |
+|---|---|
+| `{basename}` | Full filename (`IMG_1234.HEIC`) |
+| `{stem}` | Filename without extension (`IMG_1234`) |
+| `{ext}` | Extension without dot (`heic`); `none` when extensionless |
+| `{dir}` | Parent directory's basename |
+| `{content_type}` | e.g. `image-heic` (slash sanitised) |
+| `{size}` | Byte size |
+
+**Time-bucket tokens** (`<attr>_<year|month|day>`): `{mtime_year}`, `{mtime_month}`, `{mtime_day}`, plus `taken_at_*`, `created_at_*`, `metadata_changed_at_*`, `sent_at_*`, `date_*`. Empty when the file has no such timestamp → `unknown`.
+
+**Any attribute by its CEL name:** `{camera_make}`, `{camera_model}`, `{raw_vendor}`, `{language}`, `{ocr_language}`, `{license_id}`, `{project_type}`, … — anything that shows up in `file-search-on --list` resolves here.
+
+## Photo libraries
+
+```sh
+# RAW masters sorted by vendor then shoot-year
+file-search-on organize 'is_raw_photo' \
+  --link-into '~/sorted/raw/{raw_vendor}/{taken_at_year}/{basename}' -d ~/Pictures
+
+# Every photo grouped by the camera that took it
+file-search-on organize 'is_image' \
+  --link-into '~/by-camera/{camera_make}/{camera_model}/{basename}' -d ~/Pictures
+
+# Photos by the year + month they were SHOT (taken_at), not modified
+file-search-on organize 'is_image && taken_at_year != ""' \
+  --link-into '~/timeline/{taken_at_year}/{taken_at_month}/{basename}' -d ~/Pictures
+```
+
+> Note `{mtime_year}` is the file's modification time; `{taken_at_year}` is the EXIF capture date. For "when did I shoot this?" use `taken_at_*`.
+
+## Code + documents
+
+```sh
+# Source files bucketed by language
+file-search-on organize 'is_source' \
+  --link-into '~/code-by-lang/{language}/{basename}' -d ~/Code
+
+# Markdown drafts vs published, by front-matter draft flag
+file-search-on organize 'is_markdown' \
+  --link-into '~/posts/{frontmatter_format}/{basename}' -d ~/blog
+```
+
+## Screenshots by detected language (with OCR)
+
+```sh
+file-search-on organize 'is_image' --ocr \
+  --link-into '~/screenshots-by-lang/{ocr_language}/{basename}' -d ~/Desktop
+```
+
+`--ocr` runs the OCR provider so `{ocr_language}` resolves (macOS Vision today; no-op on platforms without a provider).
+
+## Preview first — `--dry-run`
+
+Always safe to preview. Prints the planned `source -> target` actions and a summary, creating nothing:
+
+```sh
+file-search-on organize 'is_raw_photo' \
+  --link-into '~/sorted/{raw_vendor}/{basename}' -d ~/Pictures --dry-run
+```
+
+```
+[dry-run] /Users/me/Pictures/a.cr2 -> /Users/me/sorted/canon/a.cr2
+[dry-run] /Users/me/Pictures/b.nef -> /Users/me/sorted/nikon/b.nef
+would link 2, skipped 0, failed 0
+```
+
+## Symlink vs copy
+
+The default creates **symlinks** (absolute, so they resolve regardless of where the view lives). Pass `--copy-instead` to materialise real file copies — useful when the view needs to survive the source being moved, or to hand someone a self-contained folder:
+
+```sh
+file-search-on organize 'is_image && taken_at_year == "2024"' \
+  --link-into '~/2024-export/{basename}' --copy-instead -d ~/Pictures
+```
+
+## Collision handling — `--on-conflict`
+
+When two source files render to the same target path (e.g. same basename from different folders):
+
+| Mode | Behaviour |
+|---|---|
+| `skip` (default) | Leave the existing target, skip the new one |
+| `overwrite` | Replace the existing target |
+| `number` | Append ` (1)`, ` (2)`, … before the extension |
+
+```sh
+# Keep every collision as a numbered variant
+file-search-on organize 'is_image' \
+  --link-into '~/flat/{basename}' --on-conflict number -d ~/Pictures/nested
+```
+
+## Composes with the walk flags
+
+`organize` shares the walk machinery, so the usual pruning / filtering applies: `--exclude`, `--respect-gitignore`, `--prune-build-artefacts`, `--follow-symlinks`, `--index-path` (cache the attribute parse across repeat organizes), `-w` workers, and `--body` (only needed if the selecting expression uses `body.contains` / `has_secrets` / etc.).
+
+```sh
+file-search-on organize 'is_source && has_secrets(body)' --body \
+  --link-into '~/quarantine/{basename}' --prune-build-artefacts -d ~/Code
+```
+
+## Known limitations
+
+- **Read-only view.** The symlink/copy tree is a one-way projection. Editing through a symlink edits the original (expected); editing a `--copy-instead` file does NOT propagate back. There's no sync.
+- **No Finder-tag / xattr-based organisation.** Tokens resolve from parsed attributes, not macOS tags. (Tag-based organising is a possible follow-up.)
+- **Case-insensitive filesystems.** On default macOS / Windows volumes, `{camera_make}` values differing only in case (`Canon` vs `canon`) collapse into one directory. Usually what you want; noted for completeness.
+- **`organize` is CLI-only.** It's a filesystem-mutating command, intentionally not exposed as an MCP tool.


### PR DESCRIPTION
Closes #209.

## Summary

A new `organize` subcommand that builds a **virtual organized view** of a flat directory from search results — without moving or touching the originals.

```sh
file-search-on organize 'is_raw_photo' \
  --link-into '~/sorted/{raw_vendor}/{taken_at_year}/{basename}' -d ~/Pictures
```

Default creates symlinks (free, resolve back to source); `--copy-instead` materialises real copies.

## `--link-into` template

`{token}` brace syntax — friendlier than Go text/template for paths. Literal `/` are real separators; substituted token **values** are sanitised (embedded `/` → `-`, empty → `unknown`, `.`/`..` → `unknown`) so a stray slash can't inject extra nesting or a traversal segment. Leading `~/` expands to `$HOME`.

| Token class | Examples |
|---|---|
| Path / file | `{basename}` `{stem}` `{ext}` `{dir}` `{content_type}` `{size}` |
| Time buckets | `{mtime_year}` `{taken_at_month}` `{created_at_day}` … (`<attr>_<year\|month\|day>`) |
| Any attribute | `{camera_make}` `{raw_vendor}` `{language}` `{ocr_language}` … (by CEL name, via the Extra map) |

## Safety

- **`--dry-run`** prints `source -> target` actions, creates nothing.
- **`--on-conflict`** `skip` (default) / `overwrite` / `number` (`name (1).ext`).
- Symlinks use an **absolute** source, so the view resolves regardless of where it lives.
- **CLI-only** by design — a filesystem-mutating command shouldn't be an MCP tool.
- Shares the walk flags: `--exclude`, `--respect-gitignore`, `--prune-build-artefacts`, `--follow-symlinks`, `--index-path`, `-w`, `--ocr` (for `{ocr_language}`), `--with-phash`, `--body`.

## End-to-end (verified on the SA photos dataset)

```
$ file-search-on organize 'is_image' \
    --link-into '/tmp/out/{camera_make}/{mtime_year}/{basename}' -d ~/Pictures/south-africa-holiday
…
linked 43, skipped 0, failed 0

$ find /tmp/out -maxdepth 2 -type d
/tmp/out/Apple/2026
/tmp/out/Canon/2026
/tmp/out/Nikon/2026
/tmp/out/Panasonic/2026
/tmp/out/unknown/2026     # files with no camera_make EXIF
…
$ ls -l /tmp/out/Apple/2026/table-mountain_Samburu_Sunrise.jpg
… -> /Users/me/Pictures/south-africa-holiday/table-mountain_Samburu_Sunrise.jpg
```

## Tests

`organize_cmd_test.go`: token resolution (path / time-bucket / Extra / missing), sanitisation, full template render, end-to-end symlink-tree creation (with filter + resolve-back-to-original assertions), dry-run-creates-nothing, `--copy-instead` produces a real file, `--on-conflict number` leaves the original intact and creates the numbered variant.

## Docs

README subcommand table + examples index; new `examples/organize.md` with the full token reference, photo-library / code / OCR / copy / collision recipes, and documented limitations.

## Out of scope (per the issue)

Bidirectional sync, Finder-tag organisation, iCloud / network-drive collision quirks.

## Test plan

- [ ] CI green (vet / fix / lint / test; cross-platform compile clean).
- [ ] Manual: `organize 'is_raw_photo' --link-into '~/sorted/{raw_vendor}/{basename}' --dry-run` previews; drop `--dry-run` and confirm the tree + symlink resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)