### PR TITLE
feat(watch): continuous file watching — CLI watch + bounded MCP watch_search (closes #211)

### DIFF
--- a/.claude/skills/add-content-type/SKILL.md
+++ b/.claude/skills/add-content-type/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: add-content-type
-description: Registers a new file-format content type in file-search-on by creating a file under `internal/content/` that implements the four-method `ContentType` interface (`Name`, `Extensions`, `MagicBytes`, `Attributes`), self-registers via `init()` calling `content.Register(...)`, and for image variants extends the `BuildAttributes` `image/*` prefix branch in `internal/celexpr/evaluator.go` — covers CSV, YAML, plain-text, EPUB, new audio/image families, and similar formats. Use when adding support for a new file format so the search recognises it and reports a `content_type`; does NOT cover CEL attribute wiring for type-specific attributes, which is the `extend-cel-schema` skill's job.
+description: Registers a new file-format content type in file-search-on by creating a file under `internal/content/` that implements the four-method `ContentType` interface (`Name`, `Extensions`, `MagicBytes`, `Attributes(ctx, fsys, path)`), self-registers via `init()` calling `content.Register(...)`, and for image variants relies on the `image/` prefix block in `setTypeFlags` (`internal/celexpr/evaluator.go`) — covers CSV, YAML, plain-text, EPUB, new audio/image families, and similar formats. Use when adding support for a new file format so the search recognises it and reports a `content_type`; does NOT cover CEL attribute wiring for type-specific attributes, which is the `extend-cel-schema` skill's job.
 ---
 
 # Add Content Type
 
-A "content type" is anything `Detect()` can identify and `Walk` can tag. Registering one is mostly mechanical: drop a file in `internal/content/`, implement four methods, register it, done. The wrinkle is the `Attributes(path)` method — if it returns *any* type-specific keys, you also need the `extend-cel-schema` workflow to make those keys CEL-visible.
+A "content type" is anything `Detect()` can identify and `Walk` can tag. Registering one is mostly mechanical: drop a file in `internal/content/`, implement four methods, register it, done. The wrinkle is the `Attributes(ctx, fsys, path)` method — if it returns *any* type-specific keys, you also need the `extend-cel-schema` workflow to make those keys CEL-visible.
 
 ## What gets registered
 
@@ -31,7 +31,7 @@ For a type like CSV that you want detected but where you don't (yet) care about 
 
 ## Quick start (with attributes)
 
-If `Attributes(path)` returns type-specific keys (e.g. `csv_columns`, `csv_rows`):
+If `Attributes(ctx, fsys, path)` returns type-specific keys (e.g. `csv_columns`, `csv_rows`):
 
 1. Steps 1–3 as above, but make `Attributes` return the keys.
 2. **Then** run the `extend-cel-schema` skill for *each* new key — declare the CEL variable, add to the activation defaults, add a switch case, and document in `Schema()`.
@@ -43,33 +43,33 @@ If `Attributes(path)` returns type-specific keys (e.g. `csv_columns`, `csv_rows`
 
 ```go
 type ContentType interface {
-    Name() string                                                      // stable identifier; image family must use "image/<subtype>"
-    Extensions() []string                                              // lowercase, with leading dot, e.g. []string{".csv"}
-    MagicBytes() [][]byte                                              // each entry is a prefix to match against the first 512 bytes; nil if not used
-    Attributes(ctx context.Context, path string) (Attributes, error)   // called per matching file; return a map[string]any, never nil
+    Name() string                                                                 // stable identifier; image family must use "image/<subtype>"
+    Extensions() []string                                                         // lowercase, with leading dot, e.g. []string{".csv"}
+    MagicBytes() [][]byte                                                         // each entry is a prefix to match against the first 512 bytes; nil if not used
+    Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error)  // called per matching file; read via fsys, not os; return a map[string]any, never nil
 }
 ```
 
 Semantic notes:
 
-- **`Name()`** — used by `BuildAttributes` to set the `is_*` flag and the `content_type` CEL attribute. For an image family, the name MUST start with `image/` (e.g. `image/avif`); for the office family, MUST start with `office/`. The corresponding `strings.HasPrefix` branch in `BuildAttributes` turns `is_image` / `is_office` on automatically.
+- **`Name()`** — used by `setTypeFlags` (in `internal/celexpr/evaluator.go`) to set the `is_*` flag and the `content_type` CEL attribute. For an image family, the name MUST start with `image/` (e.g. `image/avif`); for the office family, MUST start with `office/`. The corresponding `strings.HasPrefix(name, ...)` block in `setTypeFlags` turns `is_image` / `is_office` on automatically.
 - **`Extensions()`** — lowercase, dotted. The detector matches case-insensitively against `filepath.Ext(path)` lower-cased.
 - **`MagicBytes()`** — return `nil` (not `[][]byte{}`) if the type is detected by extension only. Each `[]byte` is a prefix; the detector matches if any prefix is a prefix of the first 512 bytes.
-- **`Attributes(ctx, path)`** — called *per matching file* during the walk. Honour ctx: check `ctx.Err()` at entry, and inside any unbounded scan/decode loop. Return `ctx.Err()` on cancellation so the walker can terminate cleanly. Avoid expensive parses without bounds (use `bufio.Scanner` with a buffer cap, decode just enough of the file to extract what you need). Return `Attributes{}` (empty) if no type-specific data; never return `nil`.
+- **`Attributes(ctx, fsys, path)`** — called *per matching file* during the walk. **Read the file through `fsys`, not `os`** — open with `fsys.Open(path)`, or use the helpers in `internal/content/fsutil.go` (`openReadSeeker` for seekable/streamed access, `openReaderAt` for `zip`/`pdf`-style random access, `readAll` for whole-file slurps). This is what lets the same parser run against real files, archive entries, and in-memory test filesystems. Honour ctx: check `ctx.Err()` at entry, and inside any unbounded scan/decode loop. Return `ctx.Err()` on cancellation. Avoid expensive parses without bounds (use `bufio.Scanner` with a buffer cap, decode just enough of the file). Return `Attributes{}` (empty) if no type-specific data; never return `nil`.
 
 ## Image-family addition
 
 When the new type is an image variant (e.g. `image/avif`):
 
 - `Name()` MUST return `image/<subtype>`.
-- `BuildAttributes` (`internal/celexpr/evaluator.go`) already has a `case strings.HasPrefix(contentTypeName, "image/")` branch — no edit needed there for new image variants. The branch sets `is_image = true` and dispatches to the registered type's `Attributes` for `width` / `height` (which are renamed to `img_width` / `img_height` by the `attrs.Extra` switch).
-- If the new image type emits *additional* attributes beyond `width` / `height` (e.g. `color_space`, `bit_depth`), each one is a CEL-schema extension — use the `extend-cel-schema` skill.
+- `setTypeFlags` (`internal/celexpr/evaluator.go`) already has an `if strings.HasPrefix(name, "image/")` block — no edit needed there for new image variants; it sets `is_image = true` automatically. The type's `Attributes` should emit `img_width` / `img_height` directly (the final CEL names — there is no rename layer; see the `extend-cel-schema` foot-guns).
+- If the new image type emits *additional* attributes beyond `img_width` / `img_height` (e.g. `color_space`, `bit_depth`), each one is a CEL-schema extension — use the `extend-cel-schema` skill.
 
 For a non-image type with its own `is_*` flag (e.g. an `audio/*` family):
 
 - Add an `IsAudio bool` field to `FileAttributes`.
-- Add the `is_audio` CEL variable via the four-place invariant (`extend-cel-schema`).
-- Add a `case strings.HasPrefix(contentTypeName, "audio/"):` branch in `BuildAttributes`.
+- Add a `case "is_audio": return a.attrs.IsAudio, true` to `ResolveName` (`activation.go`) and declare the `is_audio` CEL variable (`extend-cel-schema`).
+- Add an `if strings.HasPrefix(name, "audio/") { attrs.IsAudio = true }` block to `setTypeFlags`.
 
 ## Templates
 
@@ -77,7 +77,7 @@ For a non-image type with its own `is_*` flag (e.g. an `audio/*` family):
 
 ## References
 
-- [references/detection.md](references/detection.md) — how `Registry.Detect` works (extension-then-magic), magic-byte gotchas, and what `Attributes(path)` should and should not do during a walk.
+- [references/detection.md](references/detection.md) — how `Registry.Detect` works (extension-then-magic), magic-byte gotchas, and what `Attributes(ctx, fsys, path)` should and should not do during a walk.
 
 ## Conventions
 

--- a/.claude/skills/add-content-type/references/detection.md
+++ b/.claude/skills/add-content-type/references/detection.md
@@ -1,6 +1,6 @@
 # Content-type detection
 
-How `Registry.Detect` decides what a file is, what `Attributes(path)` should and should not do, and the gotchas that bite when adding a new type.
+How `Registry.Detect` decides what a file is, what `Attributes(ctx, fsys, path)` should and should not do, and the gotchas that bite when adding a new type.
 
 ## How `Registry.Detect` works
 
@@ -32,13 +32,13 @@ Pragmatic recommendation: start with extension-only. Add magic bytes when you ha
 - **Prefix, not substring.** The detector checks `bytes.HasPrefix(read, magic)`. A magic of `"foo"` won't match a file that starts with `"\xef\xbb\xbffoo"` (BOM-prefixed). If you need BOM tolerance, register multiple magic entries: `[]byte("foo"), []byte("\xef\xbb\xbffoo")`.
 - **Avoid super-short or super-common prefixes.** `"{"` matches every JSON file but also every file that happens to start with `{`. JSON gets away with it because almost nothing else does. CSV has no usable magic — leave `MagicBytes` as `nil`.
 
-## What `Attributes(ctx, path)` should and should not do
+## What `Attributes(ctx, fsys, path)` should and should not do
 
 `Attributes` is called *per matching file*. A search across 100k markdown files calls it 100k times. Performance and resource bounds matter.
 
 **Do:**
 
-- Open the file at `path`, decode just enough to extract what you need, close it. Use `defer f.Close()`.
+- Open the file via `fsys.Open(path)` (NOT `os.Open` — `fsys` is what makes the parser work against archive entries + in-memory test filesystems). For seekable / random-access needs use `openReadSeeker` / `openReaderAt` / `readAll` from `internal/content/fsutil.go`. Decode just enough to extract what you need, close it. Use `defer f.Close()`.
 - Use bounded buffers — `bufio.Scanner` with a sized buffer cap, `io.LimitReader` for streams that could be huge.
 - Honour `ctx`: check `ctx.Err()` at entry, and inside any unbounded scan/decode loop. Return `ctx.Err()` on cancellation. The walker treats `context.Canceled` / `context.DeadlineExceeded` as a signal to terminate the worker rather than skip-and-continue, so cancellation actually stops the search.
 - Return `Attributes{}` (empty map, not `nil`) if there's nothing type-specific to extract. The detector still records `content_type`; you don't need attributes to be useful.
@@ -48,28 +48,29 @@ Pragmatic recommendation: start with extension-only. Add magic bytes when you ha
 
 - Read or parse the entire file when you only need the first chunk. JSON's content type only reads the first token to detect `object` vs `array` — copy that pattern.
 - Ignore ctx. A pathological 1 GB log file with `bufio.Scanner` will run to completion if the loop doesn't check ctx, even after the user has cancelled. Per-iteration `ctx.Err()` is a single atomic load — well below file-I/O noise.
-- Make additional file-system calls beyond reading `path`. The walker has already passed you a stat-able path; recomputing stat or scanning siblings is wasted work.
+- Make additional file-system calls beyond reading `path` through `fsys`. The walker has already passed you the path; recomputing stat or scanning siblings is wasted work. (Path-anchored cross-file lookups — like the Live Photo sibling check — belong in a `BuildAttributesWith` hook keyed on the absolute `displayPath`, not inside a `ContentType.Attributes` working through `fsys`.)
 - Cache anything in a package-level variable. The `Attributes` call is concurrent — content types are stateless by contract. If you need a cache, scope it inside the function with a `sync.Once`-protected init, but think hard about why first.
 - Panic. The walker doesn't recover; a panicking type takes down the whole search.
 
-## Image-family branching
+## Family-prefix branching
 
-The `BuildAttributes` function in `internal/celexpr/evaluator.go` (around line 189) has a single branch that catches every image variant by name prefix:
+The `setTypeFlags` function in `internal/celexpr/evaluator.go` has a series of name-prefix `if` blocks that catch every variant of a family. For images:
 
 ```go
-case strings.HasPrefix(contentTypeName, "image/"):
-    isImage = true
+if strings.HasPrefix(name, "image/") {
+    attrs.IsImage = true
+}
 ```
 
 Adding a new image variant (e.g. `image/avif`) is therefore additive: register the type with `Name() = "image/avif"` and the `is_image` flag flips on for that variant automatically. No edit to `evaluator.go` is needed.
 
-For a brand-new family (audio, archive, …), you DO need to extend `BuildAttributes`:
+For a brand-new family (audio, archive, 3D models, …), you DO need to:
 
-1. Add a `case strings.HasPrefix(contentTypeName, "audio/"): isAudio = true` (or whatever family prefix).
-2. Add an `IsAudio bool` field to the `FileAttributes` struct in the same file.
-3. Add `is_audio` to the four-place CEL invariant (use the `extend-cel-schema` skill).
+1. Add an `IsAudio bool` field to the `FileAttributes` struct (in `evaluator.go`).
+2. Add an `if strings.HasPrefix(name, "audio/") { attrs.IsAudio = true }` block to `setTypeFlags`.
+3. Add a `case "is_audio": return a.attrs.IsAudio, true` to `ResolveName` (`internal/celexpr/activation.go`) and declare the `is_audio` `cel.Variable` (use the `extend-cel-schema` skill).
 
-The reason image is different is that it was the first family to need this pattern; if you add audio/archive/video, you're following the same template, not inventing one.
+The `model3d/`, `image/raw-`, and `font/` families are recent worked examples of this pattern.
 
 ## Verifying a new type
 

--- a/.claude/skills/add-content-type/templates/content_type.go.tmpl
+++ b/.claude/skills/add-content-type/templates/content_type.go.tmpl
@@ -1,9 +1,9 @@
 package content
 
-// REPLACE: package import this type needs (e.g. "encoding/csv", "io", "os") and remove unused imports.
+// REPLACE: package imports this type needs (e.g. "encoding/csv", "io") and remove unused imports.
 import (
 	"context"
-	"os"
+	"io/fs"
 )
 
 func init() {
@@ -32,17 +32,22 @@ func (t *<typename>Type) MagicBytes() [][]byte {
 // decode only what you need to extract the attributes you'll surface to CEL.
 // Return Attributes{} (never nil) if there are no type-specific attributes.
 //
+// Read through fsys (NOT os) so the same parser works against real files,
+// archive entries, and in-memory test filesystems. fsys.Open(path) works for
+// sequential reads; for seekable / random access use the helpers in
+// fsutil.go (openReadSeeker, openReaderAt, readAll).
+//
 // ctx must be honoured: check ctx.Err() at entry, and inside any unbounded
 // scan/decode loop. Return ctx.Err() on cancellation so the walker can
 // terminate cleanly instead of finishing this file then bailing.
 //
 // REPLACE: open the file, do the minimum work needed, return the keys. If you
 // add any keys, also follow the extend-cel-schema skill so cel-go sees them.
-func (t *<typename>Type) Attributes(ctx context.Context, path string) (Attributes, error) {
+func (t *<typename>Type) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	f, err := os.Open(path)
+	f, err := fsys.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/.claude/skills/extend-cel-schema/SKILL.md
+++ b/.claude/skills/extend-cel-schema/SKILL.md
@@ -1,52 +1,59 @@
 ---
 name: extend-cel-schema
-description: Extends file-search-on's CEL attribute schema by editing the four call sites that must move together — `cel.Variable(...)` declarations in `celexpr.New`, the activation defaults map in `Evaluate`, the `attrs.Extra` switch in `Evaluate`, and `celexpr.Schema()` — then runs an audit script that catches drift between them. Use when adding a new content-type attribute, promoting a new front-matter key like `summary` or `slug`, or extending an existing content type's attribute set; cel-go errors at runtime (not compile time) when these fall out of sync, so the audit script is the only deterministic guard.
+description: Extends file-search-on's CEL attribute schema by editing the call sites that must move together — `cel.Variable(...)` declarations in `celexpr.New` (evaluator.go), the `ResolveName` switch + `zeroDefaults` map in `activation.go`, and `celexpr.Schema()` — then runs an audit script that catches drift between them. Use when adding a new content-type attribute, promoting a new front-matter key like `summary` or `slug`, or extending an existing content type's attribute set; cel-go errors at runtime (not compile time) when these fall out of sync, so the audit script is the only deterministic guard.
 ---
 
 # Extend CEL Schema
 
-Every CEL-visible attribute in file-search-on must appear in **four** places. Drift between them produces a runtime error (`no such attribute: foo`) the moment a CEL expression references the missing piece — `go build` will not catch it. This skill makes the four-place invariant explicit and ships an audit script that reports drift.
+Every CEL-visible attribute in file-search-on must be **declared**, **resolvable**, and **documented** — three call sites that must move together. Drift between them produces a runtime error (`no such attribute: foo`) the moment a CEL expression references the missing piece — `go build` will not catch it. This skill makes the invariant explicit and ships an audit script that reports drift.
 
-## The four-place invariant
+## The invariant
 
-| # | Where | What goes there | Failure mode if missing |
-| - | --- | --- | --- |
-| 1 | `internal/celexpr/evaluator.go` — `cel.Variable("foo", cel.<Type>Type)` inside `New` | Declares the variable to cel-go | Compile error: `undeclared reference to 'foo'` |
-| 2 | `internal/celexpr/evaluator.go` — activation defaults map literal in `Evaluate` | Zero value used when the matched type didn't emit this attribute | Runtime error: `no such attribute: foo` |
-| 3 | `internal/celexpr/evaluator.go` — `attrs.Extra` switch in `Evaluate` | Maps the content-type's emitted key to the CEL variable name (often a rename, e.g. `kind` → `json_kind`) | Attribute is always its zero value — silently wrong, no error |
-| 4 | `internal/celexpr/schema.go` — entry in the right `AttributeDoc` slice | Drives both `--list` output and the MCP `list_attributes` tool | Attribute is invisible to humans and to MCP clients |
+A CEL-visible attribute must be **declared**, **resolvable**, and **documented**. Drift produces a runtime error (`no such attribute: foo`) the moment a CEL expression references the missing piece — `go build` will not catch it.
 
-Place 3 only applies to **type-specific** attributes (anything that comes from a `ContentType.Attributes()` map). The "common" attributes (`name`, `path`, `size`, `is_markdown`, …) are populated directly from the `FileAttributes` struct fields and don't go through the switch. Schema slot:
+| Where | What goes there | Failure mode if missing |
+| --- | --- | --- |
+| `internal/celexpr/evaluator.go` — `cel.Variable("foo", cel.<Type>Type)` inside `New` | Declares the variable to cel-go | Compile error: `undeclared reference to 'foo'` |
+| `internal/celexpr/activation.go` — resolution in `(*fileAttrsActivation).ResolveName`, via **either** a `case "foo":` returning a typed `FileAttributes` field **or** a key in the `zeroDefaults` map | How the attribute's value is produced at evaluation time | Runtime error: `no such attribute: foo` |
+| `internal/celexpr/schema.go` — entry in the right `AttributeDoc` slice | Drives both `--list` output and the MCP `list_attributes` tool | Attribute is invisible to humans and to MCP clients |
 
-- `schema.Common` → places 1, 2 (no switch entry)
-- `schema.TypeSpecific` → places 1, 2, 3, 4
-- `schema.Frontmatter` → places 1, 2, 3, 4
+**How resolution works (post-2024 refactor).** `ResolveName(name)` is a single switch:
+
+1. **Typed fields** — common scalars (`name`, `path`, `size`, …) and every `is_*` predicate / `md5` / `similarity` / … resolve via a `case "foo": return a.attrs.Foo, true` that reads a `FileAttributes` struct field. No default needed; the field is always present.
+2. **Type-specific / front-matter attributes** — fall through the switch to a verbatim `Extra[name]` lookup, then to `zeroDefaults[name]`. There is **no rename switch anymore**: the content type's `Attributes()` map must emit the *final CEL name* directly (e.g. emit `img_width`, not `width`; emit `json_kind`, not `kind`). The `zeroDefaults` entry supplies the value for files that didn't emit the key.
+
+Schema slot → what you must add:
+
+- `schema.Common` → `cel.Variable` + a typed `ResolveName` case (struct field). No `zeroDefaults` entry (it's never absent).
+- `schema.TypeSpecific` / `schema.Frontmatter` → `cel.Variable` + a `zeroDefaults` entry + `Attributes()` emitting the key verbatim into `Extra`.
 
 ## Quick start
 
-1. Decide the CEL variable name (snake_case) and type. Decide whether it's `Common`, `TypeSpecific`, or `Frontmatter`.
-2. Add `cel.Variable("foo", cel.<Type>Type)` in `celexpr.New` (place 1).
-3. Add `"foo": <zero-value>` to the activation defaults map in `Evaluate` (place 2).
-4. If the value comes from a `ContentType.Attributes()` map, add a `case "<source-key>": activation["foo"] = v` to the `attrs.Extra` switch (place 3).
-5. Add `{"foo", "<celtype>", "<description>"}` to the right slice in `celexpr.Schema()` (place 4).
-6. **Run** the audit (see Scripts).
-7. Update the README front-matter table if the new attribute is front-matter-related.
-8. Add a test in `internal/content/frontmatter_test.go` (front-matter case) or the relevant content-type test file.
+1. Decide the CEL variable name (snake_case) and type, and whether it's `Common`, `TypeSpecific`, or `Frontmatter`.
+2. Add `cel.Variable("foo", cel.<Type>Type)` in `celexpr.New` (evaluator.go).
+3. Make it resolve in `activation.go`:
+   - **Common / typed predicate**: add a `case "foo": return a.attrs.Foo, true` to `ResolveName` (and the backing `FileAttributes` field).
+   - **Type-specific / front-matter**: add `"foo": <zero-value>` to the `zeroDefaults` map, and make the content type's `Attributes()` put `"foo"` into its returned map verbatim (it flows through the `Extra[name]` fallthrough).
+4. Add `{"foo", "<celtype>", "<description>"}` to the right slice in `celexpr.Schema()`.
+5. **Run** the audit (see Scripts).
+6. Update the README front-matter / attribute tables (the `schema_docs` test enforces this).
+7. Add a test in `internal/content/frontmatter_test.go` (front-matter case) or the relevant content-type test file.
 
 For a new content type's *registration mechanics* (creating the file in `internal/content/`, implementing `ContentType`), see the `add-content-type` skill — this skill only covers the CEL plumbing.
 
 ## Scripts
 
-- **Run** `python scripts/audit_attributes.py` from the repo root — parses `internal/celexpr/evaluator.go` and `internal/celexpr/schema.go`, prints a markdown table of every CEL attribute name with which of the four places it appears in, and exits non-zero on drift. Run before committing any change to those files.
+- **Run** `python scripts/audit_attributes.py` from the repo root — parses `cel.Variable` declarations from `internal/celexpr/evaluator.go`, the `ResolveName` switch cases + `zeroDefaults` map from `internal/celexpr/activation.go`, and the `AttributeDoc` slices from `internal/celexpr/schema.go`. Prints a markdown table (Declared / Cased / Defaulted / Documented per attribute) and exits non-zero on drift — every declared var must be cased OR defaulted, and every documented type-specific/front-matter attr must have a default. Run before committing any change to those files.
 
 ## References
 
-- [references/foot-guns.md](references/foot-guns.md) — the renames in the `attrs.Extra` switch (`kind` → `json_kind`, `width` → `img_width`, …), the cel-go runtime error text, and the image-family branch in `BuildAttributes`.
+- [references/foot-guns.md](references/foot-guns.md) — the verbatim `Extra[name]` resolution (the content type must emit the final CEL name, e.g. `img_width` not `width`; there is no longer a rename switch), the cel-go runtime error text, and the image-family branch in `BuildAttributes`.
 
 ## Conventions
 
 - CEL variable names are `snake_case`. Match the existing style (`json_kind`, `img_width`, `frontmatter_format`).
-- The CEL type for collections is exact: `cel.ListType(cel.StringType)` for `[]string`, `cel.MapType(cel.StringType, cel.DynType)` for `map[string]any`. cel-go errors loudly on type mismatch.
-- Zero values in the activation map must match the declared CEL type (e.g. `int64(0)` for `cel.IntType`, never plain `0`).
-- Do not edit `cmd/file-search-on/main.go:printHelp` — it's data-driven from `celexpr.Schema()`. Editing place 4 is sufficient.
+- The CEL type for collections is exact: `cel.ListType(cel.StringType)` for `[]string`, `cel.ListType(cel.DoubleType)` for `[]float64`, `cel.MapType(cel.StringType, cel.DynType)` for `map[string]any`. cel-go errors loudly on type mismatch.
+- Zero values in the `zeroDefaults` map must match the declared CEL type (e.g. `int64(0)` for `cel.IntType`, `[]string{}` for `cel.ListType(cel.StringType)`, never plain `0`).
+- Do not edit `cmd/file-search-on/main.go:printHelp` — it's data-driven from `celexpr.Schema()`. Editing the `AttributeDoc` slice is sufficient.
+- The `schema_docs` test (`internal/celexpr/schema_docs_test.go`) additionally requires every documented attribute to appear in `README.md` — update the README's attribute / front-matter tables in the same change or that test fails.
 - If the new attribute crosses content types (e.g. `description` could come from PDF metadata *and* HTML `<meta>` *and* markdown front-matter), document each emitting site in the schema description so callers know what they're filtering on.

--- a/.claude/skills/extend-cel-schema/references/foot-guns.md
+++ b/.claude/skills/extend-cel-schema/references/foot-guns.md
@@ -10,29 +10,21 @@ When a CEL variable is referenced by a compiled expression but missing from the 
 search failed: walk: ...: evaluating CEL expression: no such attribute(s): foo
 ```
 
-This is the failure mode for forgetting place 2 (the activation defaults map) or place 3 (the `attrs.Extra` switch — when the expression explicitly references the attribute and no content type emits it). Compile-only smoke tests don't catch this; the test that catches it is one that actually `Walk`s a real directory.
+This is the failure mode for forgetting to make the attribute *resolvable* in `(*fileAttrsActivation).ResolveName` (`internal/celexpr/activation.go`) — either a `case "foo":` returning a typed field, or a `zeroDefaults` key for an Extra-flowing attribute that no content type emitted on this file. Compile-only smoke tests don't catch this; the test that catches it is one that actually `Walk`s a real directory.
 
-The guard against this is the activation defaults map: every `cel.Variable(...)` declared in `New` MUST have a key in the activation map literal in `Evaluate`, with a zero value of the right type. The audit script enforces this.
+The guard is the `zeroDefaults` map: every `cel.Variable(...)` declared in `New` that resolves through `Extra` MUST have a key in `zeroDefaults`, with a zero value of the right type. (Typed-field attributes resolve via a `ResolveName` case instead and don't need a default.) The audit script enforces `declared == cased ∪ defaulted`.
 
-## The renames in the Extra switch
+## No rename layer — emit the final CEL name
 
-The keys content types emit in their `Attributes()` map are NOT always the same as the CEL variable names. The `attrs.Extra` switch in `Evaluate` is a translation layer.
+**There is no `attrs.Extra` rename switch.** (There used to be one in `Evaluate`; the 2024 activation refactor removed it.) `ResolveName` does a *verbatim* `Extra[name]` lookup, so a content type's `Attributes()` map MUST emit the exact CEL variable name — there is no translation step.
 
-Current renames (in `internal/celexpr/evaluator.go`):
+Concretely: `imagetype.go` emits `img_width` / `img_height` directly (not `width` / `height`); a JSON type that wants the `json_kind` CEL variable must put `"json_kind"` into its returned map, not `"kind"`. If the emitted key and the CEL name diverge, the attribute silently stays at its zero value — no error, just wrong.
 
-| Source key (from `Attributes()`) | CEL variable |
-| --- | --- |
-| `kind` | `json_kind` |
-| `width` | `img_width` |
-| `height` | `img_height` |
-
-All other keys pass through unchanged (`title` → `title`, `word_count` → `word_count`, etc.).
-
-When adding a new attribute, you can either keep the same name on both sides (preferred) or introduce a rename. Renames are warranted when the source key is a generic word that would clash across content types — `kind` makes sense locally inside `jsonType.Attributes` but `json_kind` is clearer in CEL.
+When adding a new attribute, keep the same name on both sides. If you want a "namespaced" CEL name (`json_kind` rather than a bare `kind`), do the naming inside the content type's `Attributes()` map — that's the only place the name is set now.
 
 ## Type mismatches between zero value and `cel.Variable` type
 
-The zero value in the activation map must match the declared CEL type:
+The zero value in the `zeroDefaults` map must match the declared CEL type:
 
 | `cel.Variable` type | Zero value |
 | --- | --- |
@@ -45,37 +37,42 @@ The zero value in the activation map must match the declared CEL type:
 
 cel-go errors with a confusing "unsupported type conversion" message on mismatch. The audit script does not check zero-value types — `go vet` and the existing test suite do.
 
-## Image-family branching
+## Family-prefix branching
 
-Image content types use a name prefix (`image/jpeg`, `image/png`, …). The `BuildAttributes` function in `evaluator.go` (around line 189) maps any name starting with `image/` to `is_image = true` via:
+Family `is_*` predicates are set by name-prefix blocks in `setTypeFlags` (`internal/celexpr/evaluator.go`). For example, any name starting with `image/` sets `attrs.IsImage = true`:
 
 ```go
-case strings.HasPrefix(contentTypeName, "image/"):
-    isImage = true
+if strings.HasPrefix(name, "image/") {
+    attrs.IsImage = true
+}
 ```
 
 When adding a new image variant (e.g. `image/avif`):
 
 1. Register it like any other content type — name MUST start with `image/`.
-2. The `BuildAttributes` branch picks it up automatically; no edit needed there.
+2. The `setTypeFlags` prefix block picks it up automatically; no edit needed there.
 
-When adding a NEW family with its own `is_*` boolean (e.g. an audio family with `is_audio`), you DO need to edit `BuildAttributes`: add a `case strings.HasPrefix(contentTypeName, "audio/"): isAudio = true` and follow the four-place invariant for the `is_audio` CEL variable.
+When adding a NEW family with its own `is_*` boolean (e.g. a 3D-model family with `is_3d_model`), you DO need to:
 
-## When to update the README front-matter table
+1. Add the `Is3DModel bool` field to `FileAttributes`.
+2. Add a `case "is_3d_model": return a.attrs.Is3DModel, true` to `ResolveName` (activation.go).
+3. Add a `if strings.HasPrefix(name, "model3d/") { attrs.Is3DModel = true }` block to `setTypeFlags`.
+4. Declare the `is_3d_model` `cel.Variable` and document it in `Schema()`.
 
-The README has a hand-maintained front-matter table at the bottom of "Markdown front-matter search". Update it when:
+(See the `model3d/`, `image/raw-`, and `font/` families for worked examples.)
 
-- Adding a new front-matter promoted variable (place 4 row in `schema.Frontmatter`).
-- Changing the precedence note (e.g. front-matter > H1 for `title`).
+## You MUST update the README — `schema_docs_test` enforces it
 
-The README does NOT list common attributes (`name`, `size`, …) or type-specific attributes (`page_count`, `img_width`, …) — those live only in `--list` and the MCP `list_attributes` tool. Don't add them to the README.
+`internal/celexpr/schema_docs_test.go` cross-checks every `AttributeDoc` and `FunctionDoc` in `Schema()` against `README.md`: each documented attribute / function name must appear as a backticked literal somewhere in the README, or the test fails with e.g. `README.md missing TypeSpecific attribute "face_count"`.
+
+So when you add a `schema.Common` / `schema.TypeSpecific` / `schema.Frontmatter` entry, also add the name to the matching README table (the per-family attribute tables under "Available attributes", or the front-matter table). This is not optional — `go test ./internal/celexpr/` will go red otherwise. (Historically the README only listed front-matter attributes; the test now covers the full schema.)
 
 ## What the audit script does NOT catch
 
-The audit script enforces the four-place invariant for CEL attribute *names*. It does not check:
+The audit script enforces the declared / resolvable / documented invariant for CEL attribute *names*. It does not check:
 
 - Whether the CEL variable type matches the zero value's Go type.
-- Whether the source key in the Extra switch matches what content types actually emit.
+- Whether the key a content type actually emits into `Extra` matches the declared CEL name (the verbatim lookup means a typo'd emit key silently yields the zero value — see "No rename layer" above).
 - Whether the `AttributeDoc.Type` string in `Schema()` matches the declared `cel.Variable` type.
 
-Those checks are the job of `go build`, `go vet`, and the existing test suite. The audit catches the one class of error that no compiler will.
+Those checks are the job of `go build`, `go vet`, and the existing test suite (including `schema_docs_test.go`, which cross-checks `Schema()` against the README). The audit catches the one class of error that no compiler will.

--- a/.claude/skills/extend-cel-schema/scripts/audit_attributes.py
+++ b/.claude/skills/extend-cel-schema/scripts/audit_attributes.py
@@ -1,22 +1,38 @@
 #!/usr/bin/env python3
-"""Audit file-search-on's CEL attribute schema for drift between the four call sites.
+"""Audit file-search-on's CEL attribute schema for drift between the call sites.
 
 Usage: python audit_attributes.py [--repo-root .]
 
-Exits 0 if every CEL attribute appears in every place it must, non-zero on drift.
-Prints a markdown table summarising the state of each attribute.
+Exits 0 if every CEL attribute is declared, resolvable, and documented
+consistently; non-zero on drift. Prints a markdown table summarising each
+attribute.
 
-The four places (see extend-cel-schema/SKILL.md):
-  1. cel.Variable("foo", ...) declarations in celexpr.New             (-> declared)
-  2. activation defaults map literal in celexpr.Evaluate              (-> defaulted)
-  3. attrs.Extra switch case assignments in celexpr.Evaluate          (-> assigned)
-  4. AttributeDoc{...} entries in celexpr.Schema()                    (-> documented)
+The places a CEL attribute must appear (see extend-cel-schema/SKILL.md):
+  1. cel.Variable("foo", ...) declarations in celexpr.New
+     (internal/celexpr/evaluator.go)                                  -> declared
+  2. resolvable in (*fileAttrsActivation).ResolveName
+     (internal/celexpr/activation.go), via EITHER:
+       a. a `case "foo":` label returning a typed FileAttributes field
+          (common scalars + is_* predicates + md5/sha1/...)           -> cased
+       b. a key in the `zeroDefaults` map literal (type-specific attrs
+          that flow through the verbatim `Extra[name]` fallthrough)    -> defaulted
+  3. AttributeDoc{...} entries in celexpr.Schema()
+     (internal/celexpr/schema.go)                                     -> documented
+
+Note (2024 refactor): the activation machinery moved out of celexpr.Evaluate
+into internal/celexpr/activation.go. There is no longer an
+`activation["foo"] = v` rename switch — type-specific attributes resolve by
+verbatim key match against FileAttributes.Extra (so the content type must
+emit the final CEL name directly), falling back to zeroDefaults when a file
+didn't emit them. "Resolvable" therefore means cased OR defaulted.
 
 Invariants:
-  declared == defaulted                                          (sanity, hard error on drift)
-  documented (any slice) ⊆ declared                              (hard error)
-  documented (TypeSpecific ∪ Frontmatter) ⊆ assigned             (hard error)
-  declared - documented                                          (warn — undocumented attribute)
+  declared == (cased ∪ defaulted)        (every declared var resolves; no orphans — hard error)
+  documented ⊆ declared                  (can't document an undeclared var — hard error)
+  documented (TypeSpecific ∪ Frontmatter) ⊆ defaulted
+                                         (Extra-flowing docs need a zero default so files
+                                          that don't emit them don't error — hard error)
+  declared - documented                  (warn — undocumented, hidden from --list)
 """
 from __future__ import annotations
 
@@ -27,22 +43,19 @@ from pathlib import Path
 
 
 CEL_VARIABLE_RE = re.compile(r'cel\.Variable\(\s*"([^"]+)"')
+# A `case "a":` or `case "a", "b":` label line inside ResolveName.
+CASE_LINE_RE = re.compile(r'^\s*case\s+(.+?):\s*$')
+QUOTED_RE = re.compile(r'"([^"]+)"')
 ACTIVATION_KEY_RE = re.compile(r'^\s*"([^"]+)"\s*:')
-ASSIGN_RE = re.compile(r'activation\[\s*"([^"]+)"\s*\]\s*=')
 DOC_ENTRY_RE = re.compile(r'\{\s*"([^"]+)"\s*,\s*"([^"]*)"\s*,\s*"[^"]*"\s*\}')
 
 
-def parse_evaluator(text: str) -> tuple[set[str], set[str], set[str]]:
-    """Return (declared, defaulted, assigned) sets parsed from evaluator.go."""
-    declared = set(CEL_VARIABLE_RE.findall(text))
-
-    # Locate the activation map literal: starts at `activation := map[string]any{`
-    # ends at the matching closing brace at the same indentation level.
-    start_marker = "activation := map[string]any{"
+def find_block(text: str, start_marker: str, what: str) -> str:
+    """Return the brace-balanced block body following start_marker (the
+    marker must end with the opening `{`)."""
     start = text.find(start_marker)
     if start < 0:
-        raise SystemExit("ERROR: could not find `activation := map[string]any{` in evaluator.go")
-    # Track brace depth from the opening { in the marker
+        raise SystemExit(f"ERROR: could not find `{start_marker}` ({what})")
     open_brace = start + len(start_marker) - 1
     depth = 1
     i = open_brace + 1
@@ -52,38 +65,52 @@ def parse_evaluator(text: str) -> tuple[set[str], set[str], set[str]]:
         elif text[i] == "}":
             depth -= 1
         i += 1
-    activation_block = text[open_brace + 1 : i - 1]
-    defaulted = set()
-    for line in activation_block.splitlines():
+    return text[open_brace + 1 : i - 1]
+
+
+def parse_declared(evaluator_text: str) -> set[str]:
+    """cel.Variable declarations in celexpr.New."""
+    return set(CEL_VARIABLE_RE.findall(evaluator_text))
+
+
+def parse_activation(activation_text: str) -> tuple[set[str], set[str]]:
+    """Return (cased, defaulted) from activation.go.
+
+    cased     — string labels of every `case "..."` in ResolveName's switch.
+    defaulted — keys of the `var zeroDefaults = map[string]any{...}` literal.
+    """
+    # 1. ResolveName switch case labels (handles multi-label `case "a", "b":`).
+    body = find_block(
+        activation_text,
+        "func (a *fileAttrsActivation) ResolveName(name string) (any, bool) {",
+        "ResolveName in activation.go",
+    )
+    cased: set[str] = set()
+    for line in body.splitlines():
+        m = CASE_LINE_RE.match(line)
+        if m:
+            cased.update(QUOTED_RE.findall(m.group(1)))
+
+    # 2. zeroDefaults map keys.
+    defaults_block = find_block(
+        activation_text,
+        "var zeroDefaults = map[string]any{",
+        "zeroDefaults in activation.go",
+    )
+    defaulted: set[str] = set()
+    for line in defaults_block.splitlines():
         m = ACTIVATION_KEY_RE.match(line)
         if m:
             defaulted.add(m.group(1))
 
-    assigned = set(ASSIGN_RE.findall(text))
-    return declared, defaulted, assigned
+    return cased, defaulted
 
 
 def parse_schema(text: str) -> dict[str, list[tuple[str, str]]]:
-    """Return mapping of slice name (Common / TypeSpecific / Frontmatter) to a list
-    of (attribute_name, attribute_type) tuples in source order."""
+    """Map slice name (Common / TypeSpecific / Frontmatter) to (name, type) tuples."""
     result: dict[str, list[tuple[str, str]]] = {}
-    # Find each `Common: []AttributeDoc{` / `TypeSpecific: []AttributeDoc{` / `Frontmatter: []AttributeDoc{`
     for slice_name in ("Common", "TypeSpecific", "Frontmatter"):
-        marker = f"{slice_name}: []AttributeDoc{{"
-        start = text.find(marker)
-        if start < 0:
-            raise SystemExit(f"ERROR: could not find `{marker}` in schema.go")
-        # Find matching closing brace
-        open_brace = start + len(marker) - 1
-        depth = 1
-        i = open_brace + 1
-        while i < len(text) and depth > 0:
-            if text[i] == "{":
-                depth += 1
-            elif text[i] == "}":
-                depth -= 1
-            i += 1
-        block = text[open_brace + 1 : i - 1]
+        block = find_block(text, f"{slice_name}: []AttributeDoc{{", f"{slice_name} in schema.go")
         result[slice_name] = [(m.group(1), m.group(2)) for m in DOC_ENTRY_RE.finditer(block)]
     return result
 
@@ -95,72 +122,72 @@ def main() -> int:
 
     root = args.repo_root.resolve()
     evaluator_path = root / "internal" / "celexpr" / "evaluator.go"
+    activation_path = root / "internal" / "celexpr" / "activation.go"
     schema_path = root / "internal" / "celexpr" / "schema.go"
-    for p in (evaluator_path, schema_path):
+    for p in (evaluator_path, activation_path, schema_path):
         if not p.exists():
             print(f"ERROR: {p} not found (run from the repo root, or pass --repo-root)", file=sys.stderr)
             return 1
 
-    declared, defaulted, assigned = parse_evaluator(evaluator_path.read_text(encoding="utf-8"))
+    declared = parse_declared(evaluator_path.read_text(encoding="utf-8"))
+    cased, defaulted = parse_activation(activation_path.read_text(encoding="utf-8"))
     schema = parse_schema(schema_path.read_text(encoding="utf-8"))
+
+    resolvable = cased | defaulted
 
     documented_common = {n for n, _ in schema["Common"]}
     documented_typespec = {n for n, _ in schema["TypeSpecific"]}
     documented_frontmatter = {n for n, _ in schema["Frontmatter"]}
     documented_all = documented_common | documented_typespec | documented_frontmatter
-    must_be_assigned = documented_typespec | documented_frontmatter
+    extra_flowing_docs = documented_typespec | documented_frontmatter
 
     errors: list[str] = []
     warnings: list[str] = []
 
-    # Invariant 1: declared == defaulted
-    only_declared = declared - defaulted
-    only_defaulted = defaulted - declared
-    if only_declared:
+    # Invariant 1: declared == resolvable.
+    declared_unresolvable = declared - resolvable
+    if declared_unresolvable:
         errors.append(
-            f"declared but missing zero-value default in activation map: {sorted(only_declared)}"
+            "declared via cel.Variable but neither a ResolveName `case` nor a "
+            f"zeroDefaults key (→ runtime 'no such attribute'): {sorted(declared_unresolvable)}"
         )
-    if only_defaulted:
+    resolvable_undeclared = resolvable - declared
+    if resolvable_undeclared:
         errors.append(
-            f"defaulted in activation map but not declared via cel.Variable: {sorted(only_defaulted)}"
+            "resolvable in activation.go (case or zeroDefaults) but not declared via "
+            f"cel.Variable: {sorted(resolvable_undeclared)}"
         )
 
-    # Invariant 2: documented ⊆ declared
+    # Invariant 2: documented ⊆ declared.
     documented_not_declared = documented_all - declared
     if documented_not_declared:
         errors.append(
             f"documented in schema.go but not declared via cel.Variable: {sorted(documented_not_declared)}"
         )
 
-    # Invariant 3: type-specific & front-matter docs ⊆ assigned
-    must_assign_missing = must_be_assigned - assigned
-    if must_assign_missing:
+    # Invariant 3: Extra-flowing docs (TypeSpecific ∪ Frontmatter) need a zero
+    # default — they resolve via the verbatim Extra fallthrough, so a file that
+    # doesn't emit them must fall back to a default or cel-go errors. (A doc
+    # that's instead handled by a typed `case` is fine — exclude those.)
+    extra_flowing_missing_default = extra_flowing_docs - defaulted - cased
+    if extra_flowing_missing_default:
         errors.append(
-            f"documented as type-specific/front-matter but no `activation[\"foo\"] = v` "
-            f"assignment in the attrs.Extra switch: {sorted(must_assign_missing)}"
+            "documented as type-specific/front-matter but no zeroDefaults entry "
+            f"(and not a typed ResolveName case): {sorted(extra_flowing_missing_default)}"
         )
 
-    # Sanity: assignments should target declared variables (unless they are common — but
-    # common attrs are populated from struct fields, never via the switch, so any switch
-    # assignment is to a type-specific or front-matter slot).
-    assigned_not_declared = assigned - declared
-    if assigned_not_declared:
-        errors.append(
-            f"attrs.Extra switch assigns to undeclared CEL variable: {sorted(assigned_not_declared)}"
-        )
-
-    # Warning: declared but undocumented (the `--list` view will hide it).
+    # Warning: declared but undocumented (hidden from --list / list_attributes).
     declared_not_documented = declared - documented_all
     if declared_not_documented:
         warnings.append(
-            f"declared via cel.Variable but not documented in schema.go (won't show "
+            "declared via cel.Variable but not documented in schema.go (won't show "
             f"in --list or list_attributes): {sorted(declared_not_documented)}"
         )
 
-    # Build the markdown report.
-    print("| Attribute | Declared | Defaulted | Assigned | Documented |")
+    # Markdown report.
+    print("| Attribute | Declared | Cased | Defaulted | Documented |")
     print("| --- | --- | --- | --- | --- |")
-    every = sorted(declared | defaulted | assigned | documented_all)
+    every = sorted(declared | resolvable | documented_all)
     for name in every:
         slot = ""
         if name in documented_common:
@@ -170,12 +197,12 @@ def main() -> int:
         elif name in documented_frontmatter:
             slot = "Frontmatter"
         d = "✓" if name in declared else "—"
+        c = "✓" if name in cased else "—"
         f_ = "✓" if name in defaulted else "—"
-        a = "✓" if name in assigned else ("·" if slot == "Common" else "—")
         doc = slot if slot else "—"
-        print(f"| `{name}` | {d} | {f_} | {a} | {doc} |")
+        print(f"| `{name}` | {d} | {c} | {f_} | {doc} |")
     print()
-    print("Legend: ✓ = present, — = missing, · = N/A (common attrs are not assigned via the switch)")
+    print("Legend: ✓ = present, — = absent. A declared attr must be Cased OR Defaulted.")
     print()
 
     for w in warnings:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ file-search-on -d .                                   # empty expression matches
 | `archive-contents <path> [--expr]` | List or filter entries inside ZIP / TAR / TAR.GZ / GZIP — full CEL vocabulary on per-entry attributes | [examples/archive-search.md](./examples/archive-search.md) |
 | `archive-read <path> <entry>` | Read a single entry's bytes out of an archive without extracting | [examples/archive-search.md](./examples/archive-search.md) |
 | `find-matches <re> --expr <cel> -C N` | Line-level regex hits with context | [examples/find-matches.md](./examples/find-matches.md) |
+| `watch [expr] -d <dir>` | Continuously watch directories; emit each new / changed file that matches — the inverse of `search` | [examples/watch.md](./examples/watch.md) |
 | `organize <expr> --link-into <template>` | Build a templated symlink / copy tree from results — `{raw_vendor}/{taken_at_year}/{basename}` etc. | [examples/organize.md](./examples/organize.md) |
 | `lines <path> --start --end` | Print a line range | [examples/read-lines.md](./examples/read-lines.md) |
 | `detect-project [dir]` | Identify project type(s) of a directory | [examples/projects.md](./examples/projects.md) |

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -59,6 +59,7 @@ var CLI struct {
 	ArchiveRead     ArchiveReadCmd     `cmd:"" name:"archive-read" help:"Read a single file's content out of a ZIP / TAR / TAR.GZ / GZIP archive without extracting. Returns the bytes plus detected content_type + attributes."`
 	FindMatches     FindMatchesCmd     `cmd:"" name:"find-matches" help:"Scan text files for an RE2 regex; report line-level hits with optional context windows (combines CEL type-pruning with grep-style output)."`
 	Organize        OrganizeCmd        `cmd:"" name:"organize" help:"Build a templated symlink (or copy) tree from search results — a virtual organized view of a flat directory without moving the originals. e.g. organize 'is_raw_photo' --link-into '~/sorted/{raw_vendor}/{mtime_year}/{basename}'."`
+	Watch           WatchCmd           `cmd:"" name:"watch" help:"Continuously watch directories and emit each new / changed file that matches a CEL expression (the inverse of search — 'tell me when X appears'). Runs until Ctrl-C. e.g. watch 'is_image && body.contains(\"error\")' --ocr -d ~/Desktop."`
 	Detect          DetectProjectCmd   `cmd:"" name:"detect-project" help:"Identify project type(s) (go / node / rust / …) for a directory by checking canonical indicator files."`
 	Projects        FindProjectsCmd    `cmd:"" name:"find-projects" help:"Walk a root and list every project subdirectory under it."`
 	WhichProject    WhichProjectCmd    `cmd:"" name:"which-project" help:"Given a file or directory path, walk up the chain and identify the nearest enclosing project root and type(s)."`

--- a/cmd/file-search-on/watch_cmd.go
+++ b/cmd/file-search-on/watch_cmd.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"text/template"
+	"time"
+
+	contentpkg "github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// WatchCmd is the continuous-query counterpart of `search`: instead of
+// walking the tree once, it watches for new / modified files and emits
+// each one that matches the CEL expression, until Ctrl-C. Issue #211.
+type WatchCmd struct {
+	Expr   string   `arg:"" optional:"" help:"CEL expression to match against new / changed files (e.g. 'is_image && body.contains(\"error\")'). Empty matches everything."`
+	Dir    []string `short:"d" name:"dir" default:"." help:"Directory to watch. Repeatable; each is watched recursively (subdirectories created later are picked up automatically)."`
+	Output string   `short:"o" name:"output" enum:"json,bare" default:"json" help:"Output per match: json (NDJSON, one object per line) | bare (path only)."`
+	Format string   `name:"format" help:"Custom Go text/template applied per match (e.g. '{{.Path}}\\t{{.ContentType}}'). Overrides -o."`
+
+	IndexPath        string        `name:"index-path" help:"Persistent attribute index (bbolt) — caches per-file parses + bodies (incl. OCR) across the watch and across runs."`
+	Exclude          []string      `name:"exclude" help:"Basename glob to prune from the watched tree. Repeatable."`
+	RespectGitignore bool          `name:"respect-gitignore" help:"Honour a .gitignore at each watch root when registering directories."`
+	Body             bool          `name:"body" help:"Make file body available as the 'body' CEL variable (needed for body.contains / has_secrets / etc.)."`
+	BodyMaxBytes     int           `name:"body-max-bytes" default:"0" help:"Cap on the body string per file in bytes. 0 = 1 MiB default."`
+	OCR              bool          `name:"ocr" help:"Run OCR over new image/* files (macOS Vision). Populates body + ocr_* for body.contains queries on screenshots."`
+	OCRTimeout       time.Duration `name:"ocr-timeout" default:"10s" help:"Per-file OCR timeout."`
+	WithHashes       bool          `name:"with-hashes" help:"Compute md5 / sha1 / sha256 for each matched file."`
+	WithPHash        bool          `name:"with-phash" help:"Compute the perceptual hash (phash) of each new image."`
+	WithXattrs       bool          `name:"with-xattrs" help:"Read macOS extended attributes for each new file (Darwin only)."`
+}
+
+func (c *WatchCmd) Run(ctx context.Context) error {
+	var tmpl *template.Template
+	if c.Format != "" {
+		t, err := parseFormatTemplate(c.Format)
+		if err != nil {
+			return fmt.Errorf("parsing --format template: %w", err)
+		}
+		tmpl = t
+	}
+
+	idx, err := openIndex(c.IndexPath, index.BodyCacheCap{})
+	if err != nil {
+		return err
+	}
+	if idx != nil {
+		defer func() { _ = idx.Close() }()
+	}
+
+	opts := search.Options{
+		Roots:                  c.Dir,
+		Expr:                   c.Expr,
+		IncludeAttributes:      true, // JSON / template output wants the full attrs
+		Index:                  idx,
+		IncludeBody:            c.Body,
+		BodyMaxBytes:           c.BodyMaxBytes,
+		OCRImages:              c.OCR,
+		OCRTimeout:             c.OCRTimeout,
+		WithPHash:              c.WithPHash,
+		ComputeHashes:          c.WithHashes,
+		ReadExtendedAttributes: c.WithXattrs,
+		Excludes:               c.Exclude,
+		RespectGitignore:       c.RespectGitignore,
+	}
+
+	// onMatch fires from debounce-timer goroutines, so serialise the
+	// writes. Buffered stdout would risk losing a tail on Ctrl-C, so
+	// write straight through.
+	enc := json.NewEncoder(os.Stdout)
+	var mu sync.Mutex
+	onMatch := func(r search.Result) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch {
+		case tmpl != nil:
+			_ = tmpl.Execute(os.Stdout, search.MatchFrom(r))
+			_, _ = fmt.Fprintln(os.Stdout)
+		case c.Output == "bare":
+			_, _ = fmt.Fprintln(os.Stdout, r.Path)
+		default:
+			_ = enc.Encode(search.MatchFrom(r)) // NDJSON
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "watching %v for %q (Ctrl-C to stop)…\n", c.Dir, orTrue(c.Expr))
+	return search.Watch(ctx, opts, contentpkg.DefaultRegistry(), onMatch)
+}
+
+func orTrue(expr string) string {
+	if expr == "" {
+		return "true"
+	}
+	return expr
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,6 +41,7 @@ CEL expression recipes by content family, plus cross-cutting cookbook patterns.
 | [`near-duplicates.md`](./near-duplicates.md) | Find SIMILAR files via SimHash fingerprint — catches typo edits, regenerated headers, template copies. `file-search-on near-duplicates [--threshold 0.85]` |
 | [`archive-search.md`](./archive-search.md) | List or read entries inside ZIP / TAR / TAR.GZ / GZIP without extracting — `file-search-on archive-contents <archive> [--expr]` and `file-search-on archive-read <archive> <entry>` |
 | [`find-matches.md`](./find-matches.md) | Line-level regex matching with context — `file-search-on find-matches '<re>' --expr 'is_source' -C 2` |
+| [`watch.md`](./watch.md) | Watch directories continuously and emit each new / changed file that matches — the inverse of `search`. `file-search-on watch '<expr>' -d DIR`; bounded `watch_search` MCP tool |
 | [`forensics.md`](./forensics.md) | Forensic triage — `--with-hashes` populates `md5` / `sha1` / `sha256` (NSRL / VirusTotal / threat-intel interop), magic-byte-vs-extension detection, GPS / EXIF / email triage, time-bucketed activity |
 | [`hashsets.md`](./hashsets.md) | Hash allowlist / denylist — `is_known_good` / `is_known_bad` predicates; build NSRL or threat-intel-feed `.hashset` files via `file-search-on hash-set build` |
 | [`semantic-search.md`](./semantic-search.md) | Semantic similarity via local Ollama embeddings — `similarity` CEL variable + `search_semantic` MCP tool; conceptual / paraphrase-tolerant document discovery |

--- a/examples/watch.md
+++ b/examples/watch.md
@@ -1,0 +1,107 @@
+# Watching for new / changed files
+
+The `watch` subcommand (and the matching MCP `watch_search` tool) is the **inverse of `search`**: instead of walking a tree once and reporting what already matches, it watches directories continuously and emits each new or changed file *as it appears*, filtered by the same CEL expression vocabulary. "Tell me when X shows up" rather than "what X is here right now".
+
+## When to reach for this vs `search`
+
+| Question | Tool |
+| --- | --- |
+| "What files match X right now?" — one-shot walk | [`search`](../README.md) |
+| "Tell me each time a file matching X appears" — continuous | **`watch`** |
+| "Wait up to N seconds for the next matching file, then stop" — bounded | **`watch_search`** MCP tool |
+
+Typical uses: a `~/Downloads` triage (`is_pdf && page_count > 50`), screenshot OCR as you save them (`is_image && body.contains("error")` with `--ocr`), build-artefact spotting (`is_binary`), or feeding a pipeline that reacts to new data drops.
+
+## How it works
+
+Built on [fsnotify](https://github.com/fsnotify/fsnotify). Every directory under each watch root is registered up front; directories created *during* the watch are registered when their `CREATE` event arrives, so the watch is effectively recursive. Each `CREATE` / `WRITE` event is debounced (300 ms) to coalesce the multi-write bursts editors and downloaders emit into a single evaluation, then the file is run through the **exact same** `BuildAttributes` + CEL `Evaluate` path as `search` — so OCR, hashes, perceptual hash, body access, xattrs, and index caching all compose identically.
+
+Only create + write events are considered; deletes and renames are out of scope. Files created inside a brand-new directory in the narrow window before its watch is added can be missed — an inherent fsnotify race, acceptable for a "notice new matches" tool.
+
+## CLI
+
+Runs until Ctrl-C. Output is NDJSON by default (one match object per line), or `-o bare` for paths only, or a custom `--format` template.
+
+```sh
+# Every new / changed markdown file under the docs tree
+file-search-on watch 'is_markdown' -d ./docs
+
+# Watch Downloads for large PDFs, paths only
+file-search-on watch 'is_pdf && page_count > 50' -d ~/Downloads -o bare
+
+# OCR each screenshot as it lands on the Desktop; match ones mentioning "invoice"
+file-search-on watch 'is_image && body.contains("invoice")' --ocr -d ~/Desktop
+
+# Watch several roots at once (repeat -d), custom output line
+file-search-on watch 'is_source && language == "go"' \
+  -d ./cmd -d ./internal \
+  --format '{{.Path}}	{{.ContentType}}'
+
+# Persist parses/bodies across the watch (and across runs) with an index
+file-search-on watch 'is_image' --ocr --index-path ~/.fso-index.db -d ~/Screenshots
+
+# Empty expression matches every new / changed file
+file-search-on watch -d ./incoming -o bare
+```
+
+Flags mirror `search` where they make sense: `--body` / `--body-max-bytes`, `--ocr` / `--ocr-timeout`, `--with-hashes`, `--with-phash`, `--with-xattrs`, `--exclude`, `--respect-gitignore`, `--index-path`. Ranking, semantic embedding, and project resolution are omitted — they're walk-collection concerns, not single-file-event concerns.
+
+NDJSON output is the same wire shape as `search -o json`, so the same `jq` recipes work:
+
+```sh
+file-search-on watch 'is_image' --with-phash -d ~/Screenshots | jq '{path, phash}'
+```
+
+## MCP
+
+The MCP surface is a **bounded** `watch_search` tool rather than open-ended streaming: it blocks for a watch window, collects matching files, and returns them in one response. MCP is request/response, so an unbounded subscription would hang the call forever — use the CLI `watch` for that.
+
+```json
+{
+  "name": "watch_search",
+  "arguments": {
+    "expr": "is_image && body.contains(\"error\")",
+    "dir": "/Users/me/Desktop",
+    "duration_seconds": 60,
+    "max_events": 5,
+    "ocr_images": true
+  }
+}
+```
+
+The call returns when **any** of these happens first: `duration_seconds` elapses (default 30s, hard-capped at 600s), `max_events` matches are collected, or the client cancels.
+
+Response:
+
+```json
+{
+  "matches": [
+    {
+      "path": "/Users/me/Desktop/Screenshot 2026-05-27 at 14.03.10.png",
+      "content_type": "image/png",
+      "size": 481222,
+      "ocr_confidence": 0.94,
+      "body": "… Build error: cannot find module …"
+    }
+  ],
+  "count": 1,
+  "watched_seconds": 12.4,
+  "hit_max_events": true
+}
+```
+
+`hit_max_events` is `true` when the watch returned early because `max_events` was reached; otherwise the window ran to `duration_seconds`. Inputs mirror the `search` tool: `ocr_images` / `ocr_timeout_ms`, `compute_hashes`, `with_phash`, `with_xattrs`, `include_body` / `body_max_bytes`, `excludes`, `respect_gitignore`, and `dir` / `dirs`.
+
+## Pitfalls
+
+- **Debounce window is 300 ms.** A file written and matched once won't re-emit for sub-300ms re-saves. Rapid append-loops (e.g. a growing log) emit at most one event per 300 ms quiet period, not per write.
+- **No delete / rename events.** `watch` only reports files that exist and match at evaluation time. A file matched then deleted within the window still appears (it existed when the debounce timer fired).
+- **New-subdirectory race.** A file created in the same instant a new subdirectory is created can be missed before the subdir's watch is armed. Re-running a `search` over the tree afterwards catches any such gaps.
+- **`watch_search` is bounded.** It is not a persistent subscription — it returns after the window. For long-lived monitoring, run the CLI `watch` subcommand as a background process.
+- **OCR / hashing cost applies per event.** With `--ocr` or `--with-hashes`, every matching event pays the extraction cost. Pair with `--index-path` so repeat hits on unchanged files are free.
+
+## Related recipes
+
+- [`ocr.md`](ocr.md) — OCR provider details; pairs with `watch --ocr` for live screenshot triage.
+- [`body-search.md`](body-search.md) — the `body.contains` / `body.matches` filters that `watch --body` enables.
+- [`indexing.md`](indexing.md) — `--index-path` caching, which makes repeat watch evaluations free.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
 	github.com/djherbis/times v1.6.0
 	github.com/evanoberholster/imagemeta v1.0.0
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/cel-go v0.28.1
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/evanoberholster/imagemeta v1.0.0 h1:FlSihlsjkWIoS83wmgPOP3CbAxlRpxM8jQGZgLu+MWQ=
 github.com/evanoberholster/imagemeta v1.0.0/go.mod h1:2ITZJjD1ygzWIhepvn8coRvpaFcnDNk3E6hx6v7z8DU=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/cel-go v0.28.1 h1:YWIwi77J4xIsYUwAF/iIuS6haffzIHS8yWI8glSbLWM=

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -331,6 +331,11 @@ func New(version string, idx index.Index, defaultTimeout time.Duration, embedDef
 	}, h.findMatchesHandler)
 
 	mcp.AddTool(s, &mcp.Tool{
+		Name:        "watch_search",
+		Description: "Watch directories for a BOUNDED window and return every new / changed file that matches a CEL expression — the inverse of search ('tell me when X appears' instead of 'what already matches'). Same CEL vocabulary as the search tool (is_image, is_pdf, is_source && language == \"go\", size > 1000000, body.contains(\"error\"), …). Watches recursively (subdirectories created during the window are picked up). Blocks until duration_seconds elapses (default 30s, hard-capped at 600s), max_events matches are collected, or the call is cancelled — whichever comes first; then returns the collected matches. Inputs: expr (optional CEL filter), dir / dirs, duration_seconds (how long to watch), max_events (return early after N matches), plus the usual ocr_images / compute_hashes / with_phash / with_xattrs / include_body / excludes / respect_gitignore flags. Output: matches[] (same shape as search) + watched_seconds + hit_max_events. Use for short 'wait for the next screenshot / build artefact / download' flows; for open-ended streaming use the CLI 'watch' subcommand. Issue #211.",
+	}, h.watchSearchHandler)
+
+	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_presets",
 		Description: "List every named search recipe ('preset') available to the query_preset tool — each preset bakes a vetted CEL filter + sensible sort / limit defaults for a common workflow. Use this to discover what's available before calling query_preset. v1 presets: recent_changes (files modified in the last 7 days), recent_photos (images taken in the last 30 days), old_drafts (markdown drafts older than 90 days — neglected work), large_files (files > 100 MB), large_binaries (compiled binaries > 100 MB), suspicious_files (forensic-triage shortcut — disguised files or btime anomalies; auto-enables check_disguised), failed_tests (source test files mentioning FAIL/FIXME/XXX; auto-enables include_body), system_metadata (OS leftovers — .DS_Store / Thumbs.db / Desktop.ini / .directory). Output: presets[] with name + description; pass the name to query_preset to run.",
 	}, h.listPresetsHandler)

--- a/internal/mcpserver/server_version_test.go
+++ b/internal/mcpserver/server_version_test.go
@@ -213,6 +213,17 @@ func TestServerVersionInResponses(t *testing.T) {
 			},
 		},
 		{
+			// Short fixed window so the bounded watch returns promptly;
+			// we only assert the version wiring, not match behaviour.
+			name: "watch_search",
+			args: WatchSearchInput{Dir: dir, DurationSeconds: 0.2},
+			decode: func(t *testing.T, res *mcp.CallToolResult) string {
+				var o WatchSearchOutput
+				mustDecodeStructured(t, res, &o)
+				return o.ServerVersion
+			},
+		},
+		{
 			name: "query_preset",
 			args: QueryPresetInput{Name: "recent_changes", Dir: dir, Limit: 1},
 			decode: func(t *testing.T, res *mcp.CallToolResult) string {

--- a/internal/mcpserver/watch_tool.go
+++ b/internal/mcpserver/watch_tool.go
@@ -1,0 +1,147 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// watchSearchMaxDuration is the hard ceiling on how long a single
+// watch_search call may block, regardless of the requested
+// duration_seconds. MCP is request/response — an unbounded watch would
+// hang the client's tool call forever. 600s (10 min) is generous for
+// "wait for the next build artefact / screenshot / download" flows
+// while still guaranteeing the call returns. The CLI `watch` subcommand
+// is the unbounded streaming counterpart.
+const watchSearchMaxDuration = 600 * time.Second
+
+// watchSearchDefaultDuration applies when duration_seconds is omitted.
+const watchSearchDefaultDuration = 30 * time.Second
+
+// WatchSearchInput is the JSON-schema input for the `watch_search` tool.
+type WatchSearchInput struct {
+	Expr             string   `json:"expr,omitempty" jsonschema:"CEL expression matched against each new / changed file — same vocabulary as the search tool (is_image, is_pdf, is_source && language == \"go\", size > 1000000, body.contains(\"error\"), …). Empty matches every new / changed file. Call list_attributes for the full schema."`
+	Dir              string   `json:"dir,omitempty" jsonschema:"Directory to watch. Defaults to '.'. Ignored when 'dirs' is non-empty. Watched recursively — subdirectories created during the watch are picked up automatically."`
+	Dirs             []string `json:"dirs,omitempty" jsonschema:"Multiple directories to watch in one call. When non-empty, takes precedence over 'dir'."`
+	DurationSeconds  float64  `json:"duration_seconds,omitempty" jsonschema:"How long to watch before returning the collected matches (seconds; fractions allowed). Defaults to 30s when omitted. Hard-capped at 600s (10 min) — this is a BOUNDED 'search over the near future', not an open-ended subscription. For unbounded streaming, use the CLI 'watch' subcommand instead."`
+	MaxEvents        int      `json:"max_events,omitempty" jsonschema:"Return early once this many matching files have been collected, before duration_seconds elapses. 0 = no cap (watch the full duration). Use to bound the response when you only need 'the next file that matches'."`
+	IncludeBody      bool     `json:"include_body,omitempty" jsonschema:"When true, the full file body is exposed to the CEL expression as the 'body' string variable, so filters like body.contains(\"transformer\") run against newly-written files. Only text-based content types populate body; capped at body_max_bytes (default 1 MiB)."`
+	BodyMaxBytes     int      `json:"body_max_bytes,omitempty" jsonschema:"Cap on the body string in bytes (default 1 MiB). Ignored when include_body is false."`
+	OCRImages        bool     `json:"ocr_images,omitempty" jsonschema:"When true, run OCR over new image/* files via the registered provider (macOS Vision today). Populates 'body' + ocr_* so body.contains() queries fire on screenshots as they're saved. No-op on platforms without a registered provider. Issue #189."`
+	OCRTimeoutMS     int      `json:"ocr_timeout_ms,omitempty" jsonschema:"Per-file OCR timeout in milliseconds. Default 10000 (10s) when zero."`
+	ComputeHashes    bool     `json:"compute_hashes,omitempty" jsonschema:"When true, populate md5 / sha1 / sha256 (lowercase hex) on each match and expose them as CEL variables."`
+	WithPHash        bool     `json:"with_phash,omitempty" jsonschema:"When true, compute the 64-bit perceptual hash of each new image and surface it as the 'phash' CEL string."`
+	WithXattrs       bool     `json:"with_xattrs,omitempty" jsonschema:"When true, populate the xattr family of CEL variables (is_quarantined, quarantine_source_url, finder_tags, …). Darwin-only."`
+	Excludes         []string `json:"excludes,omitempty" jsonschema:"Basename glob patterns; matched directories are pruned from the watched tree. Same semantics as the search tool."`
+	RespectGitignore bool     `json:"respect_gitignore,omitempty" jsonschema:"When true, honour a .gitignore at each watch root when registering directories."`
+}
+
+// WatchSearchOutput is the structured response. Matches carries every
+// file that matched during the watch window (deduped per debounce). The
+// watch ends when duration_seconds elapses, max_events is reached, or
+// the call's parent ctx is cancelled — whichever comes first.
+type WatchSearchOutput struct {
+	CommonOutput
+	Matches        []search.Match `json:"matches"`
+	Count          int            `json:"count"`
+	WatchedSeconds float64        `json:"watched_seconds"`
+	// HitMaxEvents is true when the watch returned early because
+	// max_events matches were collected before duration_seconds elapsed.
+	HitMaxEvents bool `json:"hit_max_events,omitempty"`
+}
+
+func (h *handlers) watchSearchHandler(ctx context.Context, _ *mcp.CallToolRequest, in WatchSearchInput) (*mcp.CallToolResult, WatchSearchOutput, error) {
+	dir, err := expandHomeDir(in.Dir)
+	if err != nil {
+		return nil, WatchSearchOutput{}, fmt.Errorf("expand dir: %w", err)
+	}
+	dirs, err := expandHomeDirs(in.Dirs)
+	if err != nil {
+		return nil, WatchSearchOutput{}, fmt.Errorf("expand dirs: %w", err)
+	}
+	if dir == "" && len(dirs) == 0 {
+		dir = "."
+	}
+	// search.Watch registers opts.Roots only (not opts.Root), so fold
+	// the single-dir case into the slice.
+	roots := dirs
+	if len(roots) == 0 {
+		roots = []string{dir}
+	}
+
+	dur := watchSearchDefaultDuration
+	if in.DurationSeconds > 0 {
+		dur = time.Duration(in.DurationSeconds * float64(time.Second))
+	}
+	if dur > watchSearchMaxDuration {
+		dur = watchSearchMaxDuration
+	}
+
+	wctx, cancel := context.WithTimeout(ctx, dur)
+	defer cancel()
+
+	var mu sync.Mutex
+	var collected []search.Match
+	hitMax := false
+	onMatch := func(r search.Result) {
+		mu.Lock()
+		defer mu.Unlock()
+		if in.MaxEvents > 0 && len(collected) >= in.MaxEvents {
+			return // already full; ignore late debounce fires
+		}
+		collected = append(collected, search.MatchFrom(r))
+		if in.MaxEvents > 0 && len(collected) >= in.MaxEvents {
+			hitMax = true
+			cancel() // got enough; stop watching so Watch returns now
+		}
+	}
+
+	opts := search.Options{
+		Roots:                  roots,
+		Expr:                   in.Expr,
+		IncludeAttributes:      true,
+		Index:                  h.idx,
+		IncludeBody:            in.IncludeBody,
+		BodyMaxBytes:           in.BodyMaxBytes,
+		OCRImages:              in.OCRImages,
+		OCRTimeout:             time.Duration(in.OCRTimeoutMS) * time.Millisecond,
+		ComputeHashes:          in.ComputeHashes,
+		WithPHash:              in.WithPHash,
+		ReadExtendedAttributes: in.WithXattrs,
+		Excludes:               in.Excludes,
+		RespectGitignore:       in.RespectGitignore,
+	}
+
+	start := time.Now()
+	err = search.Watch(wctx, opts, content.DefaultRegistry(), onMatch)
+	elapsed := time.Since(start).Seconds()
+
+	// Watch returns nil on ctx cancel / deadline (the normal stop path).
+	// Only a genuine setup error (e.g. invalid CEL, unreadable root)
+	// surfaces as a tool error.
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		return nil, WatchSearchOutput{}, fmt.Errorf("watch_search: %w", err)
+	}
+
+	mu.Lock()
+	matches := collected
+	out := WatchSearchOutput{
+		Matches:        matches,
+		Count:          len(matches),
+		WatchedSeconds: elapsed,
+		HitMaxEvents:   hitMax,
+	}
+	mu.Unlock()
+	if out.Matches == nil {
+		out.Matches = []search.Match{}
+	}
+	out.ServerVersion = h.version
+	return nil, out, nil
+}

--- a/internal/mcpserver/watch_tool_test.go
+++ b/internal/mcpserver/watch_tool_test.go
@@ -1,0 +1,123 @@
+package mcpserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestWatchSearchFiresOnNewMatch creates a matching file shortly after
+// the watch starts and asserts the bounded watch_search call returns it,
+// stopping early via max_events.
+func TestWatchSearchFiresOnNewMatch(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cs := newSession(t)
+
+	mdPath := filepath.Join(dir, "note.md")
+	// Re-write the file a few times spaced out: the MCP handshake +
+	// handler startup + recursive watcher registration take an
+	// indeterminate amount of time, so a single early write can land
+	// before the watch is armed. Each re-write emits a fresh WRITE
+	// event, so a later one is guaranteed to be observed.
+	go func() {
+		for range 10 {
+			time.Sleep(300 * time.Millisecond)
+			_ = os.WriteFile(mdPath, []byte("# hello\n"), 0o644)
+		}
+	}()
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "watch_search",
+		Arguments: WatchSearchInput{
+			Expr:            "is_markdown",
+			Dir:             dir,
+			DurationSeconds: 6,
+			MaxEvents:       1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.GetError() != nil {
+		t.Fatalf("tool returned error: %v", res.GetError())
+	}
+
+	var out WatchSearchOutput
+	mustDecodeStructured(t, res, &out)
+
+	if out.Count != 1 {
+		t.Fatalf("expected 1 match, got %d (%+v)", out.Count, out.Matches)
+	}
+	if got := filepath.Base(out.Matches[0].Path); got != "note.md" {
+		t.Fatalf("expected note.md, got %s", got)
+	}
+	if !out.HitMaxEvents {
+		t.Errorf("expected hit_max_events=true (max_events reached before duration)")
+	}
+}
+
+// TestWatchSearchTimesOutEmpty asserts that a watch window with no
+// matching activity returns an empty (non-nil) match set, not an error.
+func TestWatchSearchTimesOutEmpty(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cs := newSession(t)
+
+	// Write a non-matching file during the window — must NOT surface.
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		_ = os.WriteFile(filepath.Join(dir, "data.json"), []byte(`{"x":1}`), 0o644)
+	}()
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "watch_search",
+		Arguments: WatchSearchInput{
+			Expr:            "is_markdown",
+			Dir:             dir,
+			DurationSeconds: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.GetError() != nil {
+		t.Fatalf("tool returned error: %v", res.GetError())
+	}
+
+	var out WatchSearchOutput
+	mustDecodeStructured(t, res, &out)
+
+	if out.Count != 0 {
+		t.Fatalf("expected 0 matches for is_markdown when only a JSON file appeared, got %d (%+v)", out.Count, out.Matches)
+	}
+	if out.Matches == nil {
+		t.Errorf("expected non-nil empty matches slice")
+	}
+	if out.HitMaxEvents {
+		t.Errorf("hit_max_events should be false when no matches collected")
+	}
+}
+
+// TestWatchSearchInvalidExpr asserts a malformed CEL expression surfaces
+// as a tool error rather than an empty result.
+func TestWatchSearchInvalidExpr(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cs := newSession(t)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "watch_search",
+		Arguments: WatchSearchInput{
+			Expr:            "this is not valid CEL %%%",
+			Dir:             dir,
+			DurationSeconds: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError=true for an invalid CEL expression")
+	}
+}

--- a/internal/search/watch.go
+++ b/internal/search/watch.go
@@ -1,0 +1,197 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+	"github.com/richardwooding/file-search-on/internal/content"
+)
+
+// watchDebounce coalesces rapid write bursts into a single evaluation
+// per path. Editors and downloaders emit several WRITE events for one
+// logical save / download; without debouncing the same file would
+// match (and emit) multiple times. 300ms is below human-perceptible
+// latency yet long enough to swallow a multi-write save.
+const watchDebounce = 300 * time.Millisecond
+
+// Watch sets up recursive filesystem watching across opts.Roots and
+// calls onMatch once per newly-created / modified file that matches
+// opts.Expr. It blocks until ctx is cancelled, then stops cleanly.
+//
+// The per-file evaluation mirrors the Walk path exactly — same
+// BuildAttributesWith + Evaluate, so OCR / hashes / phash / body /
+// xattrs / index caching all compose identically. Only create + write
+// events are considered (deletes are out of scope per issue #211).
+//
+// fsnotify is not recursive: every existing directory under each root
+// is registered up front, and any directory created during the watch
+// is registered when its CREATE event arrives. Files created inside a
+// brand-new directory in the window before its watch is added can be
+// missed — an inherent fsnotify race, acceptable for a "tell me about
+// new matches" tool.
+//
+// Issue #211.
+func Watch(ctx context.Context, opts Options, registry *content.Registry, onMatch func(Result)) error {
+	if registry == nil {
+		registry = content.DefaultRegistry()
+	}
+	expr := opts.Expr
+	if expr == "" {
+		expr = "true"
+	}
+	evaluator, err := celexpr.New(expr)
+	if err != nil {
+		return fmt.Errorf("compiling CEL expression: %w", err)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("creating watcher: %w", err)
+	}
+	defer func() { _ = watcher.Close() }()
+
+	for _, root := range opts.Roots {
+		if err := addDirsRecursive(watcher, root, opts.Excludes, opts.RespectGitignore); err != nil {
+			return err
+		}
+	}
+
+	buildOpts := opts.watchBuildOptions()
+
+	// Per-path debounce timers. Stopped on exit so a pending timer
+	// can't call onMatch after Watch returns.
+	var mu sync.Mutex
+	timers := make(map[string]*time.Timer)
+	defer func() {
+		mu.Lock()
+		for _, t := range timers {
+			t.Stop()
+		}
+		mu.Unlock()
+	}()
+
+	evalPath := func(path string) {
+		if ctx.Err() != nil {
+			return
+		}
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			return // vanished, or a directory (handled separately)
+		}
+		dir := filepath.Dir(path)
+		base := filepath.Base(path)
+		attrs, err := celexpr.BuildAttributesWith(ctx, os.DirFS(dir), base, path, registry, buildOpts)
+		if err != nil {
+			return
+		}
+		match, err := evaluator.Evaluate(attrs)
+		if err != nil || !match {
+			return
+		}
+		r := Result{Path: path, ContentType: attrs.ContentType, Size: attrs.Size}
+		if opts.IncludeAttributes {
+			r.Attrs = attrs
+		}
+		onMatch(r)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			// A newly-created directory must be watched too (fsnotify
+			// isn't recursive). Register it and skip evaluation.
+			if event.Has(fsnotify.Create) {
+				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+					_ = addDirsRecursive(watcher, event.Name, opts.Excludes, opts.RespectGitignore)
+					continue
+				}
+			}
+			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
+				name := event.Name
+				mu.Lock()
+				if t, ok := timers[name]; ok {
+					t.Stop()
+				}
+				timers[name] = time.AfterFunc(watchDebounce, func() {
+					mu.Lock()
+					delete(timers, name)
+					mu.Unlock()
+					evalPath(name)
+				})
+				mu.Unlock()
+			}
+		case _, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			// Best-effort: a transient watcher error (e.g. a removed
+			// directory's watch going stale) shouldn't tear down the
+			// whole watch. Keep going.
+		}
+	}
+}
+
+// addDirsRecursive registers root and every subdirectory under it with
+// the watcher, skipping basenames matched by the excluder. Missing /
+// unreadable directories are skipped, not fatal — the tree can change
+// under us.
+func addDirsRecursive(watcher *fsnotify.Watcher, root string, globs []string, respectGitignore bool) error {
+	info, err := os.Stat(root)
+	if err != nil {
+		return fmt.Errorf("watch root %s: %w", root, err)
+	}
+	if !info.IsDir() {
+		// Watching a single file: register its parent so writes to it
+		// surface (fsnotify watches directories, not files, reliably).
+		return watcher.Add(filepath.Dir(root))
+	}
+	excl := newExcluder(os.DirFS(root), globs, respectGitignore)
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // unreadable entry; skip
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if path != root {
+			if rel, rerr := filepath.Rel(root, path); rerr == nil && excl.Match(filepath.ToSlash(rel), true) {
+				return filepath.SkipDir
+			}
+		}
+		_ = watcher.Add(path) // best-effort; a vanished dir is fine
+		return nil
+	})
+}
+
+// watchBuildOptions maps the subset of search.Options that make sense
+// for per-event evaluation onto celexpr.BuildOptions. Ranking,
+// semantic embedding, and project resolution are omitted — they're
+// walk-collection concerns, not single-file-event concerns.
+func (opts Options) watchBuildOptions() celexpr.BuildOptions {
+	return celexpr.BuildOptions{
+		Index:                  opts.Index,
+		IncludeBody:            opts.IncludeBody,
+		BodyMaxBytes:           opts.BodyMaxBytes,
+		ComputeHashes:          opts.ComputeHashes,
+		CheckDisguised:         opts.CheckDisguised,
+		ReadExtendedAttributes: opts.ReadExtendedAttributes,
+		Allowlist:              opts.Allowlist,
+		Denylist:               opts.Denylist,
+		OCRImages:              opts.OCRImages,
+		OCRTimeout:             opts.OCRTimeout,
+		WithPHash:              opts.WithPHash,
+	}
+}

--- a/internal/search/watch_test.go
+++ b/internal/search/watch_test.go
@@ -1,0 +1,140 @@
+package search
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+)
+
+// collectMatches runs Watch in a goroutine and returns a thread-safe
+// accessor for the matches seen so far, plus a cancel func.
+func startWatch(t *testing.T, opts Options) (paths func() []string, cancel func()) {
+	t.Helper()
+	ctx, cancelFn := context.WithCancel(context.Background())
+	var mu sync.Mutex
+	var seen []string
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = Watch(ctx, opts, content.DefaultRegistry(), func(r Result) {
+			mu.Lock()
+			seen = append(seen, r.Path)
+			mu.Unlock()
+		})
+	}()
+	// Give the watcher a beat to register the initial directories
+	// before the test starts creating files.
+	time.Sleep(150 * time.Millisecond)
+	return func() []string {
+			mu.Lock()
+			defer mu.Unlock()
+			out := make([]string, len(seen))
+			copy(out, seen)
+			return out
+		}, func() {
+			cancelFn()
+			<-done
+		}
+}
+
+// waitFor polls cond until it's true or the deadline elapses.
+func waitFor(cond func() bool, d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return cond()
+}
+
+func TestWatchFiresOnNewMatch(t *testing.T) {
+	dir := t.TempDir()
+	paths, cancel := startWatch(t, Options{Roots: []string{dir}, Expr: "is_markdown"})
+	defer cancel()
+
+	mdPath := filepath.Join(dir, "note.md")
+	if err := os.WriteFile(mdPath, []byte("# hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !waitFor(func() bool {
+		return slices.Contains(paths(), mdPath)
+	}, 3*time.Second) {
+		t.Errorf("watch did not fire for %s within 3s; saw %v", mdPath, paths())
+	}
+}
+
+func TestWatchFiltersNonMatch(t *testing.T) {
+	dir := t.TempDir()
+	paths, cancel := startWatch(t, Options{Roots: []string{dir}, Expr: "is_markdown"})
+	defer cancel()
+
+	// A JSON file should NOT match is_markdown.
+	if err := os.WriteFile(filepath.Join(dir, "data.json"), []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Give it time to (not) fire.
+	time.Sleep(800 * time.Millisecond)
+	if got := paths(); len(got) != 0 {
+		t.Errorf("expected no matches for a JSON file under is_markdown, got %v", got)
+	}
+}
+
+func TestWatchPicksUpNewSubdir(t *testing.T) {
+	dir := t.TempDir()
+	paths, cancel := startWatch(t, Options{Roots: []string{dir}, Expr: "is_markdown"})
+	defer cancel()
+
+	// Create a subdirectory AFTER the watch started, then a file in it.
+	sub := filepath.Join(dir, "nested")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Let the watcher register the new subdir.
+	time.Sleep(200 * time.Millisecond)
+	nestedMd := filepath.Join(sub, "deep.md")
+	if err := os.WriteFile(nestedMd, []byte("# deep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !waitFor(func() bool {
+		return slices.Contains(paths(), nestedMd)
+	}, 3*time.Second) {
+		t.Errorf("watch did not fire for file in new subdir %s; saw %v", nestedMd, paths())
+	}
+}
+
+func TestWatchInvalidExpr(t *testing.T) {
+	dir := t.TempDir()
+	err := Watch(context.Background(), Options{Roots: []string{dir}, Expr: "this is not valid CEL %%%"}, content.DefaultRegistry(), func(Result) {})
+	if err == nil {
+		t.Error("expected an error compiling an invalid CEL expression")
+	}
+}
+
+func TestWatchCancelReturns(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- Watch(ctx, Options{Roots: []string{dir}, Expr: "true"}, content.DefaultRegistry(), func(Result) {})
+	}()
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Watch returned error on cancel: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("Watch did not return within 2s of ctx cancel")
+	}
+}


### PR DESCRIPTION
## Summary

Adds **watch mode** — the inverse of `search`. Instead of walking a tree once and reporting what already matches, it watches directories continuously and emits each new / changed file *as it appears*, filtered by the same CEL vocabulary.

- **`internal/search/watch.go`** — shared `Watch(ctx, opts, registry, onMatch)` core. [fsnotify](https://github.com/fsnotify/fsnotify)-based, recursive (subdirs created during the watch are registered on their CREATE event), 300 ms debounce to coalesce multi-write saves, ctx-driven clean shutdown. Per-event evaluation reuses the exact `BuildAttributesWith` + `Evaluate` path, so OCR / hashes / phash / body / xattrs / index caching all compose identically.
- **CLI `watch` subcommand** — runs until Ctrl-C. NDJSON (default) / `-o bare` / `--format` output. Mirrors `search` flags where they make sense (`--body`, `--ocr`, `--with-hashes`, `--with-phash`, `--with-xattrs`, `--exclude`, `--respect-gitignore`, `--index-path`).
- **MCP `watch_search` tool** — a *bounded* "search over the near future". Blocks until `duration_seconds` elapses (default 30s, hard cap 600s), `max_events` matches are collected, or the call is cancelled — then returns the collected matches. MCP is request/response, so unbounded streaming would hang the call; the CLI `watch` is the streaming counterpart.
- Docs: README subcommand row + `examples/watch.md` + examples index entry.

## Test plan

- [x] `internal/search/watch_test.go` — 5 tests (fires on new match, filters non-match, picks up new subdir, invalid expr errors, clean cancel), race-clean.
- [x] `internal/mcpserver/watch_tool_test.go` — fires-on-new-match (early return via `max_events`), times-out-empty, invalid-expr errors.
- [x] `watch_search` added to the `server_version` regression test (CommonOutput wiring guard).
- [x] `go vet`, `go fix` (idempotent), `golangci-lint`, `go test -race ./...` all clean.
- [x] Cross-compiles for linux/amd64 and windows/amd64 (fsnotify is cross-platform).
- [x] Manual CLI smoke: `watch 'is_markdown'` emitted a new `.md`, correctly skipped a `.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)