### PR TITLE
chore(skills): fix staleness in add-content-type + extend-cel-schema (closes #219)

### DIFF
--- a/.claude/skills/add-content-type/SKILL.md
+++ b/.claude/skills/add-content-type/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: add-content-type
-description: Registers a new file-format content type in file-search-on by creating a file under `internal/content/` that implements the four-method `ContentType` interface (`Name`, `Extensions`, `MagicBytes`, `Attributes`), self-registers via `init()` calling `content.Register(...)`, and for image variants extends the `BuildAttributes` `image/*` prefix branch in `internal/celexpr/evaluator.go` — covers CSV, YAML, plain-text, EPUB, new audio/image families, and similar formats. Use when adding support for a new file format so the search recognises it and reports a `content_type`; does NOT cover CEL attribute wiring for type-specific attributes, which is the `extend-cel-schema` skill's job.
+description: Registers a new file-format content type in file-search-on by creating a file under `internal/content/` that implements the four-method `ContentType` interface (`Name`, `Extensions`, `MagicBytes`, `Attributes(ctx, fsys, path)`), self-registers via `init()` calling `content.Register(...)`, and for image variants relies on the `image/` prefix block in `setTypeFlags` (`internal/celexpr/evaluator.go`) — covers CSV, YAML, plain-text, EPUB, new audio/image families, and similar formats. Use when adding support for a new file format so the search recognises it and reports a `content_type`; does NOT cover CEL attribute wiring for type-specific attributes, which is the `extend-cel-schema` skill's job.
 ---
 
 # Add Content Type
 
-A "content type" is anything `Detect()` can identify and `Walk` can tag. Registering one is mostly mechanical: drop a file in `internal/content/`, implement four methods, register it, done. The wrinkle is the `Attributes(path)` method — if it returns *any* type-specific keys, you also need the `extend-cel-schema` workflow to make those keys CEL-visible.
+A "content type" is anything `Detect()` can identify and `Walk` can tag. Registering one is mostly mechanical: drop a file in `internal/content/`, implement four methods, register it, done. The wrinkle is the `Attributes(ctx, fsys, path)` method — if it returns *any* type-specific keys, you also need the `extend-cel-schema` workflow to make those keys CEL-visible.
 
 ## What gets registered
 
@@ -31,7 +31,7 @@ For a type like CSV that you want detected but where you don't (yet) care about 
 
 ## Quick start (with attributes)
 
-If `Attributes(path)` returns type-specific keys (e.g. `csv_columns`, `csv_rows`):
+If `Attributes(ctx, fsys, path)` returns type-specific keys (e.g. `csv_columns`, `csv_rows`):
 
 1. Steps 1–3 as above, but make `Attributes` return the keys.
 2. **Then** run the `extend-cel-schema` skill for *each* new key — declare the CEL variable, add to the activation defaults, add a switch case, and document in `Schema()`.
@@ -43,33 +43,33 @@ If `Attributes(path)` returns type-specific keys (e.g. `csv_columns`, `csv_rows`
 
 ```go
 type ContentType interface {
-    Name() string                                                      // stable identifier; image family must use "image/<subtype>"
-    Extensions() []string                                              // lowercase, with leading dot, e.g. []string{".csv"}
-    MagicBytes() [][]byte                                              // each entry is a prefix to match against the first 512 bytes; nil if not used
-    Attributes(ctx context.Context, path string) (Attributes, error)   // called per matching file; return a map[string]any, never nil
+    Name() string                                                                 // stable identifier; image family must use "image/<subtype>"
+    Extensions() []string                                                         // lowercase, with leading dot, e.g. []string{".csv"}
+    MagicBytes() [][]byte                                                         // each entry is a prefix to match against the first 512 bytes; nil if not used
+    Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error)  // called per matching file; read via fsys, not os; return a map[string]any, never nil
 }
 ```
 
 Semantic notes:
 
-- **`Name()`** — used by `BuildAttributes` to set the `is_*` flag and the `content_type` CEL attribute. For an image family, the name MUST start with `image/` (e.g. `image/avif`); for the office family, MUST start with `office/`. The corresponding `strings.HasPrefix` branch in `BuildAttributes` turns `is_image` / `is_office` on automatically.
+- **`Name()`** — used by `setTypeFlags` (in `internal/celexpr/evaluator.go`) to set the `is_*` flag and the `content_type` CEL attribute. For an image family, the name MUST start with `image/` (e.g. `image/avif`); for the office family, MUST start with `office/`. The corresponding `strings.HasPrefix(name, ...)` block in `setTypeFlags` turns `is_image` / `is_office` on automatically.
 - **`Extensions()`** — lowercase, dotted. The detector matches case-insensitively against `filepath.Ext(path)` lower-cased.
 - **`MagicBytes()`** — return `nil` (not `[][]byte{}`) if the type is detected by extension only. Each `[]byte` is a prefix; the detector matches if any prefix is a prefix of the first 512 bytes.
-- **`Attributes(ctx, path)`** — called *per matching file* during the walk. Honour ctx: check `ctx.Err()` at entry, and inside any unbounded scan/decode loop. Return `ctx.Err()` on cancellation so the walker can terminate cleanly. Avoid expensive parses without bounds (use `bufio.Scanner` with a buffer cap, decode just enough of the file to extract what you need). Return `Attributes{}` (empty) if no type-specific data; never return `nil`.
+- **`Attributes(ctx, fsys, path)`** — called *per matching file* during the walk. **Read the file through `fsys`, not `os`** — open with `fsys.Open(path)`, or use the helpers in `internal/content/fsutil.go` (`openReadSeeker` for seekable/streamed access, `openReaderAt` for `zip`/`pdf`-style random access, `readAll` for whole-file slurps). This is what lets the same parser run against real files, archive entries, and in-memory test filesystems. Honour ctx: check `ctx.Err()` at entry, and inside any unbounded scan/decode loop. Return `ctx.Err()` on cancellation. Avoid expensive parses without bounds (use `bufio.Scanner` with a buffer cap, decode just enough of the file). Return `Attributes{}` (empty) if no type-specific data; never return `nil`.
 
 ## Image-family addition
 
 When the new type is an image variant (e.g. `image/avif`):
 
 - `Name()` MUST return `image/<subtype>`.
-- `BuildAttributes` (`internal/celexpr/evaluator.go`) already has a `case strings.HasPrefix(contentTypeName, "image/")` branch — no edit needed there for new image variants. The branch sets `is_image = true` and dispatches to the registered type's `Attributes` for `width` / `height` (which are renamed to `img_width` / `img_height` by the `attrs.Extra` switch).
-- If the new image type emits *additional* attributes beyond `width` / `height` (e.g. `color_space`, `bit_depth`), each one is a CEL-schema extension — use the `extend-cel-schema` skill.
+- `setTypeFlags` (`internal/celexpr/evaluator.go`) already has an `if strings.HasPrefix(name, "image/")` block — no edit needed there for new image variants; it sets `is_image = true` automatically. The type's `Attributes` should emit `img_width` / `img_height` directly (the final CEL names — there is no rename layer; see the `extend-cel-schema` foot-guns).
+- If the new image type emits *additional* attributes beyond `img_width` / `img_height` (e.g. `color_space`, `bit_depth`), each one is a CEL-schema extension — use the `extend-cel-schema` skill.
 
 For a non-image type with its own `is_*` flag (e.g. an `audio/*` family):
 
 - Add an `IsAudio bool` field to `FileAttributes`.
-- Add the `is_audio` CEL variable via the four-place invariant (`extend-cel-schema`).
-- Add a `case strings.HasPrefix(contentTypeName, "audio/"):` branch in `BuildAttributes`.
+- Add a `case "is_audio": return a.attrs.IsAudio, true` to `ResolveName` (`activation.go`) and declare the `is_audio` CEL variable (`extend-cel-schema`).
+- Add an `if strings.HasPrefix(name, "audio/") { attrs.IsAudio = true }` block to `setTypeFlags`.
 
 ## Templates
 
@@ -77,7 +77,7 @@ For a non-image type with its own `is_*` flag (e.g. an `audio/*` family):
 
 ## References
 
-- [references/detection.md](references/detection.md) — how `Registry.Detect` works (extension-then-magic), magic-byte gotchas, and what `Attributes(path)` should and should not do during a walk.
+- [references/detection.md](references/detection.md) — how `Registry.Detect` works (extension-then-magic), magic-byte gotchas, and what `Attributes(ctx, fsys, path)` should and should not do during a walk.
 
 ## Conventions
 

--- a/.claude/skills/add-content-type/references/detection.md
+++ b/.claude/skills/add-content-type/references/detection.md
@@ -1,6 +1,6 @@
 # Content-type detection
 
-How `Registry.Detect` decides what a file is, what `Attributes(path)` should and should not do, and the gotchas that bite when adding a new type.
+How `Registry.Detect` decides what a file is, what `Attributes(ctx, fsys, path)` should and should not do, and the gotchas that bite when adding a new type.
 
 ## How `Registry.Detect` works
 
@@ -32,13 +32,13 @@ Pragmatic recommendation: start with extension-only. Add magic bytes when you ha
 - **Prefix, not substring.** The detector checks `bytes.HasPrefix(read, magic)`. A magic of `"foo"` won't match a file that starts with `"\xef\xbb\xbffoo"` (BOM-prefixed). If you need BOM tolerance, register multiple magic entries: `[]byte("foo"), []byte("\xef\xbb\xbffoo")`.
 - **Avoid super-short or super-common prefixes.** `"{"` matches every JSON file but also every file that happens to start with `{`. JSON gets away with it because almost nothing else does. CSV has no usable magic — leave `MagicBytes` as `nil`.
 
-## What `Attributes(ctx, path)` should and should not do
+## What `Attributes(ctx, fsys, path)` should and should not do
 
 `Attributes` is called *per matching file*. A search across 100k markdown files calls it 100k times. Performance and resource bounds matter.
 
 **Do:**
 
-- Open the file at `path`, decode just enough to extract what you need, close it. Use `defer f.Close()`.
+- Open the file via `fsys.Open(path)` (NOT `os.Open` — `fsys` is what makes the parser work against archive entries + in-memory test filesystems). For seekable / random-access needs use `openReadSeeker` / `openReaderAt` / `readAll` from `internal/content/fsutil.go`. Decode just enough to extract what you need, close it. Use `defer f.Close()`.
 - Use bounded buffers — `bufio.Scanner` with a sized buffer cap, `io.LimitReader` for streams that could be huge.
 - Honour `ctx`: check `ctx.Err()` at entry, and inside any unbounded scan/decode loop. Return `ctx.Err()` on cancellation. The walker treats `context.Canceled` / `context.DeadlineExceeded` as a signal to terminate the worker rather than skip-and-continue, so cancellation actually stops the search.
 - Return `Attributes{}` (empty map, not `nil`) if there's nothing type-specific to extract. The detector still records `content_type`; you don't need attributes to be useful.
@@ -48,28 +48,29 @@ Pragmatic recommendation: start with extension-only. Add magic bytes when you ha
 
 - Read or parse the entire file when you only need the first chunk. JSON's content type only reads the first token to detect `object` vs `array` — copy that pattern.
 - Ignore ctx. A pathological 1 GB log file with `bufio.Scanner` will run to completion if the loop doesn't check ctx, even after the user has cancelled. Per-iteration `ctx.Err()` is a single atomic load — well below file-I/O noise.
-- Make additional file-system calls beyond reading `path`. The walker has already passed you a stat-able path; recomputing stat or scanning siblings is wasted work.
+- Make additional file-system calls beyond reading `path` through `fsys`. The walker has already passed you the path; recomputing stat or scanning siblings is wasted work. (Path-anchored cross-file lookups — like the Live Photo sibling check — belong in a `BuildAttributesWith` hook keyed on the absolute `displayPath`, not inside a `ContentType.Attributes` working through `fsys`.)
 - Cache anything in a package-level variable. The `Attributes` call is concurrent — content types are stateless by contract. If you need a cache, scope it inside the function with a `sync.Once`-protected init, but think hard about why first.
 - Panic. The walker doesn't recover; a panicking type takes down the whole search.
 
-## Image-family branching
+## Family-prefix branching
 
-The `BuildAttributes` function in `internal/celexpr/evaluator.go` (around line 189) has a single branch that catches every image variant by name prefix:
+The `setTypeFlags` function in `internal/celexpr/evaluator.go` has a series of name-prefix `if` blocks that catch every variant of a family. For images:
 
 ```go
-case strings.HasPrefix(contentTypeName, "image/"):
-    isImage = true
+if strings.HasPrefix(name, "image/") {
+    attrs.IsImage = true
+}
 ```
 
 Adding a new image variant (e.g. `image/avif`) is therefore additive: register the type with `Name() = "image/avif"` and the `is_image` flag flips on for that variant automatically. No edit to `evaluator.go` is needed.
 
-For a brand-new family (audio, archive, …), you DO need to extend `BuildAttributes`:
+For a brand-new family (audio, archive, 3D models, …), you DO need to:
 
-1. Add a `case strings.HasPrefix(contentTypeName, "audio/"): isAudio = true` (or whatever family prefix).
-2. Add an `IsAudio bool` field to the `FileAttributes` struct in the same file.
-3. Add `is_audio` to the four-place CEL invariant (use the `extend-cel-schema` skill).
+1. Add an `IsAudio bool` field to the `FileAttributes` struct (in `evaluator.go`).
+2. Add an `if strings.HasPrefix(name, "audio/") { attrs.IsAudio = true }` block to `setTypeFlags`.
+3. Add a `case "is_audio": return a.attrs.IsAudio, true` to `ResolveName` (`internal/celexpr/activation.go`) and declare the `is_audio` `cel.Variable` (use the `extend-cel-schema` skill).
 
-The reason image is different is that it was the first family to need this pattern; if you add audio/archive/video, you're following the same template, not inventing one.
+The `model3d/`, `image/raw-`, and `font/` families are recent worked examples of this pattern.
 
 ## Verifying a new type
 

--- a/.claude/skills/add-content-type/templates/content_type.go.tmpl
+++ b/.claude/skills/add-content-type/templates/content_type.go.tmpl
@@ -1,9 +1,9 @@
 package content
 
-// REPLACE: package import this type needs (e.g. "encoding/csv", "io", "os") and remove unused imports.
+// REPLACE: package imports this type needs (e.g. "encoding/csv", "io") and remove unused imports.
 import (
 	"context"
-	"os"
+	"io/fs"
 )
 
 func init() {
@@ -32,17 +32,22 @@ func (t *<typename>Type) MagicBytes() [][]byte {
 // decode only what you need to extract the attributes you'll surface to CEL.
 // Return Attributes{} (never nil) if there are no type-specific attributes.
 //
+// Read through fsys (NOT os) so the same parser works against real files,
+// archive entries, and in-memory test filesystems. fsys.Open(path) works for
+// sequential reads; for seekable / random access use the helpers in
+// fsutil.go (openReadSeeker, openReaderAt, readAll).
+//
 // ctx must be honoured: check ctx.Err() at entry, and inside any unbounded
 // scan/decode loop. Return ctx.Err() on cancellation so the walker can
 // terminate cleanly instead of finishing this file then bailing.
 //
 // REPLACE: open the file, do the minimum work needed, return the keys. If you
 // add any keys, also follow the extend-cel-schema skill so cel-go sees them.
-func (t *<typename>Type) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (t *<typename>Type) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(path)
+	f, err := fsys.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/.claude/skills/extend-cel-schema/SKILL.md
+++ b/.claude/skills/extend-cel-schema/SKILL.md
@@ -1,52 +1,59 @@
 ---
 name: extend-cel-schema
-description: Extends file-search-on's CEL attribute schema by editing the four call sites that must move together — `cel.Variable(...)` declarations in `celexpr.New`, the activation defaults map in `Evaluate`, the `attrs.Extra` switch in `Evaluate`, and `celexpr.Schema()` — then runs an audit script that catches drift between them. Use when adding a new content-type attribute, promoting a new front-matter key like `summary` or `slug`, or extending an existing content type's attribute set; cel-go errors at runtime (not compile time) when these fall out of sync, so the audit script is the only deterministic guard.
+description: Extends file-search-on's CEL attribute schema by editing the call sites that must move together — `cel.Variable(...)` declarations in `celexpr.New` (evaluator.go), the `ResolveName` switch + `zeroDefaults` map in `activation.go`, and `celexpr.Schema()` — then runs an audit script that catches drift between them. Use when adding a new content-type attribute, promoting a new front-matter key like `summary` or `slug`, or extending an existing content type's attribute set; cel-go errors at runtime (not compile time) when these fall out of sync, so the audit script is the only deterministic guard.
 ---
 
 # Extend CEL Schema
 
-Every CEL-visible attribute in file-search-on must appear in **four** places. Drift between them produces a runtime error (`no such attribute: foo`) the moment a CEL expression references the missing piece — `go build` will not catch it. This skill makes the four-place invariant explicit and ships an audit script that reports drift.
+Every CEL-visible attribute in file-search-on must be **declared**, **resolvable**, and **documented** — three call sites that must move together. Drift between them produces a runtime error (`no such attribute: foo`) the moment a CEL expression references the missing piece — `go build` will not catch it. This skill makes the invariant explicit and ships an audit script that reports drift.
 
-## The four-place invariant
+## The invariant
 
-| # | Where | What goes there | Failure mode if missing |
-| - | --- | --- | --- |
-| 1 | `internal/celexpr/evaluator.go` — `cel.Variable("foo", cel.<Type>Type)` inside `New` | Declares the variable to cel-go | Compile error: `undeclared reference to 'foo'` |
-| 2 | `internal/celexpr/evaluator.go` — activation defaults map literal in `Evaluate` | Zero value used when the matched type didn't emit this attribute | Runtime error: `no such attribute: foo` |
-| 3 | `internal/celexpr/evaluator.go` — `attrs.Extra` switch in `Evaluate` | Maps the content-type's emitted key to the CEL variable name (often a rename, e.g. `kind` → `json_kind`) | Attribute is always its zero value — silently wrong, no error |
-| 4 | `internal/celexpr/schema.go` — entry in the right `AttributeDoc` slice | Drives both `--list` output and the MCP `list_attributes` tool | Attribute is invisible to humans and to MCP clients |
+A CEL-visible attribute must be **declared**, **resolvable**, and **documented**. Drift produces a runtime error (`no such attribute: foo`) the moment a CEL expression references the missing piece — `go build` will not catch it.
 
-Place 3 only applies to **type-specific** attributes (anything that comes from a `ContentType.Attributes()` map). The "common" attributes (`name`, `path`, `size`, `is_markdown`, …) are populated directly from the `FileAttributes` struct fields and don't go through the switch. Schema slot:
+| Where | What goes there | Failure mode if missing |
+| --- | --- | --- |
+| `internal/celexpr/evaluator.go` — `cel.Variable("foo", cel.<Type>Type)` inside `New` | Declares the variable to cel-go | Compile error: `undeclared reference to 'foo'` |
+| `internal/celexpr/activation.go` — resolution in `(*fileAttrsActivation).ResolveName`, via **either** a `case "foo":` returning a typed `FileAttributes` field **or** a key in the `zeroDefaults` map | How the attribute's value is produced at evaluation time | Runtime error: `no such attribute: foo` |
+| `internal/celexpr/schema.go` — entry in the right `AttributeDoc` slice | Drives both `--list` output and the MCP `list_attributes` tool | Attribute is invisible to humans and to MCP clients |
 
-- `schema.Common` → places 1, 2 (no switch entry)
-- `schema.TypeSpecific` → places 1, 2, 3, 4
-- `schema.Frontmatter` → places 1, 2, 3, 4
+**How resolution works (post-2024 refactor).** `ResolveName(name)` is a single switch:
+
+1. **Typed fields** — common scalars (`name`, `path`, `size`, …) and every `is_*` predicate / `md5` / `similarity` / … resolve via a `case "foo": return a.attrs.Foo, true` that reads a `FileAttributes` struct field. No default needed; the field is always present.
+2. **Type-specific / front-matter attributes** — fall through the switch to a verbatim `Extra[name]` lookup, then to `zeroDefaults[name]`. There is **no rename switch anymore**: the content type's `Attributes()` map must emit the *final CEL name* directly (e.g. emit `img_width`, not `width`; emit `json_kind`, not `kind`). The `zeroDefaults` entry supplies the value for files that didn't emit the key.
+
+Schema slot → what you must add:
+
+- `schema.Common` → `cel.Variable` + a typed `ResolveName` case (struct field). No `zeroDefaults` entry (it's never absent).
+- `schema.TypeSpecific` / `schema.Frontmatter` → `cel.Variable` + a `zeroDefaults` entry + `Attributes()` emitting the key verbatim into `Extra`.
 
 ## Quick start
 
-1. Decide the CEL variable name (snake_case) and type. Decide whether it's `Common`, `TypeSpecific`, or `Frontmatter`.
-2. Add `cel.Variable("foo", cel.<Type>Type)` in `celexpr.New` (place 1).
-3. Add `"foo": <zero-value>` to the activation defaults map in `Evaluate` (place 2).
-4. If the value comes from a `ContentType.Attributes()` map, add a `case "<source-key>": activation["foo"] = v` to the `attrs.Extra` switch (place 3).
-5. Add `{"foo", "<celtype>", "<description>"}` to the right slice in `celexpr.Schema()` (place 4).
-6. **Run** the audit (see Scripts).
-7. Update the README front-matter table if the new attribute is front-matter-related.
-8. Add a test in `internal/content/frontmatter_test.go` (front-matter case) or the relevant content-type test file.
+1. Decide the CEL variable name (snake_case) and type, and whether it's `Common`, `TypeSpecific`, or `Frontmatter`.
+2. Add `cel.Variable("foo", cel.<Type>Type)` in `celexpr.New` (evaluator.go).
+3. Make it resolve in `activation.go`:
+   - **Common / typed predicate**: add a `case "foo": return a.attrs.Foo, true` to `ResolveName` (and the backing `FileAttributes` field).
+   - **Type-specific / front-matter**: add `"foo": <zero-value>` to the `zeroDefaults` map, and make the content type's `Attributes()` put `"foo"` into its returned map verbatim (it flows through the `Extra[name]` fallthrough).
+4. Add `{"foo", "<celtype>", "<description>"}` to the right slice in `celexpr.Schema()`.
+5. **Run** the audit (see Scripts).
+6. Update the README front-matter / attribute tables (the `schema_docs` test enforces this).
+7. Add a test in `internal/content/frontmatter_test.go` (front-matter case) or the relevant content-type test file.
 
 For a new content type's *registration mechanics* (creating the file in `internal/content/`, implementing `ContentType`), see the `add-content-type` skill — this skill only covers the CEL plumbing.
 
 ## Scripts
 
-- **Run** `python scripts/audit_attributes.py` from the repo root — parses `internal/celexpr/evaluator.go` and `internal/celexpr/schema.go`, prints a markdown table of every CEL attribute name with which of the four places it appears in, and exits non-zero on drift. Run before committing any change to those files.
+- **Run** `python scripts/audit_attributes.py` from the repo root — parses `cel.Variable` declarations from `internal/celexpr/evaluator.go`, the `ResolveName` switch cases + `zeroDefaults` map from `internal/celexpr/activation.go`, and the `AttributeDoc` slices from `internal/celexpr/schema.go`. Prints a markdown table (Declared / Cased / Defaulted / Documented per attribute) and exits non-zero on drift — every declared var must be cased OR defaulted, and every documented type-specific/front-matter attr must have a default. Run before committing any change to those files.
 
 ## References
 
-- [references/foot-guns.md](references/foot-guns.md) — the renames in the `attrs.Extra` switch (`kind` → `json_kind`, `width` → `img_width`, …), the cel-go runtime error text, and the image-family branch in `BuildAttributes`.
+- [references/foot-guns.md](references/foot-guns.md) — the verbatim `Extra[name]` resolution (the content type must emit the final CEL name, e.g. `img_width` not `width`; there is no longer a rename switch), the cel-go runtime error text, and the image-family branch in `BuildAttributes`.
 
 ## Conventions
 
 - CEL variable names are `snake_case`. Match the existing style (`json_kind`, `img_width`, `frontmatter_format`).
-- The CEL type for collections is exact: `cel.ListType(cel.StringType)` for `[]string`, `cel.MapType(cel.StringType, cel.DynType)` for `map[string]any`. cel-go errors loudly on type mismatch.
-- Zero values in the activation map must match the declared CEL type (e.g. `int64(0)` for `cel.IntType`, never plain `0`).
-- Do not edit `cmd/file-search-on/main.go:printHelp` — it's data-driven from `celexpr.Schema()`. Editing place 4 is sufficient.
+- The CEL type for collections is exact: `cel.ListType(cel.StringType)` for `[]string`, `cel.ListType(cel.DoubleType)` for `[]float64`, `cel.MapType(cel.StringType, cel.DynType)` for `map[string]any`. cel-go errors loudly on type mismatch.
+- Zero values in the `zeroDefaults` map must match the declared CEL type (e.g. `int64(0)` for `cel.IntType`, `[]string{}` for `cel.ListType(cel.StringType)`, never plain `0`).
+- Do not edit `cmd/file-search-on/main.go:printHelp` — it's data-driven from `celexpr.Schema()`. Editing the `AttributeDoc` slice is sufficient.
+- The `schema_docs` test (`internal/celexpr/schema_docs_test.go`) additionally requires every documented attribute to appear in `README.md` — update the README's attribute / front-matter tables in the same change or that test fails.
 - If the new attribute crosses content types (e.g. `description` could come from PDF metadata *and* HTML `<meta>` *and* markdown front-matter), document each emitting site in the schema description so callers know what they're filtering on.

--- a/.claude/skills/extend-cel-schema/references/foot-guns.md
+++ b/.claude/skills/extend-cel-schema/references/foot-guns.md
@@ -10,29 +10,21 @@ When a CEL variable is referenced by a compiled expression but missing from the 
 search failed: walk: ...: evaluating CEL expression: no such attribute(s): foo
 ```
 
-This is the failure mode for forgetting place 2 (the activation defaults map) or place 3 (the `attrs.Extra` switch — when the expression explicitly references the attribute and no content type emits it). Compile-only smoke tests don't catch this; the test that catches it is one that actually `Walk`s a real directory.
+This is the failure mode for forgetting to make the attribute *resolvable* in `(*fileAttrsActivation).ResolveName` (`internal/celexpr/activation.go`) — either a `case "foo":` returning a typed field, or a `zeroDefaults` key for an Extra-flowing attribute that no content type emitted on this file. Compile-only smoke tests don't catch this; the test that catches it is one that actually `Walk`s a real directory.
 
-The guard against this is the activation defaults map: every `cel.Variable(...)` declared in `New` MUST have a key in the activation map literal in `Evaluate`, with a zero value of the right type. The audit script enforces this.
+The guard is the `zeroDefaults` map: every `cel.Variable(...)` declared in `New` that resolves through `Extra` MUST have a key in `zeroDefaults`, with a zero value of the right type. (Typed-field attributes resolve via a `ResolveName` case instead and don't need a default.) The audit script enforces `declared == cased ∪ defaulted`.
 
-## The renames in the Extra switch
+## No rename layer — emit the final CEL name
 
-The keys content types emit in their `Attributes()` map are NOT always the same as the CEL variable names. The `attrs.Extra` switch in `Evaluate` is a translation layer.
+**There is no `attrs.Extra` rename switch.** (There used to be one in `Evaluate`; the 2024 activation refactor removed it.) `ResolveName` does a *verbatim* `Extra[name]` lookup, so a content type's `Attributes()` map MUST emit the exact CEL variable name — there is no translation step.
 
-Current renames (in `internal/celexpr/evaluator.go`):
+Concretely: `imagetype.go` emits `img_width` / `img_height` directly (not `width` / `height`); a JSON type that wants the `json_kind` CEL variable must put `"json_kind"` into its returned map, not `"kind"`. If the emitted key and the CEL name diverge, the attribute silently stays at its zero value — no error, just wrong.
 
-| Source key (from `Attributes()`) | CEL variable |
-| --- | --- |
-| `kind` | `json_kind` |
-| `width` | `img_width` |
-| `height` | `img_height` |
-
-All other keys pass through unchanged (`title` → `title`, `word_count` → `word_count`, etc.).
-
-When adding a new attribute, you can either keep the same name on both sides (preferred) or introduce a rename. Renames are warranted when the source key is a generic word that would clash across content types — `kind` makes sense locally inside `jsonType.Attributes` but `json_kind` is clearer in CEL.
+When adding a new attribute, keep the same name on both sides. If you want a "namespaced" CEL name (`json_kind` rather than a bare `kind`), do the naming inside the content type's `Attributes()` map — that's the only place the name is set now.
 
 ## Type mismatches between zero value and `cel.Variable` type
 
-The zero value in the activation map must match the declared CEL type:
+The zero value in the `zeroDefaults` map must match the declared CEL type:
 
 | `cel.Variable` type | Zero value |
 | --- | --- |
@@ -45,37 +37,42 @@ The zero value in the activation map must match the declared CEL type:
 
 cel-go errors with a confusing "unsupported type conversion" message on mismatch. The audit script does not check zero-value types — `go vet` and the existing test suite do.
 
-## Image-family branching
+## Family-prefix branching
 
-Image content types use a name prefix (`image/jpeg`, `image/png`, …). The `BuildAttributes` function in `evaluator.go` (around line 189) maps any name starting with `image/` to `is_image = true` via:
+Family `is_*` predicates are set by name-prefix blocks in `setTypeFlags` (`internal/celexpr/evaluator.go`). For example, any name starting with `image/` sets `attrs.IsImage = true`:
 
 ```go
-case strings.HasPrefix(contentTypeName, "image/"):
-    isImage = true
+if strings.HasPrefix(name, "image/") {
+    attrs.IsImage = true
+}
 ```
 
 When adding a new image variant (e.g. `image/avif`):
 
 1. Register it like any other content type — name MUST start with `image/`.
-2. The `BuildAttributes` branch picks it up automatically; no edit needed there.
+2. The `setTypeFlags` prefix block picks it up automatically; no edit needed there.
 
-When adding a NEW family with its own `is_*` boolean (e.g. an audio family with `is_audio`), you DO need to edit `BuildAttributes`: add a `case strings.HasPrefix(contentTypeName, "audio/"): isAudio = true` and follow the four-place invariant for the `is_audio` CEL variable.
+When adding a NEW family with its own `is_*` boolean (e.g. a 3D-model family with `is_3d_model`), you DO need to:
 
-## When to update the README front-matter table
+1. Add the `Is3DModel bool` field to `FileAttributes`.
+2. Add a `case "is_3d_model": return a.attrs.Is3DModel, true` to `ResolveName` (activation.go).
+3. Add a `if strings.HasPrefix(name, "model3d/") { attrs.Is3DModel = true }` block to `setTypeFlags`.
+4. Declare the `is_3d_model` `cel.Variable` and document it in `Schema()`.
 
-The README has a hand-maintained front-matter table at the bottom of "Markdown front-matter search". Update it when:
+(See the `model3d/`, `image/raw-`, and `font/` families for worked examples.)
 
-- Adding a new front-matter promoted variable (place 4 row in `schema.Frontmatter`).
-- Changing the precedence note (e.g. front-matter > H1 for `title`).
+## You MUST update the README — `schema_docs_test` enforces it
 
-The README does NOT list common attributes (`name`, `size`, …) or type-specific attributes (`page_count`, `img_width`, …) — those live only in `--list` and the MCP `list_attributes` tool. Don't add them to the README.
+`internal/celexpr/schema_docs_test.go` cross-checks every `AttributeDoc` and `FunctionDoc` in `Schema()` against `README.md`: each documented attribute / function name must appear as a backticked literal somewhere in the README, or the test fails with e.g. `README.md missing TypeSpecific attribute "face_count"`.
+
+So when you add a `schema.Common` / `schema.TypeSpecific` / `schema.Frontmatter` entry, also add the name to the matching README table (the per-family attribute tables under "Available attributes", or the front-matter table). This is not optional — `go test ./internal/celexpr/` will go red otherwise. (Historically the README only listed front-matter attributes; the test now covers the full schema.)
 
 ## What the audit script does NOT catch
 
-The audit script enforces the four-place invariant for CEL attribute *names*. It does not check:
+The audit script enforces the declared / resolvable / documented invariant for CEL attribute *names*. It does not check:
 
 - Whether the CEL variable type matches the zero value's Go type.
-- Whether the source key in the Extra switch matches what content types actually emit.
+- Whether the key a content type actually emits into `Extra` matches the declared CEL name (the verbatim lookup means a typo'd emit key silently yields the zero value — see "No rename layer" above).
 - Whether the `AttributeDoc.Type` string in `Schema()` matches the declared `cel.Variable` type.
 
-Those checks are the job of `go build`, `go vet`, and the existing test suite. The audit catches the one class of error that no compiler will.
+Those checks are the job of `go build`, `go vet`, and the existing test suite (including `schema_docs_test.go`, which cross-checks `Schema()` against the README). The audit catches the one class of error that no compiler will.

--- a/.claude/skills/extend-cel-schema/scripts/audit_attributes.py
+++ b/.claude/skills/extend-cel-schema/scripts/audit_attributes.py
@@ -1,22 +1,38 @@
 #!/usr/bin/env python3
-"""Audit file-search-on's CEL attribute schema for drift between the four call sites.
+"""Audit file-search-on's CEL attribute schema for drift between the call sites.
 
 Usage: python audit_attributes.py [--repo-root .]
 
-Exits 0 if every CEL attribute appears in every place it must, non-zero on drift.
-Prints a markdown table summarising the state of each attribute.
+Exits 0 if every CEL attribute is declared, resolvable, and documented
+consistently; non-zero on drift. Prints a markdown table summarising each
+attribute.
 
-The four places (see extend-cel-schema/SKILL.md):
-  1. cel.Variable("foo", ...) declarations in celexpr.New             (-> declared)
-  2. activation defaults map literal in celexpr.Evaluate              (-> defaulted)
-  3. attrs.Extra switch case assignments in celexpr.Evaluate          (-> assigned)
-  4. AttributeDoc{...} entries in celexpr.Schema()                    (-> documented)
+The places a CEL attribute must appear (see extend-cel-schema/SKILL.md):
+  1. cel.Variable("foo", ...) declarations in celexpr.New
+     (internal/celexpr/evaluator.go)                                  -> declared
+  2. resolvable in (*fileAttrsActivation).ResolveName
+     (internal/celexpr/activation.go), via EITHER:
+       a. a `case "foo":` label returning a typed FileAttributes field
+          (common scalars + is_* predicates + md5/sha1/...)           -> cased
+       b. a key in the `zeroDefaults` map literal (type-specific attrs
+          that flow through the verbatim `Extra[name]` fallthrough)    -> defaulted
+  3. AttributeDoc{...} entries in celexpr.Schema()
+     (internal/celexpr/schema.go)                                     -> documented
+
+Note (2024 refactor): the activation machinery moved out of celexpr.Evaluate
+into internal/celexpr/activation.go. There is no longer an
+`activation["foo"] = v` rename switch — type-specific attributes resolve by
+verbatim key match against FileAttributes.Extra (so the content type must
+emit the final CEL name directly), falling back to zeroDefaults when a file
+didn't emit them. "Resolvable" therefore means cased OR defaulted.
 
 Invariants:
-  declared == defaulted                                          (sanity, hard error on drift)
-  documented (any slice) ⊆ declared                              (hard error)
-  documented (TypeSpecific ∪ Frontmatter) ⊆ assigned             (hard error)
-  declared - documented                                          (warn — undocumented attribute)
+  declared == (cased ∪ defaulted)        (every declared var resolves; no orphans — hard error)
+  documented ⊆ declared                  (can't document an undeclared var — hard error)
+  documented (TypeSpecific ∪ Frontmatter) ⊆ defaulted
+                                         (Extra-flowing docs need a zero default so files
+                                          that don't emit them don't error — hard error)
+  declared - documented                  (warn — undocumented, hidden from --list)
 """
 from __future__ import annotations
 
@@ -27,22 +43,19 @@ from pathlib import Path
 
 
 CEL_VARIABLE_RE = re.compile(r'cel\.Variable\(\s*"([^"]+)"')
+# A `case "a":` or `case "a", "b":` label line inside ResolveName.
+CASE_LINE_RE = re.compile(r'^\s*case\s+(.+?):\s*$')
+QUOTED_RE = re.compile(r'"([^"]+)"')
 ACTIVATION_KEY_RE = re.compile(r'^\s*"([^"]+)"\s*:')
-ASSIGN_RE = re.compile(r'activation\[\s*"([^"]+)"\s*\]\s*=')
 DOC_ENTRY_RE = re.compile(r'\{\s*"([^"]+)"\s*,\s*"([^"]*)"\s*,\s*"[^"]*"\s*\}')
 
 
-def parse_evaluator(text: str) -> tuple[set[str], set[str], set[str]]:
-    """Return (declared, defaulted, assigned) sets parsed from evaluator.go."""
-    declared = set(CEL_VARIABLE_RE.findall(text))
-
-    # Locate the activation map literal: starts at `activation := map[string]any{`
-    # ends at the matching closing brace at the same indentation level.
-    start_marker = "activation := map[string]any{"
+def find_block(text: str, start_marker: str, what: str) -> str:
+    """Return the brace-balanced block body following start_marker (the
+    marker must end with the opening `{`)."""
     start = text.find(start_marker)
     if start < 0:
-        raise SystemExit("ERROR: could not find `activation := map[string]any{` in evaluator.go")
-    # Track brace depth from the opening { in the marker
+        raise SystemExit(f"ERROR: could not find `{start_marker}` ({what})")
     open_brace = start + len(start_marker) - 1
     depth = 1
     i = open_brace + 1
@@ -52,38 +65,52 @@ def parse_evaluator(text: str) -> tuple[set[str], set[str], set[str]]:
         elif text[i] == "}":
             depth -= 1
         i += 1
-    activation_block = text[open_brace + 1 : i - 1]
-    defaulted = set()
-    for line in activation_block.splitlines():
+    return text[open_brace + 1 : i - 1]
+
+
+def parse_declared(evaluator_text: str) -> set[str]:
+    """cel.Variable declarations in celexpr.New."""
+    return set(CEL_VARIABLE_RE.findall(evaluator_text))
+
+
+def parse_activation(activation_text: str) -> tuple[set[str], set[str]]:
+    """Return (cased, defaulted) from activation.go.
+
+    cased     — string labels of every `case "..."` in ResolveName's switch.
+    defaulted — keys of the `var zeroDefaults = map[string]any{...}` literal.
+    """
+    # 1. ResolveName switch case labels (handles multi-label `case "a", "b":`).
+    body = find_block(
+        activation_text,
+        "func (a *fileAttrsActivation) ResolveName(name string) (any, bool) {",
+        "ResolveName in activation.go",
+    )
+    cased: set[str] = set()
+    for line in body.splitlines():
+        m = CASE_LINE_RE.match(line)
+        if m:
+            cased.update(QUOTED_RE.findall(m.group(1)))
+
+    # 2. zeroDefaults map keys.
+    defaults_block = find_block(
+        activation_text,
+        "var zeroDefaults = map[string]any{",
+        "zeroDefaults in activation.go",
+    )
+    defaulted: set[str] = set()
+    for line in defaults_block.splitlines():
         m = ACTIVATION_KEY_RE.match(line)
         if m:
             defaulted.add(m.group(1))
 
-    assigned = set(ASSIGN_RE.findall(text))
-    return declared, defaulted, assigned
+    return cased, defaulted
 
 
 def parse_schema(text: str) -> dict[str, list[tuple[str, str]]]:
-    """Return mapping of slice name (Common / TypeSpecific / Frontmatter) to a list
-    of (attribute_name, attribute_type) tuples in source order."""
+    """Map slice name (Common / TypeSpecific / Frontmatter) to (name, type) tuples."""
     result: dict[str, list[tuple[str, str]]] = {}
-    # Find each `Common: []AttributeDoc{` / `TypeSpecific: []AttributeDoc{` / `Frontmatter: []AttributeDoc{`
     for slice_name in ("Common", "TypeSpecific", "Frontmatter"):
-        marker = f"{slice_name}: []AttributeDoc{{"
-        start = text.find(marker)
-        if start < 0:
-            raise SystemExit(f"ERROR: could not find `{marker}` in schema.go")
-        # Find matching closing brace
-        open_brace = start + len(marker) - 1
-        depth = 1
-        i = open_brace + 1
-        while i < len(text) and depth > 0:
-            if text[i] == "{":
-                depth += 1
-            elif text[i] == "}":
-                depth -= 1
-            i += 1
-        block = text[open_brace + 1 : i - 1]
+        block = find_block(text, f"{slice_name}: []AttributeDoc{{", f"{slice_name} in schema.go")
         result[slice_name] = [(m.group(1), m.group(2)) for m in DOC_ENTRY_RE.finditer(block)]
     return result
 
@@ -95,72 +122,72 @@ def main() -> int:
 
     root = args.repo_root.resolve()
     evaluator_path = root / "internal" / "celexpr" / "evaluator.go"
+    activation_path = root / "internal" / "celexpr" / "activation.go"
     schema_path = root / "internal" / "celexpr" / "schema.go"
-    for p in (evaluator_path, schema_path):
+    for p in (evaluator_path, activation_path, schema_path):
         if not p.exists():
             print(f"ERROR: {p} not found (run from the repo root, or pass --repo-root)", file=sys.stderr)
             return 1
 
-    declared, defaulted, assigned = parse_evaluator(evaluator_path.read_text(encoding="utf-8"))
+    declared = parse_declared(evaluator_path.read_text(encoding="utf-8"))
+    cased, defaulted = parse_activation(activation_path.read_text(encoding="utf-8"))
     schema = parse_schema(schema_path.read_text(encoding="utf-8"))
+
+    resolvable = cased | defaulted
 
     documented_common = {n for n, _ in schema["Common"]}
     documented_typespec = {n for n, _ in schema["TypeSpecific"]}
     documented_frontmatter = {n for n, _ in schema["Frontmatter"]}
     documented_all = documented_common | documented_typespec | documented_frontmatter
-    must_be_assigned = documented_typespec | documented_frontmatter
+    extra_flowing_docs = documented_typespec | documented_frontmatter
 
     errors: list[str] = []
     warnings: list[str] = []
 
-    # Invariant 1: declared == defaulted
-    only_declared = declared - defaulted
-    only_defaulted = defaulted - declared
-    if only_declared:
+    # Invariant 1: declared == resolvable.
+    declared_unresolvable = declared - resolvable
+    if declared_unresolvable:
         errors.append(
-            f"declared but missing zero-value default in activation map: {sorted(only_declared)}"
+            "declared via cel.Variable but neither a ResolveName `case` nor a "
+            f"zeroDefaults key (→ runtime 'no such attribute'): {sorted(declared_unresolvable)}"
         )
-    if only_defaulted:
+    resolvable_undeclared = resolvable - declared
+    if resolvable_undeclared:
         errors.append(
-            f"defaulted in activation map but not declared via cel.Variable: {sorted(only_defaulted)}"
+            "resolvable in activation.go (case or zeroDefaults) but not declared via "
+            f"cel.Variable: {sorted(resolvable_undeclared)}"
         )
 
-    # Invariant 2: documented ⊆ declared
+    # Invariant 2: documented ⊆ declared.
     documented_not_declared = documented_all - declared
     if documented_not_declared:
         errors.append(
             f"documented in schema.go but not declared via cel.Variable: {sorted(documented_not_declared)}"
         )
 
-    # Invariant 3: type-specific & front-matter docs ⊆ assigned
-    must_assign_missing = must_be_assigned - assigned
-    if must_assign_missing:
+    # Invariant 3: Extra-flowing docs (TypeSpecific ∪ Frontmatter) need a zero
+    # default — they resolve via the verbatim Extra fallthrough, so a file that
+    # doesn't emit them must fall back to a default or cel-go errors. (A doc
+    # that's instead handled by a typed `case` is fine — exclude those.)
+    extra_flowing_missing_default = extra_flowing_docs - defaulted - cased
+    if extra_flowing_missing_default:
         errors.append(
-            f"documented as type-specific/front-matter but no `activation[\"foo\"] = v` "
-            f"assignment in the attrs.Extra switch: {sorted(must_assign_missing)}"
+            "documented as type-specific/front-matter but no zeroDefaults entry "
+            f"(and not a typed ResolveName case): {sorted(extra_flowing_missing_default)}"
         )
 
-    # Sanity: assignments should target declared variables (unless they are common — but
-    # common attrs are populated from struct fields, never via the switch, so any switch
-    # assignment is to a type-specific or front-matter slot).
-    assigned_not_declared = assigned - declared
-    if assigned_not_declared:
-        errors.append(
-            f"attrs.Extra switch assigns to undeclared CEL variable: {sorted(assigned_not_declared)}"
-        )
-
-    # Warning: declared but undocumented (the `--list` view will hide it).
+    # Warning: declared but undocumented (hidden from --list / list_attributes).
     declared_not_documented = declared - documented_all
     if declared_not_documented:
         warnings.append(
-            f"declared via cel.Variable but not documented in schema.go (won't show "
+            "declared via cel.Variable but not documented in schema.go (won't show "
             f"in --list or list_attributes): {sorted(declared_not_documented)}"
         )
 
-    # Build the markdown report.
-    print("| Attribute | Declared | Defaulted | Assigned | Documented |")
+    # Markdown report.
+    print("| Attribute | Declared | Cased | Defaulted | Documented |")
     print("| --- | --- | --- | --- | --- |")
-    every = sorted(declared | defaulted | assigned | documented_all)
+    every = sorted(declared | resolvable | documented_all)
     for name in every:
         slot = ""
         if name in documented_common:
@@ -170,12 +197,12 @@ def main() -> int:
         elif name in documented_frontmatter:
             slot = "Frontmatter"
         d = "✓" if name in declared else "—"
+        c = "✓" if name in cased else "—"
         f_ = "✓" if name in defaulted else "—"
-        a = "✓" if name in assigned else ("·" if slot == "Common" else "—")
         doc = slot if slot else "—"
-        print(f"| `{name}` | {d} | {f_} | {a} | {doc} |")
+        print(f"| `{name}` | {d} | {c} | {f_} | {doc} |")
     print()
-    print("Legend: ✓ = present, — = missing, · = N/A (common attrs are not assigned via the switch)")
+    print("Legend: ✓ = present, — = absent. A declared attr must be Cased OR Defaulted.")
     print()
 
     for w in warnings:


### PR DESCRIPTION
Closes #219.

Both skills had drifted from the codebase after (a) the activation refactor that moved the activation machinery out of `celexpr.Evaluate` into `activation.go` and removed the `attrs.Extra` rename switch, and (b) the `fs.FS` threading of `ContentType.Attributes`. Hit while implementing #208 / #212 / #213 this session.

## extend-cel-schema

- **`audit_attributes.py` rewritten.** It looked for `activation := map[string]any{` in `evaluator.go` (gone after the refactor), errored out, and silently audited nothing — so the four-place guard the skill promised was a no-op. Now it parses:
  - `cel.Variable` declarations from `evaluator.go`
  - `ResolveName` `case` labels + the `zeroDefaults` map from `activation.go`
  - `AttributeDoc` slices from `schema.go`

  New invariant: `declared == (cased ∪ defaulted)`, and documented type-specific / front-matter attrs must have a `zeroDefaults` entry. **Verified: exits 0 on the current tree** (one pre-existing undocumented-attribute warning, unrelated).
- **SKILL.md**: replaced the stale "four-place / in `Evaluate`" table with the declared / resolvable / documented model; explained typed-field-case vs Extra-fallthrough resolution; noted the `schema_docs_test` README requirement.
- **foot-guns.md**: removed the "renames in the Extra switch" section (the switch is gone — content types emit the final CEL name verbatim, `img_width` not `width`), repointed family-branch guidance from `BuildAttributes` to `setTypeFlags` + `ResolveName`, fixed the README section.

## add-content-type

- SKILL.md, detection.md, and the `.tmpl` all showed the 2-arg `Attributes(ctx, path)`. The real interface is 3-arg `Attributes(ctx, fsys fs.FS, path)` — copying the template produced code that **didn't compile** until you hand-added `fsys`. Fixed the signature everywhere; switched the template body from `os.Open` to `fsys.Open` with a pointer to the `fsutil.go` helpers; repointed the image-family / new-family guidance to the current `setTypeFlags` + `ResolveName` pattern.

## Validation

```
$ python3 .claude/skills/extend-cel-schema/scripts/audit_attributes.py >/dev/null; echo $?
0
$ grep "func.*Attributes(ctx" .claude/skills/add-content-type/templates/content_type.go.tmpl
func (t *<typename>Type) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
# ↑ matches internal/content/markdown.go verbatim
```

Doc / tooling only — **no codebase behaviour change**, so no Go source touched.

## Test plan

- [ ] CI green (the only code-ish artifact is the Python audit script + a Go template; neither is compiled by `go build`).
- [ ] Sanity: next time someone adds a content type / CEL attribute, the skills + audit should now be accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)