### PR TITLE
chore: gitignore Hugo build output + drop inert //nolint:nilerr directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ dist/
 # OCR helper artifact landing zone (issue #189) — populated by the
 # release workflow's build-ocr-helper job before goreleaser runs.
 dist-extra/
+
+# Hugo docs-site build output
+/public/
+.hugo_build.lock

--- a/internal/content/archive_gzip.go
+++ b/internal/content/archive_gzip.go
@@ -35,11 +35,11 @@ func readGZIPArchive(fsys fs.FS, path string) (Attributes, error) {
 		return Attributes{}, nil
 	}
 	if _, err := rs.Seek(size-4, io.SeekStart); err != nil {
-		return Attributes{}, nil //nolint:nilerr // unreadable footer → empty attrs
+		return Attributes{}, nil // unreadable footer → empty attrs
 	}
 	var footer [4]byte
 	if _, err := io.ReadFull(rs, footer[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	uncompressed := int64(binary.LittleEndian.Uint32(footer[:]))
 	return archiveAttrs(1, uncompressed, map[string]struct{}{}), nil

--- a/internal/content/archive_tar.go
+++ b/internal/content/archive_tar.go
@@ -29,7 +29,7 @@ func readTARArchive(ctx context.Context, fsys fs.FS, path string, gz bool) (Attr
 	if gz {
 		zr, err := gzip.NewReader(f)
 		if err != nil {
-			return Attributes{}, nil //nolint:nilerr // malformed gzip → empty attrs
+			return Attributes{}, nil // malformed gzip → empty attrs
 		}
 		defer func() { _ = zr.Close() }()
 		r = zr

--- a/internal/content/archive_zip.go
+++ b/internal/content/archive_zip.go
@@ -24,7 +24,7 @@ func readZIPArchive(ctx context.Context, fsys fs.FS, path string) (Attributes, e
 
 	zr, err := zip.NewReader(ra, size)
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr // graceful degradation: malformed archive returns empty attrs
+		return Attributes{}, nil // graceful degradation: malformed archive returns empty attrs
 	}
 
 	var entryCount, uncompressed int64

--- a/internal/content/binary_elf.go
+++ b/internal/content/binary_elf.go
@@ -18,7 +18,7 @@ func readELFInfo(fsys fs.FS, path string) (Attributes, error) {
 
 	f, err := elf.NewFile(ra)
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr // graceful degradation: malformed ELF returns empty attrs
+		return Attributes{}, nil // graceful degradation: malformed ELF returns empty attrs
 	}
 	defer func() { _ = f.Close() }()
 

--- a/internal/content/binary_macho.go
+++ b/internal/content/binary_macho.go
@@ -45,7 +45,7 @@ func readMachoInfo(ctx context.Context, fsys fs.FS, path string) (Attributes, er
 
 	f, err := macho.NewFile(ra)
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr // graceful degradation: malformed Mach-O returns empty attrs
+		return Attributes{}, nil // graceful degradation: malformed Mach-O returns empty attrs
 	}
 	defer func() { _ = f.Close() }()
 

--- a/internal/content/binary_pe.go
+++ b/internal/content/binary_pe.go
@@ -18,7 +18,7 @@ func readPEInfo(fsys fs.FS, path string) (Attributes, error) {
 
 	f, err := pe.NewFile(ra)
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr // graceful degradation: malformed PE returns empty attrs
+		return Attributes{}, nil // graceful degradation: malformed PE returns empty attrs
 	}
 	defer func() { _ = f.Close() }()
 

--- a/internal/content/body_email.go
+++ b/internal/content/body_email.go
@@ -44,7 +44,7 @@ func emlBodyFromReader(ctx context.Context, r io.Reader, maxBytes int) (string, 
 	}
 	msg, err := mail.ReadMessage(r)
 	if err != nil {
-		return "", nil //nolint:nilerr // malformed message → empty body, not error
+		return "", nil // malformed message → empty body, not error
 	}
 	return walkEmailBody(ctx, msg.Body, msg.Header.Get("Content-Type"), msg.Header.Get("Content-Transfer-Encoding"), maxBytes)
 }
@@ -187,7 +187,7 @@ func decodeTextPart(ctx context.Context, r io.Reader, transferEncoding string, i
 	}
 	b, err := io.ReadAll(io.LimitReader(decoded, int64(cap)))
 	if err != nil {
-		return strings.TrimRight(string(b), "\r\n "), nil //nolint:nilerr // partial body on transfer-encoding error is fine
+		return strings.TrimRight(string(b), "\r\n "), nil // partial body on transfer-encoding error is fine
 	}
 	return strings.TrimRight(string(b), "\r\n "), nil
 }

--- a/internal/content/body_epub.go
+++ b/internal/content/body_epub.go
@@ -21,16 +21,16 @@ func epubBody(ctx context.Context, fsys fs.FS, filePath string, maxBytes int) (s
 	defer func() { _ = closer() }()
 	zr, err := zip.NewReader(ra, size)
 	if err != nil {
-		return "", nil //nolint:nilerr
+		return "", nil
 	}
 
 	opfPath, err := readOPFPath(zr)
 	if err != nil || opfPath == "" {
-		return "", nil //nolint:nilerr
+		return "", nil
 	}
 	chapters, err := readEPUBSpineHrefs(ctx, zr, opfPath)
 	if err != nil || len(chapters) == 0 {
-		return "", nil //nolint:nilerr
+		return "", nil
 	}
 
 	opfDir := path.Dir(opfPath)

--- a/internal/content/body_office.go
+++ b/internal/content/body_office.go
@@ -21,7 +21,7 @@ func ooxmlBody(ctx context.Context, fsys fs.FS, filePath string, entries []strin
 	defer func() { _ = closer() }()
 	zr, err := zip.NewReader(ra, size)
 	if err != nil {
-		return "", nil //nolint:nilerr // malformed zip → empty body, not error
+		return "", nil // malformed zip → empty body, not error
 	}
 	var out strings.Builder
 	for _, entry := range entries {
@@ -67,7 +67,7 @@ func xlsxBody(ctx context.Context, fsys fs.FS, filePath string, maxBytes int) (s
 	defer func() { _ = closer() }()
 	zr, err := zip.NewReader(ra, size)
 	if err != nil {
-		return "", nil //nolint:nilerr
+		return "", nil
 	}
 
 	var out strings.Builder
@@ -149,7 +149,7 @@ func pptxBody(ctx context.Context, fsys fs.FS, filePath string, maxBytes int) (s
 	defer func() { _ = closer() }()
 	zr, err := zip.NewReader(ra, size)
 	if err != nil {
-		return "", nil //nolint:nilerr // malformed zip → empty body, not error
+		return "", nil // malformed zip → empty body, not error
 	}
 
 	// Collect ppt/slides/slideN.xml entries, sorted numerically by N.
@@ -222,11 +222,11 @@ func odtBody(ctx context.Context, fsys fs.FS, filePath string, maxBytes int) (st
 	defer func() { _ = closer() }()
 	zr, err := zip.NewReader(ra, size)
 	if err != nil {
-		return "", nil //nolint:nilerr // malformed zip → empty body, not error
+		return "", nil // malformed zip → empty body, not error
 	}
 	rc, err := openZipEntry(zr, "content.xml")
 	if err != nil {
-		return "", nil //nolint:nilerr // missing content.xml → empty body, not error
+		return "", nil // missing content.xml → empty body, not error
 	}
 	defer func() { _ = rc.Close() }()
 

--- a/internal/content/body_sqlite.go
+++ b/internal/content/body_sqlite.go
@@ -52,19 +52,19 @@ func sqliteBody(ctx context.Context, osPath string, maxBytes int) (string, error
 	dsn := "file:" + url.PathEscape(osPath) + "?mode=ro&immutable=1"
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
-		return "", nil //nolint:nilerr
+		return "", nil
 	}
 	defer func() { _ = db.Close() }()
 
 	// One-shot ping with ctx so a non-SQLite file (mis-detected, e.g.
 	// encrypted) errors fast instead of hanging on a bad open.
 	if err := db.PingContext(ctx); err != nil {
-		return "", nil //nolint:nilerr
+		return "", nil
 	}
 
 	ftsTables, err := listFTSTables(ctx, db)
 	if err != nil || len(ftsTables) == 0 {
-		return "", err //nolint:nilerr // empty body, no FTS tables
+		return "", err // empty body, no FTS tables
 	}
 
 	var sb strings.Builder

--- a/internal/content/browser_bookmarks_chromium.go
+++ b/internal/content/browser_bookmarks_chromium.go
@@ -84,7 +84,7 @@ func (*chromiumBookmarksType) Attributes(ctx context.Context, fsys fs.FS, path s
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, chromiumBookmarksReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseChromiumBookmarks(buf, path), nil
 }
@@ -177,7 +177,7 @@ func chromiumBookmarksBody(ctx context.Context, fsys fs.FS, path string, maxByte
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, chromiumBookmarksReadCap))
 	if err != nil {
-		return "", nil //nolint:nilerr
+		return "", nil
 	}
 	attrs := parseChromiumBookmarks(buf, path)
 	return bookmarkBody(attrs, maxBytes), nil

--- a/internal/content/browser_bookmarks_safari.go
+++ b/internal/content/browser_bookmarks_safari.go
@@ -54,7 +54,7 @@ func (*safariBookmarksType) Attributes(ctx context.Context, fsys fs.FS, path str
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, safariBookmarksReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseSafariBookmarks(buf), nil
 }
@@ -73,7 +73,7 @@ func safariBookmarksBody(ctx context.Context, fsys fs.FS, path string, maxBytes 
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, safariBookmarksReadCap))
 	if err != nil {
-		return "", nil //nolint:nilerr
+		return "", nil
 	}
 	return bookmarkBody(parseSafariBookmarks(buf), maxBytes), nil
 }

--- a/internal/content/bytecode_class.go
+++ b/internal/content/bytecode_class.go
@@ -75,7 +75,7 @@ func readClassInfo(fsys fs.FS, path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, classReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseClassFile(buf), nil
 }

--- a/internal/content/bytecode_pyc.go
+++ b/internal/content/bytecode_pyc.go
@@ -36,7 +36,7 @@ func readPYCInfo(fsys fs.FS, path string) (Attributes, error) {
 	// io.ErrUnexpectedEOF means the file is shorter than the cap —
 	// fine, we trim and parse what we have.
 	if err != nil && err != io.ErrUnexpectedEOF {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parsePYCHeader(hdr[:n]), nil
 }

--- a/internal/content/bytecode_webasm.go
+++ b/internal/content/bytecode_webasm.go
@@ -66,7 +66,7 @@ func readWASMInfo(fsys fs.FS, path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, wasmReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseWASMModule(buf), nil
 }

--- a/internal/content/database_sqlite.go
+++ b/internal/content/database_sqlite.go
@@ -81,7 +81,7 @@ func readSQLiteInfo(fsys fs.FS, path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, sqliteReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseSQLiteHeader(buf), nil
 }

--- a/internal/content/database_sqlite_wal.go
+++ b/internal/content/database_sqlite_wal.go
@@ -68,12 +68,12 @@ func readSQLiteWALInfo(fsys fs.FS, path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 	info, err := f.Stat()
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	buf := make([]byte, sqliteWALHeaderLen)
 	n, err := io.ReadFull(f, buf)
 	if err != nil && err != io.ErrUnexpectedEOF {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseSQLiteWALHeader(buf[:n], info.Size()), nil
 }

--- a/internal/content/disk_dmg.go
+++ b/internal/content/disk_dmg.go
@@ -42,11 +42,11 @@ func readDMGInfo(fsys fs.FS, path string) (Attributes, error) {
 		return Attributes{}, nil
 	}
 	if _, err := rs.Seek(size-dmgTrailerSize, io.SeekStart); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	var trailer [dmgTrailerSize]byte
 	if _, err := io.ReadFull(rs, trailer[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseDMGTrailer(trailer[:]), nil
 }

--- a/internal/content/disk_iso.go
+++ b/internal/content/disk_iso.go
@@ -50,11 +50,11 @@ func readISO9660Info(fsys fs.FS, path string) (Attributes, error) {
 		return Attributes{}, nil
 	}
 	if _, err := rs.Seek(isoPVDOffset, io.SeekStart); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	var pvd [isoPVDSize]byte
 	if _, err := io.ReadFull(rs, pvd[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseISOPVD(pvd[:]), nil
 }

--- a/internal/content/disk_qcow2.go
+++ b/internal/content/disk_qcow2.go
@@ -47,11 +47,11 @@ func readQCOW2Info(fsys fs.FS, path string) (Attributes, error) {
 		return Attributes{}, nil
 	}
 	if _, err := rs.Seek(0, io.SeekStart); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	var hdr [qcow2HeaderSize]byte
 	if _, err := io.ReadFull(rs, hdr[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseQCOW2Header(hdr[:]), nil
 }

--- a/internal/content/disk_vhd.go
+++ b/internal/content/disk_vhd.go
@@ -47,11 +47,11 @@ func readVHDInfo(fsys fs.FS, path string) (Attributes, error) {
 		return Attributes{}, nil
 	}
 	if _, err := rs.Seek(size-vhdFooterSize, io.SeekStart); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	var footer [vhdFooterSize]byte
 	if _, err := io.ReadFull(rs, footer[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseVHDFooter(footer[:]), nil
 }

--- a/internal/content/disk_vhdx.go
+++ b/internal/content/disk_vhdx.go
@@ -74,10 +74,10 @@ func readVHDXInfo(fsys fs.FS, path string) (Attributes, error) {
 	// defensive but the magic check makes the failure path cheaper.
 	var magic [8]byte
 	if _, err := rs.Seek(0, io.SeekStart); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	if _, err := io.ReadFull(rs, magic[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	if !bytes.Equal(magic[:], []byte("vhdxfile")) {
 		return Attributes{}, nil

--- a/internal/content/disk_vmdk.go
+++ b/internal/content/disk_vmdk.go
@@ -48,11 +48,11 @@ func readVMDKInfo(fsys fs.FS, path string) (Attributes, error) {
 		return Attributes{}, nil
 	}
 	if _, err := rs.Seek(0, io.SeekStart); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	var hdr [vmdkSparseHeaderSize]byte
 	if _, err := io.ReadFull(rs, hdr[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseVMDKSparseHeader(hdr[:]), nil
 }

--- a/internal/content/disk_wim.go
+++ b/internal/content/disk_wim.go
@@ -43,11 +43,11 @@ func readWIMInfo(fsys fs.FS, path string) (Attributes, error) {
 		return Attributes{}, nil
 	}
 	if _, err := rs.Seek(0, io.SeekStart); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	var hdr [wimHeaderSize]byte
 	if _, err := io.ReadFull(rs, hdr[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseWIMHeader(hdr[:]), nil
 }

--- a/internal/content/email_eml.go
+++ b/internal/content/email_eml.go
@@ -17,7 +17,7 @@ func readEMLMessage(fsys fs.FS, path string) (Attributes, error) {
 
 	msg, err := mail.ReadMessage(f)
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr // graceful degradation: malformed .eml returns empty attrs
+		return Attributes{}, nil // graceful degradation: malformed .eml returns empty attrs
 	}
 	return emailAttrs(msg), nil
 }

--- a/internal/content/email_mbox.go
+++ b/internal/content/email_mbox.go
@@ -62,7 +62,7 @@ func readMBOXArchive(fsys fs.FS, path string) (Attributes, error) {
 	}
 	msg, err := mail.ReadMessage(&firstMsg)
 	if err != nil {
-		return attrs, nil //nolint:nilerr // graceful degradation: keep email_count, drop per-message attrs
+		return attrs, nil // graceful degradation: keep email_count, drop per-message attrs
 	}
 	first := emailAttrs(msg)
 	maps.Copy(attrs, first)

--- a/internal/content/font_collection.go
+++ b/internal/content/font_collection.go
@@ -54,7 +54,7 @@ func (*fontCollectionType) Attributes(ctx context.Context, fsys fs.FS, path stri
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, fontMaxBlobSize))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseTTC(buf), nil
 }

--- a/internal/content/font_otf.go
+++ b/internal/content/font_otf.go
@@ -39,7 +39,7 @@ func (*otfType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attrib
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, fontMaxBlobSize))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	info := parseSFNT(buf, 0)
 	return sfntAttrs(info, "otf"), nil

--- a/internal/content/font_ttf.go
+++ b/internal/content/font_ttf.go
@@ -37,7 +37,7 @@ func (*ttfType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attrib
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, fontMaxBlobSize))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	info := parseSFNT(buf, 0)
 	return sfntAttrs(info, "ttf"), nil

--- a/internal/content/font_woff.go
+++ b/internal/content/font_woff.go
@@ -66,7 +66,7 @@ func (*woffType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attri
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, fontMaxBlobSize))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseWOFF(buf), nil
 }

--- a/internal/content/font_woff2.go
+++ b/internal/content/font_woff2.go
@@ -92,7 +92,7 @@ func (*woff2Type) Attributes(ctx context.Context, fsys fs.FS, path string) (Attr
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, fontMaxBlobSize))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseWOFF2(buf), nil
 }

--- a/internal/content/image_raw.go
+++ b/internal/content/image_raw.go
@@ -63,7 +63,7 @@ func (r *rawImageType) Attributes(ctx context.Context, fsys fs.FS, path string) 
 	}
 	rs, _, closer, err := openReadSeeker(fsys, path)
 	if err != nil {
-		return attrs, nil //nolint:nilerr
+		return attrs, nil
 	}
 	defer func() { _ = closer() }()
 	extractImageEXIF(rs, attrs)

--- a/internal/content/install_appimage.go
+++ b/internal/content/install_appimage.go
@@ -47,7 +47,7 @@ func readAppImageInfo(fsys fs.FS, path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 	var hdr [appimageReadSize]byte
 	if _, err := io.ReadFull(f, hdr[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	marker := hdr[appimageMagicOffset : appimageMagicOffset+4]
 	extras := Attributes{"package_kind": "linux-portable"}

--- a/internal/content/install_pkg.go
+++ b/internal/content/install_pkg.go
@@ -36,7 +36,7 @@ func readPKGInfo(fsys fs.FS, path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 	var hdr [xarHeaderSize]byte
 	if _, err := io.ReadFull(f, hdr[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	if !bytes.Equal(hdr[0:4], []byte("xar!")) {
 		return Attributes{}, nil

--- a/internal/content/install_rpm.go
+++ b/internal/content/install_rpm.go
@@ -78,7 +78,7 @@ func readRPMInfo(fsys fs.FS, path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 	var lead [rpmLeadSize]byte
 	if _, err := io.ReadFull(f, lead[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	if !bytes.Equal(lead[0:4], rpmMagic) {
 		return Attributes{}, nil

--- a/internal/content/model3d_gltf.go
+++ b/internal/content/model3d_gltf.go
@@ -65,14 +65,14 @@ func parseGLTF(ctx context.Context, fsys fs.FS, path string) (Attributes, error)
 	} else {
 		b, err := readAll(fsys, path)
 		if err != nil {
-			return Attributes{}, nil //nolint:nilerr
+			return Attributes{}, nil
 		}
 		jsonBytes = b
 	}
 
 	var doc gltfDoc
 	if err := json.Unmarshal(jsonBytes, &doc); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return gltfAttrs(&doc), nil
 }

--- a/internal/content/model3d_obj.go
+++ b/internal/content/model3d_obj.go
@@ -34,7 +34,7 @@ import (
 func parseOBJ(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	f, err := fsys.Open(path)
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	defer func() { _ = f.Close() }()
 

--- a/internal/content/model3d_stl.go
+++ b/internal/content/model3d_stl.go
@@ -30,7 +30,7 @@ import (
 func parseSTL(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	rs, size, closer, err := openReadSeeker(fsys, path)
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	defer func() { _ = closer() }()
 
@@ -38,7 +38,7 @@ func parseSTL(ctx context.Context, fsys fs.FS, path string) (Attributes, error) 
 		return parseBinarySTL(ctx, rs, size)
 	}
 	if _, err := rs.Seek(0, io.SeekStart); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseASCIISTL(ctx, rs)
 }
@@ -63,7 +63,7 @@ func isBinarySTL(rs io.ReadSeeker, size int64) bool {
 func parseBinarySTL(ctx context.Context, rs io.ReadSeeker, size int64) (Attributes, error) {
 	var head [84]byte
 	if _, err := io.ReadFull(rs, head[:]); err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	count := int64(binary.LittleEndian.Uint32(head[80:84]))
 	if count <= 0 {

--- a/internal/content/plist.go
+++ b/internal/content/plist.go
@@ -64,7 +64,7 @@ func (*plistType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attr
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, plistReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parsePlist(buf, path), nil
 }

--- a/internal/content/repofiles.go
+++ b/internal/content/repofiles.go
@@ -40,12 +40,12 @@ func (*licenseType) Attributes(ctx context.Context, fsys fs.FS, path string) (At
 	}
 	f, err := fsys.Open(path)
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr // unreadable file → no license id, not error
+		return Attributes{}, nil // unreadable file → no license id, not error
 	}
 	defer func() { _ = f.Close() }()
 	b, err := io.ReadAll(io.LimitReader(f, licenseReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	id := detectLicenseID(string(b))
 	if id == "" {

--- a/internal/content/science_cdf.go
+++ b/internal/content/science_cdf.go
@@ -70,7 +70,7 @@ func readCDFInfo(fsys fs.FS, path string) (Attributes, error) {
 
 	buf, err := io.ReadAll(io.LimitReader(f, cdfReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 
 	attrs, gdrOffset := parseCDFCDR(buf)

--- a/internal/content/science_fits.go
+++ b/internal/content/science_fits.go
@@ -46,7 +46,7 @@ func readFITSInfo(fsys fs.FS, path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, fitsReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseFITSHeaders(buf), nil
 }

--- a/internal/content/science_hdf5.go
+++ b/internal/content/science_hdf5.go
@@ -72,7 +72,7 @@ func readHDF5Info(fsys fs.FS, path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, hdf5ReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseHDF5Superblock(buf), nil
 }

--- a/internal/content/science_pds.go
+++ b/internal/content/science_pds.go
@@ -70,7 +70,7 @@ func (p *pdsType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attr
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, pdsReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	switch p.name {
 	case "science/pds3":

--- a/internal/content/science_votable.go
+++ b/internal/content/science_votable.go
@@ -68,7 +68,7 @@ func readVOTableInfo(fsys fs.FS, path string) (Attributes, error) {
 	defer func() { _ = f.Close() }()
 	buf, err := io.ReadAll(io.LimitReader(f, votableReadCap))
 	if err != nil {
-		return Attributes{}, nil //nolint:nilerr
+		return Attributes{}, nil
 	}
 	return parseVOTableHeader(buf), nil
 }


### PR DESCRIPTION
Two small cleanups surfaced by a file-search-on sweep of the repo.

## 1. Gitignore the Hugo docs-site build output
`public/` and `.hugo_build.lock` were untracked **and** unignored (`git check-ignore` confirmed), so they showed up in every `git status`. Added both to `.gitignore` alongside the existing build-artefact section.

## 2. Drop the inert `//nolint:nilerr` directives in `internal/content`
A `find_matches` sweep found **69** `//nolint:nilerr` directives across 45 files in `internal/content` — all the `return Attributes{}, nil` / `return "", nil` graceful-degradation sites. But `nilerr` is **not in the enabled linter set**: CI runs the golangci-lint standard set (errcheck / govet / ineffassign / staticcheck / unused), so these directives **suppressed nothing**. They were also applied inconsistently — `internal/search` has 24 of the same intentional return-nil-after-err sites with no directive at all.

This strips the dead `//nolint:nilerr` token while **preserving every explanatory trailing comment**, e.g.:

```diff
-		return Attributes{}, nil //nolint:nilerr // graceful degradation: malformed archive returns empty attrs
+		return Attributes{}, nil // graceful degradation: malformed archive returns empty attrs
```

Bare directives are removed entirely (`return Attributes{}, nil`). The one `//nolint:gosec` is left untouched.

**Behaviour-neutral**: lint output is identical (nilerr stays off). Enabling `nilerr` as a real linter — and handling the 24 unannotated sites in `internal/search` — is left as a separate, deliberate lint-policy decision.

## Test plan
- [x] `go build ./...`, `go vet`, `go test ./internal/content/` all pass.
- [x] `golangci-lint run ./internal/content/...` → 0 issues (unchanged).
- [x] Confirmed no gofmt regression: the only changed files gofmt flags were already flagged at HEAD (pre-existing; gofmt isn't a CI gate here).
- [x] `git check-ignore public .hugo_build.lock` now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)