### PR TITLE
feat(monitor): opt-in localhost dashboard for the mcp / watch modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,25 @@ For HTTP-based clients, point at `http://<host>:<port>/` after starting the serv
 
 Built on [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk).
 
+## Monitoring dashboard
+
+Both long-running modes (`mcp` and `watch`) can expose a read-only monitoring dashboard with `--monitor-addr`. It's off by default, binds **127.0.0.1 only** (the host part of the address is ignored — only the port is used), needs no auth, and adds no dependencies — the UI is a single embedded page that polls a small JSON API.
+
+```sh
+file-search-on mcp --monitor-addr :9090                       # stdio MCP + dashboard
+file-search-on mcp --transport http --addr :8080 --monitor-addr :9090
+file-search-on watch 'is_image' -d ~/Screenshots --monitor-addr :9090
+```
+
+Open `http://localhost:9090/`. Four panels:
+
+- **Overview** — version, uptime, run mode, PID / Go version / GOMAXPROCS, default worker count, index backing (path or in-memory), body-cache cap.
+- **Cache** — the attribute / body / embedding cache counters as live cards with derived **hit-rate %** and sparklines; body evictions / oversize rejects / embed model-mismatches flagged.
+- **Activity** — live MCP tool-call feed (tool, elapsed, outcome, result count), per-tool call / error / cancel counts and p50 / p95 / max latency, and an in-flight gauge. (Watch mode has no MCP calls, so this panel shows a notice.)
+- **Capabilities** — registered content types grouped by family, project types, OCR provider availability, embedder model / server + a reachability check.
+
+The JSON API is scriptable too: `curl -s localhost:9090/api/cache | jq`, plus `/api/overview`, `/api/activity`, `/api/capabilities`, and `/healthz` (liveness). See [examples/monitoring.md](./examples/monitoring.md).
+
 ## Contributing
 
 The project is small enough to read in an afternoon and welcoming to first-time contributors. See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, branch/commit conventions, the local CI matrix, and PR expectations. A few quick entry points:

--- a/cmd/file-search-on/mcp_cmd.go
+++ b/cmd/file-search-on/mcp_cmd.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/richardwooding/file-search-on/internal/index"
 	"github.com/richardwooding/file-search-on/internal/mcpserver"
+	"github.com/richardwooding/file-search-on/internal/monitor"
 )
 
 type MCPCmd struct {
@@ -20,6 +21,7 @@ type MCPCmd struct {
 	EmbeddingServer   string        `name:"embedding-server" default:"http://localhost:11434" help:"Default Ollama base URL for the search_semantic tool. Per-call 'embedding_server' input overrides. Lazy connect — server starts without Ollama running; search_semantic fails clearly on first call if Ollama is unreachable."`
 	EmbeddingModel    string        `name:"embedding-model" help:"Default Ollama embedding model for the search_semantic tool (e.g. nomic-embed-text, mxbai-embed-large). No default — pick a model you've pulled via 'ollama pull <name>'. Per-call 'model' input overrides. If neither is set, search_semantic returns 'no embedding model configured'."`
 	Timeout           time.Duration `name:"timeout" default:"60s" help:"Default per-tool-call timeout (Go duration: 30s, 2m, 5m). Each search/read_attributes invocation is wrapped with this deadline. Per-call 'timeout_seconds' input on the search tool overrides this. Set to 0 to disable the default (not recommended — long-running calls can exceed MCP client read deadlines)."`
+	MonitorAddr       string        `name:"monitor-addr" help:"Enable the read-only monitoring dashboard on this port (e.g. ':9090'). Binds 127.0.0.1 only — the host part is ignored. Off when empty. Shows index cache stats, live tool-call activity, and registered capabilities at http://localhost:<port>/."`
 }
 
 func (m *MCPCmd) Run(ctx context.Context) error {
@@ -34,13 +36,46 @@ func (m *MCPCmd) Run(ctx context.Context) error {
 		Model:  m.EmbeddingModel,
 	}
 
+	// Optional monitoring dashboard. When enabled, attach a collector so
+	// tool calls are recorded, and run the dashboard concurrently under
+	// the same ctx. The deferred wait runs BEFORE idx.Close() (LIFO) so
+	// the dashboard drains before the index is released.
+	var mcpOpts []mcpserver.Option
+	if m.MonitorAddr != "" {
+		collector := monitor.NewCollector()
+		mcpOpts = append(mcpOpts, mcpserver.WithCollector(collector))
+
+		bodyCap := int64(0)
+		if m.IndexPath != "" && !m.NoBodyCache {
+			bodyCap = int64(m.BodyCacheMaxBytes)
+		}
+		mon := monitor.NewServer(monitor.Config{
+			Version:      version,
+			Mode:         "mcp-" + m.Transport,
+			Index:        idx,
+			Collector:    collector,
+			EmbedServer:  m.EmbeddingServer,
+			EmbedModel:   m.EmbeddingModel,
+			IndexPath:    m.IndexPath,
+			BodyCacheCap: bodyCap,
+		})
+		monDone := make(chan struct{})
+		go func() {
+			defer close(monDone)
+			if err := mon.Run(ctx, m.MonitorAddr); err != nil {
+				fmt.Fprintln(os.Stderr, "monitor:", err)
+			}
+		}()
+		defer func() { <-monDone }()
+	}
+
 	switch m.Transport {
 	case "http":
-		return mcpserver.RunHTTP(ctx, version, m.Addr, m.Path, idx, m.Timeout, embedDefaults)
+		return mcpserver.RunHTTP(ctx, version, m.Addr, m.Path, idx, m.Timeout, embedDefaults, mcpOpts...)
 	case "sse":
 		fmt.Fprintln(os.Stderr, "warning: --transport sse is DEPRECATED (MCP 2024-11-05); prefer --transport http for new clients.")
-		return mcpserver.RunSSE(ctx, version, m.Addr, m.Path, idx, m.Timeout, embedDefaults)
+		return mcpserver.RunSSE(ctx, version, m.Addr, m.Path, idx, m.Timeout, embedDefaults, mcpOpts...)
 	default:
-		return mcpserver.Run(ctx, version, idx, m.Timeout, embedDefaults)
+		return mcpserver.Run(ctx, version, idx, m.Timeout, embedDefaults, mcpOpts...)
 	}
 }

--- a/cmd/file-search-on/watch_cmd.go
+++ b/cmd/file-search-on/watch_cmd.go
@@ -11,6 +11,7 @@ import (
 
 	contentpkg "github.com/richardwooding/file-search-on/internal/content"
 	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/monitor"
 	"github.com/richardwooding/file-search-on/internal/search"
 )
 
@@ -33,6 +34,7 @@ type WatchCmd struct {
 	WithHashes       bool          `name:"with-hashes" help:"Compute md5 / sha1 / sha256 for each matched file."`
 	WithPHash        bool          `name:"with-phash" help:"Compute the perceptual hash (phash) of each new image."`
 	WithXattrs       bool          `name:"with-xattrs" help:"Read macOS extended attributes for each new file (Darwin only)."`
+	MonitorAddr      string        `name:"monitor-addr" help:"Enable the read-only monitoring dashboard on this port (e.g. ':9090'). Binds 127.0.0.1 only. Off when empty. Shows index cache stats + registered capabilities at http://localhost:<port>/ (no MCP activity panel in watch mode)."`
 }
 
 func (c *WatchCmd) Run(ctx context.Context) error {
@@ -86,6 +88,27 @@ func (c *WatchCmd) Run(ctx context.Context) error {
 		default:
 			_ = enc.Encode(search.MatchFrom(r)) // NDJSON
 		}
+	}
+
+	// Optional monitoring dashboard. Watch mode has no MCP tool calls,
+	// so no collector is attached — the dashboard shows cache stats +
+	// capabilities only. Runs concurrently under the same ctx; the
+	// deferred wait runs before idx.Close() (LIFO).
+	if c.MonitorAddr != "" {
+		mon := monitor.NewServer(monitor.Config{
+			Version:   version,
+			Mode:      "watch",
+			Index:     idx,
+			IndexPath: c.IndexPath,
+		})
+		monDone := make(chan struct{})
+		go func() {
+			defer close(monDone)
+			if err := mon.Run(ctx, c.MonitorAddr); err != nil {
+				fmt.Fprintln(os.Stderr, "monitor:", err)
+			}
+		}()
+		defer func() { <-monDone }()
 	}
 
 	fmt.Fprintf(os.Stderr, "watching %v for %q (Ctrl-C to stop)…\n", c.Dir, orTrue(c.Expr))

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,6 +47,7 @@ CEL expression recipes by content family, plus cross-cutting cookbook patterns.
 | [`forensics.md`](./forensics.md) | Forensic triage — `--with-hashes` populates `md5` / `sha1` / `sha256` (NSRL / VirusTotal / threat-intel interop), magic-byte-vs-extension detection, GPS / EXIF / email triage, time-bucketed activity |
 | [`hashsets.md`](./hashsets.md) | Hash allowlist / denylist — `is_known_good` / `is_known_bad` predicates; build NSRL or threat-intel-feed `.hashset` files via `file-search-on hash-set build` |
 | [`semantic-search.md`](./semantic-search.md) | Semantic similarity via local Ollama embeddings — `similarity` CEL variable + `search_semantic` MCP tool; conceptual / paraphrase-tolerant document discovery |
+| [`monitoring.md`](./monitoring.md) | Read-only dashboard for a running `mcp` / `watch` process — `--monitor-addr :9090`. Cache hit-rates, live tool-call activity, capabilities; localhost-only, zero-dep, JSON API |
 
 Every recipe is a complete `file-search-on '<expr>'` invocation that you can paste and run. Most include a few variations and useful output-format snippets.
 

--- a/examples/monitoring.md
+++ b/examples/monitoring.md
@@ -1,0 +1,54 @@
+# Monitoring dashboard
+
+The long-running modes — the `mcp` server and the `watch` command — can serve a small **read-only** monitoring dashboard so you can watch file-search-on's internal state while it runs: is the cache working, what is the agent doing right now, is OCR / embedding available.
+
+Enable it with `--monitor-addr`. It's **off by default**, binds **127.0.0.1 only** (the host part of the address is ignored — only the port matters), has **no auth**, and adds **no dependencies** (the UI is a single embedded page polling a JSON API).
+
+```sh
+# stdio MCP server (the common agent setup) + dashboard
+file-search-on mcp --monitor-addr :9090
+
+# HTTP MCP server + dashboard on a separate port
+file-search-on mcp --transport http --addr :8080 --monitor-addr :9090
+
+# watch mode + dashboard
+file-search-on watch 'is_image && body.contains("error")' --ocr -d ~/Desktop --monitor-addr :9090
+```
+
+Then open **http://localhost:9090/**.
+
+## Panels
+
+| Panel | Shows |
+| --- | --- |
+| **Overview** | version, uptime, run mode (`mcp-stdio` / `mcp-http` / `watch`), PID, Go version, GOMAXPROCS, default worker count, index backing (path or in-memory), body-cache cap, goroutines |
+| **Cache** | attribute / body / embedding cache counters with derived **hit-rate %** + sparklines; body evictions / oversize rejects and embed model-mismatches highlighted |
+| **Activity** | live MCP tool-call feed (tool, elapsed, outcome, result count), per-tool call/error/cancel counts + p50/p95/max latency, in-flight gauge |
+| **Capabilities** | registered content types grouped by family, project types, OCR provider availability, embedder model/server + reachability |
+
+In **watch mode** there are no MCP tool calls, so the Activity panel shows a notice; Overview / Cache / Capabilities still populate.
+
+## JSON API (scriptable)
+
+The same data the UI renders is available as JSON — handy for scripts, smoke checks, or piping into `jq`:
+
+```sh
+curl -s localhost:9090/api/overview      | jq          # version, uptime, mode, index backing
+curl -s localhost:9090/api/cache         | jq .attr    # attribute-cache hit rate + counters
+curl -s localhost:9090/api/activity      | jq '.snapshot.tools'   # per-tool latency
+curl -s localhost:9090/api/capabilities  | jq '.content_types.total'
+curl -s localhost:9090/healthz                          # liveness: {status, uptime_seconds, index_open}
+```
+
+The cache numbers match the `index_stats` MCP tool for the same running index — the dashboard is just a friendlier, pollable view of it.
+
+## Security notes
+
+- **Loopback only.** The dashboard can surface searched file paths (in the activity feed), so it never binds a routable interface. Passing `--monitor-addr 0.0.0.0:9090` still binds `127.0.0.1:9090` (with a one-line warning). For remote/container monitoring, front it with your own authenticated proxy or an SSH tunnel.
+- **Read-only.** There are no mutation endpoints — the dashboard can't change the server's behaviour, only observe it.
+- **Negligible overhead.** Tool-call instrumentation is a timestamp + a bounded ring-buffer append per call; the cache panel reads atomic counters. With `--monitor-addr` unset there is zero instrumentation.
+
+## Related
+
+- [`indexing.md`](indexing.md) — the `--index-path` attribute cache whose hit rates the Cache panel visualises.
+- [`watch.md`](watch.md) — continuous watching, one of the two modes the dashboard attaches to.

--- a/internal/mcpserver/instrument.go
+++ b/internal/mcpserver/instrument.go
@@ -1,0 +1,83 @@
+package mcpserver
+
+import (
+	"context"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/richardwooding/file-search-on/internal/monitor"
+)
+
+// callReporter is an optional interface a tool Output may implement so
+// the activity collector can record its result count + cancellation
+// status. Outputs that don't implement it record as ok/error only.
+type callReporter interface {
+	callReport() (count int, cancelled bool, reason string)
+}
+
+// instrument wraps a tool handler so each invocation is timed and
+// recorded on the collector (in-flight gauge, per-tool latency, recent
+// feed). When c is nil it returns h unchanged, so the no-monitor path —
+// and every existing test that builds the server without a collector —
+// pays nothing.
+func instrument[In, Out any](
+	c *monitor.Collector,
+	name string,
+	h func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, Out, error),
+) func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, Out, error) {
+	if c == nil {
+		return h
+	}
+	return func(ctx context.Context, req *mcp.CallToolRequest, in In) (*mcp.CallToolResult, Out, error) {
+		c.Begin()
+		start := time.Now()
+		res, out, err := h(ctx, req, in)
+		c.End()
+
+		outcome, reason, count := monitor.OutcomeOK, "", 0
+		switch {
+		case err != nil || (res != nil && res.IsError):
+			outcome = monitor.OutcomeError
+		default:
+			if r, ok := any(out).(callReporter); ok {
+				cnt, cancelled, rsn := r.callReport()
+				count = cnt
+				if cancelled {
+					outcome = monitor.OutcomeCancelled
+					reason = rsn
+				}
+			}
+		}
+		c.Record(name, time.Since(start), outcome, reason, count)
+		return res, out, err
+	}
+}
+
+// callReport implementations for the outputs that carry a result count
+// and cancellation status. Value receivers so the wrapper's
+// any(out).(callReporter) assertion succeeds on the returned value.
+
+func (o SearchOutput) callReport() (int, bool, string) {
+	return o.Count, o.Cancelled, o.CancellationReason
+}
+
+func (o SearchSemanticOutput) callReport() (int, bool, string) {
+	return o.Count, o.Cancelled, o.CancellationReason
+}
+
+func (o FindMatchesOutput) callReport() (int, bool, string) {
+	return o.Count, o.Cancelled, o.CancellationReason
+}
+
+func (o FindProjectsOutput) callReport() (int, bool, string) {
+	return o.Count, o.Cancelled, o.CancellationReason
+}
+
+func (o DiffTreesOutput) callReport() (int, bool, string) {
+	return o.Count, o.Cancelled, o.CancellationReason
+}
+
+func (o StatsOutput) callReport() (int, bool, string) {
+	return int(o.TotalCount), o.Cancelled, o.CancellationReason
+}

--- a/internal/mcpserver/instrument_test.go
+++ b/internal/mcpserver/instrument_test.go
@@ -1,0 +1,61 @@
+package mcpserver
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/monitor"
+)
+
+// TestInstrument_RecordsToolCalls drives a search through the in-memory
+// transport against a server built WithCollector, then asserts the
+// collector observed the call with its result count.
+func TestInstrument_RecordsToolCalls(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "a.md"), "# hello\n\nbody body body\n")
+	mustWrite(t, filepath.Join(dir, "b.md"), "# world\n\nmore body\n")
+
+	ctx := t.Context()
+	coll := monitor.NewCollector()
+	server := New("test", index.NewMemory(), 0, EmbedDefaults{}, WithCollector(coll))
+	t1, t2 := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	if _, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search",
+		Arguments: SearchInput{Expr: "is_markdown", Dir: dir},
+	}); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	snap := coll.Snapshot()
+	if snap.TotalCalls != 1 {
+		t.Fatalf("TotalCalls = %d, want 1", snap.TotalCalls)
+	}
+	if len(snap.Tools) != 1 || snap.Tools[0].Tool != "search" {
+		t.Fatalf("Tools = %+v, want one 'search'", snap.Tools)
+	}
+	if snap.Tools[0].Count != 1 {
+		t.Errorf("search count = %d, want 1", snap.Tools[0].Count)
+	}
+	// The callReporter path should surface the 2 markdown matches.
+	if len(snap.Recent) != 1 || snap.Recent[0].Count != 2 {
+		t.Errorf("recent[0] = %+v, want count 2 via callReport", snap.Recent)
+	}
+	if snap.Recent[0].Outcome != monitor.OutcomeOK {
+		t.Errorf("outcome = %q, want ok", snap.Recent[0].Outcome)
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/monitor"
 )
 
 // handlers wraps tool handlers so they can share an index reference
@@ -26,6 +27,21 @@ type handlers struct {
 	defaultEmbeddingServer string
 	defaultEmbeddingModel  string
 	version                string
+	// metrics, when non-nil, records per-tool-call telemetry for the
+	// monitoring dashboard. nil disables instrumentation entirely.
+	metrics *monitor.Collector
+}
+
+// Option configures the MCP server at construction. Used to attach
+// optional cross-cutting state (e.g. the monitoring collector) without
+// churning the New / Run signatures for the common case.
+type Option func(*handlers)
+
+// WithCollector attaches a monitoring collector so every tool call is
+// timed and recorded. Pass the same collector to monitor.NewServer so
+// the dashboard can read it back.
+func WithCollector(c *monitor.Collector) Option {
+	return func(h *handlers) { h.metrics = c }
 }
 
 // resolveTimeout returns a child ctx bounded by the effective per-call
@@ -240,7 +256,7 @@ type EmbedDefaults struct {
 	Model  string // Ollama embedding model name; "" → no default
 }
 
-func New(version string, idx index.Index, defaultTimeout time.Duration, embedDefaults EmbedDefaults) *mcp.Server {
+func New(version string, idx index.Index, defaultTimeout time.Duration, embedDefaults EmbedDefaults, opts ...Option) *mcp.Server {
 	s := mcp.NewServer(&mcp.Implementation{
 		Name:    "file-search-on",
 		Version: version,
@@ -259,101 +275,104 @@ func New(version string, idx index.Index, defaultTimeout time.Duration, embedDef
 		defaultEmbeddingModel:  embedDefaults.Model,
 		version:                version,
 	}
+	for _, opt := range opts {
+		opt(h)
+	}
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "search",
 		Description: "Recursively search a directory for files matching a CEL expression evaluated over file metadata and content-type-specific attributes. Boolean type predicates you can use directly in expr: is_markdown, is_pdf, is_html, is_xml, is_json, is_yaml, is_csv, is_text, is_image, is_audio, is_video, is_office, is_epub, is_archive, is_binary, is_email, is_source, is_disk_image (umbrella for is_dmg/is_iso/is_vhd/is_vhdx/is_vmdk/is_qcow2/is_wim), is_install_package (umbrella for is_pkg/is_deb/is_rpm/is_appimage), is_bytecode (umbrella for is_class/is_pyc/is_wasm — VM bytecode artefacts with parsed runtime_version + per-format metadata), is_test_file (source files matching the per-language test convention), is_symlink + is_broken_symlink (filesystem-level symlink awareness; target_path attribute carries the raw link target). Common scalar attributes: size (int bytes), name, path, dir, ext, content_type, title, author, language, word_count, line_count, page_count. Per-family attributes (image EXIF, audio tags, video codec, frontmatter, archive sizes, binary architectures, email headers, source-LOC, disk-image virtual_size / disk_image_format / volume_label / cluster_bits / is_encrypted / image_count, install-package package_format / package_name / package_version / package_arch / package_kind, license_id for repo-license files) populate when the matching family fires — see list_attributes for the full schema. Built-in functions: levenshtein(a, b), soundex(s), ngrams(s, n), ngram_similarity(a, b, n) for fuzzy / phonetic matching; point_in_polygon(lat, lon, polygon) for GPS-bbox filtering. Example exprs: 'is_markdown && word_count > 500'; 'is_pdf && page_count > 10'; 'is_image && iso > 1600'; 'is_video && video_height >= 2160 && duration > 1800'; 'is_source && language == \"go\" && loc > 200'. Top-K queries: pass sort_by + limit, e.g. {expr:'is_video', sort_by:'duration', order:'desc', limit:5} for the 5 longest videos. Sort keys: size, name, path, mod_time, created_at, metadata_changed_at, word_count, line_count, page_count, duration, bitrate, sample_rate, video_height, video_width, frame_rate, iso, focal_length, taken_at, sent_at, year, entry_count, uncompressed_size, loc, attachment_count, email_count, virtual_size, image_count, disk_image_created_at, cluster_bits. Snippets: pass include_snippet=true to populate match.snippet with the first N lines of body text (text content types only). Body filters: pass include_body=true to expose the full file body as the CEL 'body' variable, then use built-in string methods to filter: body.contains(\"X\"), body.matches(\"\\\\bX\\\\b\") (RE2 regex). Body reads every candidate file — pair with a tight type predicate (e.g. is_markdown). Exclusions: pass excludes (basename globs like ['node_modules', '.git', '*.bak']) and/or respect_gitignore=true to prune the walk. Repeated searches reuse a per-process attribute cache so unchanged files skip the parse step (see index_stats). Timeouts: every call is bounded by the server's default timeout (set at startup via --timeout, typically 60s); pass timeout_seconds in the input to override (positive = seconds, 0 = no timeout). On timeout the call DOES NOT error — it returns the partial match set with cancelled=true, cancellation_reason set, and elapsed_seconds populated. Always check 'cancelled' before treating the result as exhaustive.",
-	}, h.searchHandler)
+	}, instrument(h.metrics, "search", h.searchHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "search_semantic",
 		Description: "Semantic similarity search via local Ollama embeddings. Returns files RANKED by conceptual similarity to a natural-language query — paraphrase, synonyms, and topic-level matches surface even when the exact words don't appear in the body. Required input: 'query' (the natural-language search). Optional: 'threshold' (default 0.5; cosine similarity floor — 0.7+ for strict topical match, 0.4-0.5 for loose / related), 'limit' (default 50; top-K cap), 'expr' (CEL pre-filter using the same vocabulary as the search tool — e.g. 'is_pdf || is_office' to scope to documents), 'model' / 'embedding_server' (per-call overrides for the server-startup defaults — useful when you've pulled multiple embedding models). Setup: requires Ollama running locally (https://ollama.com) and one embedding model pulled (e.g. 'ollama pull nomic-embed-text'). The MCP server boots WITHOUT Ollama; the first search_semantic call performs the connection check and returns a clear error if Ollama is unreachable or the model isn't pulled. The per-file embedding is cached alongside (size, mtime) so repeat searches against an unchanged tree are I/O-cheap.",
-	}, h.searchSemanticHandler)
+	}, instrument(h.metrics, "search_semantic", h.searchSemanticHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_attributes",
 		Description: "List every CEL attribute available to the search tool, the built-in functions (levenshtein, soundex, ngrams, ngram_similarity, point_in_polygon) with their signatures, and the registered content types.",
-	}, h.listAttributesHandler)
+	}, instrument(h.metrics, "list_attributes", h.listAttributesHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "read_attributes",
 		Description: "Extract content-type-specific attributes for a single file path. Use when the agent already knows the path and wants metadata without running a CEL filter or walking a directory. Returns the same Match shape as the search tool — title, author, EXIF, audio tags, video codec, frontmatter, etc., depending on the detected content type.",
-	}, h.readAttributesHandler)
+	}, instrument(h.metrics, "read_attributes", h.readAttributesHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "index_stats",
 		Description: "Return cumulative attribute-cache counters (hits, misses, puts, stales, errors) for the running MCP server. Counters reset on server restart.",
-	}, h.indexStatsHandler)
+	}, instrument(h.metrics, "index_stats", h.indexStatsHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "stats",
 		Description: "Aggregate counts and total sizes for a directory tree, bucketed by an attribute. Default bucket is content_type; pass group_by to bucket by ext, dir, language, camera_make, camera_model, lens, artist, album, genre, kernel, binary_format, binary_type, or frontmatter_format. Useful for 'what's in this folder?' and 'how many photos per camera?' style reconnaissance without retrieving individual paths. Accepts an optional CEL expr to scope the histogram (e.g. expr='is_image' + group_by='camera_make' for photos-by-camera). Multi-dir: pass 'dirs' to aggregate across multiple roots in one call. Honours the same excludes / respect_gitignore / timeout_seconds semantics as the search tool, including partial-result returns on cancellation. Output's `groups[]` is the histogram keyed by the resolved group_by; `content_types[]` is populated alongside only for the default group_by, kept for back-compat with older clients.",
-	}, h.statsHandler)
+	}, instrument(h.metrics, "stats", h.statsHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "read_lines",
 		Description: "Print a specific line range from a single file. Completes the search-then-inspect loop without a separate read tool — agent flow: search for matches, then call read_lines for context around each match. Inputs: path (required), start_line (1-indexed inclusive; default 1), end_line (1-indexed inclusive; 0 = end of file), max_lines (cap; default 1000). Returns lines[] (no trailing newlines), total_lines, and truncated:true when the requested range exceeds max_lines. Errors only on missing/unreadable files or invalid ranges (start_line > end_line); pathological lines (huge / non-UTF-8) are truncated at 64 KiB per line and the scan continues.",
-	}, h.readLinesHandler)
+	}, instrument(h.metrics, "read_lines", h.readLinesHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "find_duplicates",
 		Description: "Find groups of byte-identical files keyed by sha256. Useful for 'what's eating my disk?' and 'find redundant copies' workflows. Two-pass for performance: files with unique sizes are skipped entirely (cheaper than computing their hash). Pair with expr to scope (e.g. expr='is_image' for photo dedup) and min_size to skip tiny duplicates. Hashes are cached in the attribute index alongside (size, mtime) — first run on a large tree can be slow (every candidate file is read in full), but subsequent runs are free for unchanged files. Output: duplicates[] sorted by wasted_bytes descending — biggest reclamation candidates first.",
-	}, h.findDuplicatesHandler)
+	}, instrument(h.metrics, "find_duplicates", h.findDuplicatesHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "find_near_duplicates",
 		Description: "Find groups of SIMILAR (not identical) files via SimHash fingerprint of their extracted body. Complements 'find_duplicates' for fuzzy matching — catches files with trailing-newline edits, regenerated headers, typo fixes, template copies, and minor revisions that exact-hash dedup misses. Algorithm: 64-bit Charikar SimHash over tokenized body text → pairwise Hamming distance → union-find groups files within the similarity threshold. Inputs: expr (optional CEL pre-prune; e.g. is_markdown to limit to docs), threshold (0..1, default 0.85 ≈ 9-bit Hamming distance; 0.95 ≈ 3 bits for whitespace/typo-only edits; 0.75 ≈ 16 bits for significant structural overlap), min_size (skip tiny files), the usual dir / dirs / excludes / timeout_seconds. Only text-shaped and structured-document types fingerprint (markdown / text / html / csv / json / xml / source/* / pdf / office / epub / email); binary families return zero fingerprints and are excluded. Fingerprints cache in the attribute index alongside hash; repeat runs on unchanged trees skip body extraction AND SimHash compute. Output: groups[] sorted by member count desc — biggest near-duplicate clusters first. Similarity = 1.0 means identical body text (which would also surface via find_duplicates).",
-	}, h.findNearDuplicatesHandler)
+	}, instrument(h.metrics, "find_near_duplicates", h.findNearDuplicatesHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "diff_trees",
 		Description: "Cross-tree set operations by sha256 content hash — the inverse of find_duplicates (which finds dupes WITHIN a tree). Answers 'what's in tree A that's NOT in tree B?', 'what content do they share?', 'which same-named files drifted?'. Inputs: tree_a + tree_b (required), op ('a-minus-b' default = content in A but not B, 'b-minus-a', 'intersect' = in both, 'union' = all distinct, 'mismatch' = same relative path but differing content), expr (optional CEL pre-prune applied to both trees, e.g. 'size > 1000000'), plus excludes / respect_gitignore / follow_symlinks / min_size / timeout_seconds. Hashes cache in the attribute index alongside (size, mtime) — two warm trees diff in seconds. Output: records[] of {status, path_a, path_b, sha256, size} sorted by (path_a, path_b, sha256); status ∈ only_in_a / only_in_b / both / name_match_content_differs. Read-only — never mutates either tree. Use cases: pre-backup sanity ('what's on the external drive I don't have locally?'), incremental-migration verification, sync-correctness checks, drift detection. Issue #210.",
-	}, h.diffTreesHandler)
+	}, instrument(h.metrics, "diff_trees", h.diffTreesHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_archive_contents",
 		Description: "List or filter entries inside a ZIP / TAR / TAR.GZ / GZIP archive without extracting. Per-entry CEL evaluation against the SAME vocabulary the top-level search uses — every is_X predicate (is_source, is_dockerfile, is_pdf, …) and per-family attribute (loc, language, page_count, frontmatter, …) works inside archives. Detection runs on the entry's bytes (first 512 sniffed against a synthetic in-memory FS), so 'src/main.go' inside a tarball detects as source/go and surfaces loc / comment_loc just like a real file. Inputs: path (required), expr (optional CEL filter), glob (basename pattern applied BEFORE the CEL pass), include_attributes (off by default — terse listing of name/size/content_type only), include_body (read entry bodies so body.contains / body.matches fire; bypasses the entry-list cache), max_entries (cap), timeout_seconds. The entry-list cache uses the existing attribute index: hit path filters cached records by glob + expr without opening the archive; miss path walks + populates the cache asynchronously. Archives with > 10000 entries skip the cache (too large to encode). Output: entries[] sorted by walk order; cache_hit=true when the response came from cache. Use when an agent needs to answer 'does this tarball contain Dockerfile?' or 'find every Go file with loc > 200 inside any tarball' without extracting first.",
-	}, h.listArchiveContentsHandler)
+	}, instrument(h.metrics, "list_archive_contents", h.listArchiveContentsHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "read_file_in_archive",
 		Description: "Read a single named file's bytes out of a ZIP / TAR / TAR.GZ / GZIP archive without extracting. entry_path must match an entry exactly (not a glob). Returns content as UTF-8 text when valid (content field) or base64-encoded raw bytes when not (content_base64). Capped at max_bytes (default 1 MiB) with truncated=true when the entry exceeds the cap. Also surfaces detected content_type + per-format attributes so callers don't need a separate list_archive_contents to know what they're looking at. Useful for agent flows like 'pull pyproject.toml out of source.tar.gz to check the Python version' or 'read the .github/workflows/ci.yml from a release archive'. Errors with entry-not-found when entry_path doesn't match any archive entry.",
-	}, h.readFileInArchiveHandler)
+	}, instrument(h.metrics, "read_file_in_archive", h.readFileInArchiveHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "detect_project",
 		Description: "Inspect a single directory and report which project type(s) it matches based on canonical indicator files (go.mod → go, package.json → node, Cargo.toml → rust, pyproject.toml/requirements.txt/Pipfile → python, Gemfile → ruby, pom.xml → java-maven, build.gradle → java-gradle, *.csproj → dotnet, *.tf → terraform, docker-compose.yml → docker-compose; plus static-site generators: hugo.toml → hugo, _config.yml → jekyll, .eleventy.js / eleventy.config.* → eleventy, astro.config.* → astro, gatsby-config.* → gatsby, mkdocs.yml → mkdocs, docusaurus.config.* → docusaurus, pelicanconf.py → pelican). A directory can match multiple types simultaneously (a Go module that also ships docker-compose.yml hits both). Output includes the matched indicator filename for each type so callers can audit detection decisions. Non-recursive — only the given directory's own listing is read.",
-	}, h.detectProjectHandler)
+	}, instrument(h.metrics, "detect_project", h.detectProjectHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "find_projects",
 		Description: "Walk a root directory and return every project root found. A project root is a directory whose contents match a registered project-type indicator. By default the walker stops at the first match per branch (the 'find me all my Go repos' shape) — pass nested=true to also surface sub-projects inside matched roots (monorepo workspaces, vendored deps). Filter to specific types with 'types': ['go','rust',…]. Prune the walk with 'excludes' (basename globs like ['node_modules', '.git', 'target']) or respect_gitignore. Honours the same timeout / cancellation contract as the search tool — on expiry the partial result set is returned with cancelled=true, never an error.",
-	}, h.findProjectsHandler)
+	}, instrument(h.metrics, "find_projects", h.findProjectsHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "find_matches",
 		Description: "Scan a directory tree for lines matching an RE2 regex, with optional context windows. Combines a CEL pre-prune (type predicates + typed attributes, same vocabulary as the search tool) with a line-level regex scan: 'expr' picks the candidate files cheaply (e.g. is_source && language == \"go\"), then 'pattern' runs against each line and reports every hit with its line number and the requested before/after context. Returns line-level matches sorted by (path, line). Only text content types participate (markdown / text / html / csv / json / xml / source/*); binary families are filtered out. Inputs: pattern (required, RE2), expr (optional CEL pre-prune), context_before / context_after (surrounding lines per hit), max_matches_per_file (cap; the scanner keeps reading past the cap until pending After windows are filled). Same dir / dirs / excludes / respect_gitignore / timeout_seconds / cancellation contract as search. Use when an agent needs 'find references to X' or 'show every TODO with context' — replaces the two-call search-then-read_lines dance with one call.",
-	}, h.findMatchesHandler)
+	}, instrument(h.metrics, "find_matches", h.findMatchesHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "watch_search",
 		Description: "Watch directories for a BOUNDED window and return every new / changed file that matches a CEL expression — the inverse of search ('tell me when X appears' instead of 'what already matches'). Same CEL vocabulary as the search tool (is_image, is_pdf, is_source && language == \"go\", size > 1000000, body.contains(\"error\"), …). Watches recursively (subdirectories created during the window are picked up). Blocks until duration_seconds elapses (default 30s, hard-capped at 600s), max_events matches are collected, or the call is cancelled — whichever comes first; then returns the collected matches. Inputs: expr (optional CEL filter), dir / dirs, duration_seconds (how long to watch), max_events (return early after N matches), plus the usual ocr_images / compute_hashes / with_phash / with_xattrs / include_body / excludes / respect_gitignore flags. Output: matches[] (same shape as search) + watched_seconds + hit_max_events. Use for short 'wait for the next screenshot / build artefact / download' flows; for open-ended streaming use the CLI 'watch' subcommand. Issue #211.",
-	}, h.watchSearchHandler)
+	}, instrument(h.metrics, "watch_search", h.watchSearchHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_presets",
 		Description: "List every named search recipe ('preset') available to the query_preset tool — each preset bakes a vetted CEL filter + sensible sort / limit defaults for a common workflow. Use this to discover what's available before calling query_preset. v1 presets: recent_changes (files modified in the last 7 days), recent_photos (images taken in the last 30 days), old_drafts (markdown drafts older than 90 days — neglected work), large_files (files > 100 MB), large_binaries (compiled binaries > 100 MB), suspicious_files (forensic-triage shortcut — disguised files or btime anomalies; auto-enables check_disguised), failed_tests (source test files mentioning FAIL/FIXME/XXX; auto-enables include_body), system_metadata (OS leftovers — .DS_Store / Thumbs.db / Desktop.ini / .directory). Output: presets[] with name + description; pass the name to query_preset to run.",
-	}, h.listPresetsHandler)
+	}, instrument(h.metrics, "list_presets", h.listPresetsHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "query_preset",
 		Description: "Run a named search recipe by name. Each preset bakes a vetted CEL filter + sensible defaults — recent_changes / recent_photos / old_drafts / large_files / large_binaries / suspicious_files / failed_tests / system_metadata. Per-call overrides: dir / dirs to scope the walk, limit to override the preset's default cap, excludes / respect_gitignore / follow_symlinks for the usual walk-pruning options. Returns the same Match shape as the search tool. Discover available presets via list_presets. Issue #168 sub-feature B.",
-	}, h.queryPresetHandler)
+	}, instrument(h.metrics, "query_preset", h.queryPresetHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "resolve_project_for_path",
 		Description: "Given an arbitrary file or directory path, walk up the directory chain (unbounded — terminates at the filesystem root) and return the nearest ancestor that matches a registered project type (go.mod → go, package.json → node, Cargo.toml → rust, pyproject.toml/requirements.txt/Pipfile → python, Gemfile → ruby, pom.xml → java-maven, build.gradle → java-gradle, *.csproj → dotnet, *.tf → terraform, docker-compose.yml → docker-compose; plus static-site generators hugo / jekyll / eleventy / astro / gatsby / mkdocs / docusaurus / pelican). The MIDDLE question between detect_project (single-dir, what is THIS dir?) and find_projects (recursive, what's under this tree?): given a file path, what project owns it? Returns project_root (matched directory; empty when no ancestor matches), project_types (all matching types — a Go module that also ships docker-compose.yml hits both), and the indicators that fired. Use when an agent has a path from elsewhere and needs the project context — e.g. to scope a follow-up search or decide which language-specific tool to invoke.",
-	}, h.resolveProjectForPathHandler)
+	}, instrument(h.metrics, "resolve_project_for_path", h.resolveProjectForPathHandler))
 
 	return s
 }
@@ -361,6 +380,6 @@ func New(version string, idx index.Index, defaultTimeout time.Duration, embedDef
 // Run starts an MCP server on stdio with the given index and default
 // per-call timeout, and blocks until the transport closes or ctx is
 // cancelled.
-func Run(ctx context.Context, version string, idx index.Index, defaultTimeout time.Duration, embedDefaults EmbedDefaults) error {
-	return New(version, idx, defaultTimeout, embedDefaults).Run(ctx, &mcp.StdioTransport{})
+func Run(ctx context.Context, version string, idx index.Index, defaultTimeout time.Duration, embedDefaults EmbedDefaults, opts ...Option) error {
+	return New(version, idx, defaultTimeout, embedDefaults, opts...).Run(ctx, &mcp.StdioTransport{})
 }

--- a/internal/mcpserver/transports.go
+++ b/internal/mcpserver/transports.go
@@ -19,8 +19,8 @@ import (
 //
 // addr is a host:port pair (e.g. ":8080"). path is the URL prefix the handler
 // is mounted at (e.g. "/" or "/mcp").
-func RunHTTP(ctx context.Context, version, addr, path string, idx index.Index, defaultTimeout time.Duration, embedDefaults EmbedDefaults) error {
-	server := New(version, idx, defaultTimeout, embedDefaults)
+func RunHTTP(ctx context.Context, version, addr, path string, idx index.Index, defaultTimeout time.Duration, embedDefaults EmbedDefaults, opts ...Option) error {
+	server := New(version, idx, defaultTimeout, embedDefaults, opts...)
 	handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
 		return server
 	}, nil)
@@ -30,8 +30,8 @@ func RunHTTP(ctx context.Context, version, addr, path string, idx index.Index, d
 // RunSSE serves the MCP server over the deprecated HTTP+SSE transport
 // (MCP spec 2024-11-05). Kept for backward compatibility with older clients;
 // new deployments should prefer RunHTTP.
-func RunSSE(ctx context.Context, version, addr, path string, idx index.Index, defaultTimeout time.Duration, embedDefaults EmbedDefaults) error {
-	server := New(version, idx, defaultTimeout, embedDefaults)
+func RunSSE(ctx context.Context, version, addr, path string, idx index.Index, defaultTimeout time.Duration, embedDefaults EmbedDefaults, opts ...Option) error {
+	server := New(version, idx, defaultTimeout, embedDefaults, opts...)
 	handler := mcp.NewSSEHandler(func(*http.Request) *mcp.Server {
 		return server
 	}, nil)

--- a/internal/monitor/collector.go
+++ b/internal/monitor/collector.go
@@ -1,0 +1,200 @@
+// Package monitor provides an opt-in, localhost-only HTTP dashboard for
+// observing file-search-on's internal state while a long-running mode
+// (the MCP server or the watch command) is active. It is read-only and
+// adds no external dependencies — the UI is a single embedded page that
+// polls a small JSON API.
+//
+// Collector lives here (rather than in mcpserver) so both the MCP
+// handlers (which write tool-call telemetry) and the dashboard (which
+// reads snapshots) can depend on it without an import cycle: mcpserver
+// imports monitor; monitor never imports mcpserver.
+package monitor
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// recentCap bounds the rolling recent-calls feed.
+	recentCap = 256
+	// latencyCap bounds the per-tool latency sample kept for percentiles.
+	latencyCap = 128
+)
+
+// Outcome classifies how a tool call ended.
+const (
+	OutcomeOK        = "ok"
+	OutcomeError     = "error"
+	OutcomeCancelled = "cancelled"
+)
+
+// Collector records MCP tool-call telemetry. All methods are safe for
+// concurrent use by many tool-handler goroutines.
+type Collector struct {
+	startedAt time.Time
+	inflight  atomic.Int64
+
+	mu          sync.Mutex
+	perTool     map[string]*toolStat
+	recent      []CallRecord // oldest → newest, capped at recentCap
+	totalCalls  uint64
+	totalErrors uint64
+}
+
+// toolStat accumulates per-tool counters plus a bounded sample of recent
+// latencies (seconds) for percentile estimation.
+type toolStat struct {
+	count     uint64
+	errors    uint64
+	cancels   uint64
+	maxSec    float64
+	durations []float64 // bounded at latencyCap, drop-oldest
+}
+
+// CallRecord is one entry in the recent-calls feed.
+type CallRecord struct {
+	Tool    string    `json:"tool"`
+	At      time.Time `json:"at"`
+	Seconds float64   `json:"seconds"`
+	Outcome string    `json:"outcome"`          // ok | error | cancelled
+	Reason  string    `json:"reason,omitempty"` // cancellation reason when cancelled
+	Count   int       `json:"count,omitempty"`  // result count when the tool reports one
+}
+
+// NewCollector returns a ready Collector with its uptime clock started.
+func NewCollector() *Collector {
+	return &Collector{
+		startedAt: time.Now(),
+		perTool:   make(map[string]*toolStat),
+	}
+}
+
+// Begin marks a tool call as in-flight; pair with End (deferred).
+func (c *Collector) Begin() { c.inflight.Add(1) }
+
+// End marks an in-flight tool call as finished.
+func (c *Collector) End() { c.inflight.Add(-1) }
+
+// Record logs a completed tool call. outcome is one of the Outcome*
+// constants; reason is the cancellation reason (empty otherwise); count
+// is the tool's result count when known (0 otherwise).
+func (c *Collector) Record(tool string, d time.Duration, outcome, reason string, count int) {
+	sec := d.Seconds()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.totalCalls++
+	ts := c.perTool[tool]
+	if ts == nil {
+		ts = &toolStat{}
+		c.perTool[tool] = ts
+	}
+	ts.count++
+	switch outcome {
+	case OutcomeError:
+		ts.errors++
+		c.totalErrors++
+	case OutcomeCancelled:
+		ts.cancels++
+	}
+	if sec > ts.maxSec {
+		ts.maxSec = sec
+	}
+	if len(ts.durations) >= latencyCap {
+		ts.durations = ts.durations[1:]
+	}
+	ts.durations = append(ts.durations, sec)
+
+	if len(c.recent) >= recentCap {
+		c.recent = c.recent[1:]
+	}
+	c.recent = append(c.recent, CallRecord{
+		Tool: tool, At: time.Now(), Seconds: sec,
+		Outcome: outcome, Reason: reason, Count: count,
+	})
+}
+
+// Snapshot is an immutable view of the collector's state for the API.
+type Snapshot struct {
+	UptimeSeconds float64            `json:"uptime_seconds"`
+	InFlight      int64              `json:"in_flight"`
+	TotalCalls    uint64             `json:"total_calls"`
+	TotalErrors   uint64             `json:"total_errors"`
+	Tools         []ToolStatSnapshot `json:"tools"`
+	Recent        []CallRecord       `json:"recent"` // newest first
+}
+
+// ToolStatSnapshot is the per-tool rollup shown in the activity panel.
+type ToolStatSnapshot struct {
+	Tool    string  `json:"tool"`
+	Count   uint64  `json:"count"`
+	Errors  uint64  `json:"errors"`
+	Cancels uint64  `json:"cancels"`
+	P50     float64 `json:"p50_seconds"`
+	P95     float64 `json:"p95_seconds"`
+	Max     float64 `json:"max_seconds"`
+}
+
+// Snapshot returns a copy of the current telemetry. Tools are sorted by
+// call count descending; Recent is newest-first.
+func (c *Collector) Snapshot() Snapshot {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	tools := make([]ToolStatSnapshot, 0, len(c.perTool))
+	for name, ts := range c.perTool {
+		p50, p95 := percentiles(ts.durations)
+		tools = append(tools, ToolStatSnapshot{
+			Tool: name, Count: ts.count, Errors: ts.errors, Cancels: ts.cancels,
+			P50: p50, P95: p95, Max: ts.maxSec,
+		})
+	}
+	sort.Slice(tools, func(i, j int) bool {
+		if tools[i].Count != tools[j].Count {
+			return tools[i].Count > tools[j].Count
+		}
+		return tools[i].Tool < tools[j].Tool
+	})
+
+	recent := make([]CallRecord, len(c.recent))
+	for i, r := range c.recent { // reverse → newest first
+		recent[len(c.recent)-1-i] = r
+	}
+
+	return Snapshot{
+		UptimeSeconds: time.Since(c.startedAt).Seconds(),
+		InFlight:      c.inflight.Load(),
+		TotalCalls:    c.totalCalls,
+		TotalErrors:   c.totalErrors,
+		Tools:         tools,
+		Recent:        recent,
+	}
+}
+
+// percentiles returns p50 and p95 of the sample (seconds). Copies and
+// sorts so the caller's slice is untouched. Empty → (0, 0).
+func percentiles(sample []float64) (p50, p95 float64) {
+	if len(sample) == 0 {
+		return 0, 0
+	}
+	s := make([]float64, len(sample))
+	copy(s, sample)
+	sort.Float64s(s)
+	return s[pctIndex(len(s), 50)], s[pctIndex(len(s), 95)]
+}
+
+// pctIndex maps a percentile to a clamped index into a sorted slice of
+// length n (nearest-rank).
+func pctIndex(n, pct int) int {
+	if n == 0 {
+		return 0
+	}
+	idx := pct * n / 100
+	if idx >= n {
+		idx = n - 1
+	}
+	return idx
+}

--- a/internal/monitor/collector_test.go
+++ b/internal/monitor/collector_test.go
@@ -1,0 +1,104 @@
+package monitor
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCollector_RecordAndSnapshot(t *testing.T) {
+	c := NewCollector()
+	c.Record("search", 100*time.Millisecond, OutcomeOK, "", 5)
+	c.Record("search", 300*time.Millisecond, OutcomeOK, "", 9)
+	c.Record("search", 50*time.Millisecond, OutcomeError, "", 0)
+	c.Record("stats", 10*time.Millisecond, OutcomeCancelled, "timeout", 0)
+
+	s := c.Snapshot()
+	if s.TotalCalls != 4 {
+		t.Errorf("TotalCalls = %d, want 4", s.TotalCalls)
+	}
+	if s.TotalErrors != 1 {
+		t.Errorf("TotalErrors = %d, want 1", s.TotalErrors)
+	}
+	if len(s.Tools) != 2 {
+		t.Fatalf("Tools = %d, want 2", len(s.Tools))
+	}
+	// search has the most calls → first.
+	if s.Tools[0].Tool != "search" || s.Tools[0].Count != 3 {
+		t.Errorf("Tools[0] = %+v, want search count 3", s.Tools[0])
+	}
+	if s.Tools[0].Errors != 1 {
+		t.Errorf("search errors = %d, want 1", s.Tools[0].Errors)
+	}
+	if s.Tools[0].Max < 0.29 {
+		t.Errorf("search max = %v, want >= 0.3", s.Tools[0].Max)
+	}
+	// recent is newest-first; last recorded was the cancelled stats call.
+	if len(s.Recent) != 4 || s.Recent[0].Tool != "stats" || s.Recent[0].Outcome != OutcomeCancelled {
+		t.Errorf("Recent[0] = %+v, want newest = cancelled stats", s.Recent[0])
+	}
+	if s.Recent[0].Reason != "timeout" {
+		t.Errorf("cancel reason = %q, want timeout", s.Recent[0].Reason)
+	}
+}
+
+func TestCollector_RecentCappedAndInFlight(t *testing.T) {
+	c := NewCollector()
+	c.Begin()
+	c.Begin()
+	if got := c.Snapshot().InFlight; got != 2 {
+		t.Errorf("InFlight = %d, want 2", got)
+	}
+	c.End()
+	for range recentCap + 50 {
+		c.Record("x", time.Millisecond, OutcomeOK, "", 0)
+	}
+	s := c.Snapshot()
+	if len(s.Recent) != recentCap {
+		t.Errorf("Recent len = %d, want capped at %d", len(s.Recent), recentCap)
+	}
+	if s.InFlight != 1 {
+		t.Errorf("InFlight = %d, want 1", s.InFlight)
+	}
+}
+
+// TestCollector_Concurrent is the -race guard: many goroutines record +
+// begin/end + snapshot at once.
+func TestCollector_Concurrent(t *testing.T) {
+	c := NewCollector()
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			for i := range 200 {
+				c.Begin()
+				c.Record("tool", time.Duration(i)*time.Microsecond, OutcomeOK, "", i)
+				c.End()
+				if i%50 == 0 {
+					_ = c.Snapshot()
+				}
+			}
+		})
+	}
+	wg.Wait()
+	if got := c.Snapshot().TotalCalls; got != 16*200 {
+		t.Errorf("TotalCalls = %d, want %d", got, 16*200)
+	}
+}
+
+func TestPercentiles(t *testing.T) {
+	// 1..100 → p50 ≈ 50, p95 ≈ 95 (nearest-rank, 0-indexed).
+	sample := make([]float64, 100)
+	for i := range sample {
+		sample[i] = float64(i + 1)
+	}
+	p50, p95 := percentiles(sample)
+	if p50 < 50 || p50 > 52 {
+		t.Errorf("p50 = %v, want ~51", p50)
+	}
+	if p95 < 95 || p95 > 97 {
+		t.Errorf("p95 = %v, want ~96", p95)
+	}
+	if p, _ := percentiles(nil); p != 0 {
+		t.Errorf("empty p50 = %v, want 0", p)
+	}
+}

--- a/internal/monitor/server.go
+++ b/internal/monitor/server.go
@@ -1,0 +1,283 @@
+package monitor
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/content/ocr"
+	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/projecttype"
+)
+
+//go:embed static/*
+var staticFiles embed.FS
+
+// Config wires the dashboard to the running process's state. Index is
+// required (for cache stats); Collector is nil in watch mode (no MCP
+// tool calls to report). The Embed* / IndexPath / BodyCacheCap fields
+// are informational, surfaced on the overview panel.
+type Config struct {
+	Version      string
+	Mode         string // "mcp-stdio" | "mcp-http" | "mcp-sse" | "watch"
+	Index        index.Index
+	Collector    *Collector
+	EmbedServer  string
+	EmbedModel   string
+	IndexPath    string // "" → in-memory
+	BodyCacheCap int64  // 0 → in-memory / no cap
+}
+
+// Server is the read-only monitoring HTTP server.
+type Server struct {
+	cfg       Config
+	startedAt time.Time
+}
+
+// NewServer builds a monitoring server from cfg.
+func NewServer(cfg Config) *Server {
+	return &Server{cfg: cfg, startedAt: time.Now()}
+}
+
+// Run binds a localhost-only HTTP listener and serves the dashboard +
+// JSON API until ctx is cancelled, then shuts down gracefully. addr's
+// host is forced to 127.0.0.1 — only the port is honoured — so the
+// dashboard (which can surface searched file paths) never binds a
+// routable interface.
+func (s *Server) Run(ctx context.Context, addr string) error {
+	addr = forceLoopback(addr)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/overview", s.handleOverview)
+	mux.HandleFunc("GET /api/cache", s.handleCache)
+	mux.HandleFunc("GET /api/activity", s.handleActivity)
+	mux.HandleFunc("GET /api/capabilities", s.handleCapabilities)
+	mux.HandleFunc("GET /healthz", s.handleHealthz)
+
+	sub, err := fs.Sub(staticFiles, "static")
+	if err != nil {
+		return fmt.Errorf("monitor static assets: %w", err)
+	}
+	mux.Handle("GET /", http.FileServerFS(sub))
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe() }()
+
+	fmt.Fprintf(os.Stderr, "monitor dashboard: http://%s/\n", addr)
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("monitor shutdown: %w", err)
+		}
+		return nil
+	case err := <-errCh:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}
+
+// forceLoopback returns a 127.0.0.1 address preserving only the port of
+// addr. A non-loopback host in addr is ignored (with a one-line warn) so
+// the dashboard never escapes the local machine.
+func forceLoopback(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		// No port separator (e.g. "9090"); treat the whole thing as a port.
+		port = strings.TrimPrefix(addr, ":")
+		host = ""
+	}
+	if host != "" && host != "127.0.0.1" && host != "localhost" {
+		fmt.Fprintf(os.Stderr, "monitor: ignoring non-loopback host %q; binding 127.0.0.1 only\n", host)
+	}
+	if port == "" {
+		port = "9090"
+	}
+	return net.JoinHostPort("127.0.0.1", port)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// --- /api/overview ---
+
+func (s *Server) handleOverview(w http.ResponseWriter, _ *http.Request) {
+	indexBacking := "in-memory"
+	if s.cfg.IndexPath != "" {
+		indexBacking = s.cfg.IndexPath
+	}
+	writeJSON(w, map[string]any{
+		"version":        s.cfg.Version,
+		"mode":           s.cfg.Mode,
+		"uptime_seconds": time.Since(s.startedAt).Seconds(),
+		"pid":            os.Getpid(),
+		"go_version":     runtime.Version(),
+		"gomaxprocs":     runtime.GOMAXPROCS(0),
+		"num_cpu":        runtime.NumCPU(),
+		"index_backing":  indexBacking,
+		"body_cache_cap": s.cfg.BodyCacheCap,
+		"goroutines":     runtime.NumGoroutine(),
+	})
+}
+
+// --- /api/cache ---
+
+func (s *Server) handleCache(w http.ResponseWriter, _ *http.Request) {
+	if s.cfg.Index == nil {
+		writeJSON(w, map[string]any{"available": false})
+		return
+	}
+	st := s.cfg.Index.Stats()
+	writeJSON(w, map[string]any{
+		"available": true,
+		"attr": map[string]any{
+			"hits": st.Hits, "misses": st.Misses, "puts": st.Puts,
+			"stales": st.Stales, "errors": st.Errors,
+			"hit_rate": rate(st.Hits, st.Misses),
+		},
+		"body": map[string]any{
+			"hits": st.BodyHits, "misses": st.BodyMisses, "puts": st.BodyPuts,
+			"stales": st.BodyStales, "evictions": st.BodyEvictions,
+			"oversize": st.BodyOversize, "errors": st.BodyErrors,
+			"hit_rate": rate(st.BodyHits, st.BodyMisses),
+			"cap":      s.cfg.BodyCacheCap,
+		},
+		"embed": map[string]any{
+			"hits": st.EmbedHits, "misses": st.EmbedMisses, "puts": st.EmbedPuts,
+			"errors": st.EmbedErrors, "model_mismatches": st.EmbedModelMismatches,
+			"hit_rate": rate(st.EmbedHits, st.EmbedMisses),
+		},
+	})
+}
+
+// rate returns the hit ratio (0..1) for a hits/misses pair, or 0 when
+// there's been no traffic.
+func rate(hits, misses uint64) float64 {
+	total := hits + misses
+	if total == 0 {
+		return 0
+	}
+	return float64(hits) / float64(total)
+}
+
+// --- /api/activity ---
+
+func (s *Server) handleActivity(w http.ResponseWriter, _ *http.Request) {
+	if s.cfg.Collector == nil {
+		writeJSON(w, map[string]any{
+			"available": false,
+			"reason":    "no MCP activity in this mode",
+		})
+		return
+	}
+	snap := s.cfg.Collector.Snapshot()
+	writeJSON(w, map[string]any{
+		"available": true,
+		"snapshot":  snap,
+	})
+}
+
+// --- /api/capabilities ---
+
+func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
+	// Content types grouped by family (prefix before the first "/").
+	families := map[string][]string{}
+	total := 0
+	for _, ct := range content.DefaultRegistry().Types() {
+		name := ct.Name()
+		total++
+		fam := name
+		if before, _, ok := strings.Cut(name, "/"); ok {
+			fam = before
+		}
+		families[fam] = append(families[fam], name)
+	}
+	famList := make([]map[string]any, 0, len(families))
+	for fam, names := range families {
+		sort.Strings(names)
+		famList = append(famList, map[string]any{"family": fam, "count": len(names), "types": names})
+	}
+	sort.Slice(famList, func(i, j int) bool { return famList[i]["family"].(string) < famList[j]["family"].(string) })
+
+	// Project types.
+	projects := make([]map[string]string, 0)
+	for _, pt := range projecttype.DefaultRegistry().Types() {
+		projects = append(projects, map[string]string{"name": pt.Name, "description": pt.Description})
+	}
+
+	// OCR providers.
+	var ocrProvider string
+	if p := ocr.Default(); p != nil {
+		ocrProvider = p.Name()
+	}
+
+	writeJSON(w, map[string]any{
+		"content_types": map[string]any{"total": total, "families": famList},
+		"project_types": projects,
+		"ocr": map[string]any{
+			"available":       ocr.HasProvider(),
+			"active_provider": ocrProvider,
+			"registered":      ocr.ListProviders(),
+		},
+		"embedder": map[string]any{
+			"server":    s.cfg.EmbedServer,
+			"model":     s.cfg.EmbedModel,
+			"reachable": s.embedderReachable(r.Context()),
+		},
+	})
+}
+
+// embedderReachable does a short, best-effort GET against the Ollama
+// server's tag-list endpoint. Returns false on any error / timeout so a
+// down embedding server never hangs the dashboard.
+func (s *Server) embedderReachable(ctx context.Context) bool {
+	if s.cfg.EmbedServer == "" {
+		return false
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, 1500*time.Millisecond)
+	defer cancel()
+	url := strings.TrimRight(s.cfg.EmbedServer, "/") + "/api/tags"
+	req, err := http.NewRequestWithContext(pingCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode < 500
+}
+
+// --- /healthz ---
+
+func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, map[string]any{
+		"status":         "ok",
+		"uptime_seconds": time.Since(s.startedAt).Seconds(),
+		"index_open":     s.cfg.Index != nil,
+	})
+}

--- a/internal/monitor/server_test.go
+++ b/internal/monitor/server_test.go
@@ -1,0 +1,122 @@
+package monitor
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+)
+
+func newTestServer(coll *Collector) *Server {
+	return NewServer(Config{
+		Version:     "test-1.2.3",
+		Mode:        "mcp-stdio",
+		Index:       index.NewMemory(),
+		Collector:   coll,
+		EmbedServer: "http://localhost:1", // unreachable → reachable:false fast
+		EmbedModel:  "nomic-embed-text",
+	})
+}
+
+func decode(t *testing.T, h http.HandlerFunc, path string) map[string]any {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s status = %d", path, rec.Code)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("%s decode: %v", path, err)
+	}
+	return out
+}
+
+func TestServer_Overview(t *testing.T) {
+	s := newTestServer(nil)
+	o := decode(t, s.handleOverview, "/api/overview")
+	if o["version"] != "test-1.2.3" {
+		t.Errorf("version = %v", o["version"])
+	}
+	if o["mode"] != "mcp-stdio" {
+		t.Errorf("mode = %v", o["mode"])
+	}
+	if o["index_backing"] != "in-memory" {
+		t.Errorf("index_backing = %v", o["index_backing"])
+	}
+}
+
+func TestServer_Cache(t *testing.T) {
+	s := newTestServer(nil)
+	c := decode(t, s.handleCache, "/api/cache")
+	if c["available"] != true {
+		t.Fatalf("cache available = %v", c["available"])
+	}
+	if _, ok := c["attr"].(map[string]any); !ok {
+		t.Errorf("missing attr block")
+	}
+	if _, ok := c["body"].(map[string]any); !ok {
+		t.Errorf("missing body block")
+	}
+}
+
+func TestServer_Activity(t *testing.T) {
+	// nil collector → unavailable.
+	if d := decode(t, newTestServer(nil).handleActivity, "/api/activity"); d["available"] != false {
+		t.Errorf("nil-collector activity available = %v, want false", d["available"])
+	}
+	// with collector → available, reflects a recorded call.
+	coll := NewCollector()
+	coll.Record("search", 5*time.Millisecond, OutcomeOK, "", 3)
+	d := decode(t, newTestServer(coll).handleActivity, "/api/activity")
+	if d["available"] != true {
+		t.Fatalf("activity available = %v", d["available"])
+	}
+	snap := d["snapshot"].(map[string]any)
+	if snap["total_calls"].(float64) != 1 {
+		t.Errorf("total_calls = %v, want 1", snap["total_calls"])
+	}
+}
+
+func TestServer_Capabilities(t *testing.T) {
+	s := newTestServer(nil)
+	c := decode(t, s.handleCapabilities, "/api/capabilities")
+	ct := c["content_types"].(map[string]any)
+	if ct["total"].(float64) < 50 {
+		t.Errorf("content_types total = %v, want many", ct["total"])
+	}
+	if len(c["project_types"].([]any)) < 10 {
+		t.Errorf("project_types too few")
+	}
+	emb := c["embedder"].(map[string]any)
+	if emb["reachable"] != false {
+		t.Errorf("unreachable embedder should report reachable:false, got %v", emb["reachable"])
+	}
+}
+
+func TestServer_Healthz(t *testing.T) {
+	s := newTestServer(nil)
+	h := decode(t, s.handleHealthz, "/healthz")
+	if h["status"] != "ok" || h["index_open"] != true {
+		t.Errorf("healthz = %+v", h)
+	}
+}
+
+func TestForceLoopback(t *testing.T) {
+	cases := map[string]string{
+		":9090":           "127.0.0.1:9090",
+		"9090":            "127.0.0.1:9090",
+		"0.0.0.0:9090":    "127.0.0.1:9090", // non-loopback host forced to loopback
+		"127.0.0.1:9090":  "127.0.0.1:9090",
+		"localhost:9090":  "127.0.0.1:9090",
+		"192.168.1.5:443": "127.0.0.1:443",
+	}
+	for in, want := range cases {
+		if got := forceLoopback(in); got != want {
+			t.Errorf("forceLoopback(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/monitor/static/app.js
+++ b/internal/monitor/static/app.js
@@ -1,0 +1,172 @@
+"use strict";
+
+// Client-side history buffers for the three cache hit-rate sparklines.
+const HISTORY = 60;
+const hist = { attr: [], body: [], embed: [] };
+
+function $(id) { return document.getElementById(id); }
+function pct(x) { return (x * 100).toFixed(1) + "%"; }
+function secs(x) { return x < 1 ? (x * 1000).toFixed(0) + "ms" : x.toFixed(2) + "s"; }
+
+function dur(seconds) {
+  const s = Math.floor(seconds);
+  const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), sec = s % 60;
+  if (h) return `${h}h ${m}m`;
+  if (m) return `${m}m ${sec}s`;
+  return `${sec}s`;
+}
+
+function bytes(n) {
+  if (!n) return "—";
+  const u = ["B", "KiB", "MiB", "GiB"];
+  let i = 0, v = n;
+  while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
+  return v.toFixed(i ? 1 : 0) + " " + u[i];
+}
+
+async function getJSON(path) {
+  const r = await fetch(path, { cache: "no-store" });
+  if (!r.ok) throw new Error(path + " " + r.status);
+  return r.json();
+}
+
+// sparkline builds an inline SVG polyline from values in [0,1].
+function sparkline(values, w = 200, h = 28) {
+  if (!values.length) return "";
+  const step = w / Math.max(values.length - 1, 1);
+  const pts = values.map((v, i) => `${(i * step).toFixed(1)},${(h - v * h).toFixed(1)}`).join(" ");
+  return `<svg class="spark" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none">
+    <polyline fill="none" stroke="var(--accent)" stroke-width="1.5" points="${pts}"/></svg>`;
+}
+
+function kv(k, v) { return `<div class="kv"><div class="k">${k}</div><div class="v">${v}</div></div>`; }
+
+function renderOverview(o) {
+  $("hdr-version").textContent = o.version || "";
+  $("hdr-mode").textContent = o.mode || "";
+  $("hdr-uptime").textContent = "up " + dur(o.uptime_seconds || 0);
+  $("overview").innerHTML = [
+    kv("Mode", o.mode),
+    kv("Uptime", dur(o.uptime_seconds || 0)),
+    kv("Index", o.index_backing),
+    kv("Body cache cap", o.body_cache_cap ? bytes(o.body_cache_cap) : "in-memory"),
+    kv("Workers (default)", o.num_cpu),
+    kv("GOMAXPROCS", o.gomaxprocs),
+    kv("Goroutines", o.goroutines),
+    kv("Go", o.go_version),
+    kv("PID", o.pid),
+  ].join("");
+}
+
+function cacheCard(title, c, key) {
+  hist[key].push(c.hit_rate || 0);
+  if (hist[key].length > HISTORY) hist[key].shift();
+  const warn = (n) => n ? '<span class="num warn">' + n + "</span>" : '<span class="num">0</span>';
+  let rows = `
+    <div class="lbl">hits</div><div class="num">${c.hits}</div>
+    <div class="lbl">misses</div><div class="num">${c.misses}</div>
+    <div class="lbl">puts</div><div class="num">${c.puts}</div>`;
+  if ("stales" in c) rows += `<div class="lbl">stales</div><div class="num">${c.stales}</div>`;
+  if ("evictions" in c) rows += `<div class="lbl">evictions</div>${warn(c.evictions)}`;
+  if ("oversize" in c) rows += `<div class="lbl">oversize</div>${warn(c.oversize)}`;
+  if ("model_mismatches" in c) rows += `<div class="lbl">model mismatch</div>${warn(c.model_mismatches)}`;
+  if ("errors" in c) rows += `<div class="lbl">errors</div>${warn(c.errors)}`;
+  return `<div class="cache-card">
+    <div class="title"><span>${title}</span><span class="hr">${pct(c.hit_rate || 0)}</span></div>
+    <div class="counters">${rows}</div>
+    ${sparkline(hist[key])}
+  </div>`;
+}
+
+function renderCache(d) {
+  if (!d.available) { $("cache").innerHTML = '<div class="empty">No index attached.</div>'; return; }
+  $("cache").innerHTML =
+    cacheCard("Attributes", d.attr, "attr") +
+    cacheCard("Body", d.body, "body") +
+    cacheCard("Embeddings", d.embed, "embed");
+}
+
+function renderActivity(d) {
+  if (!d.available) {
+    $("inflight").textContent = "";
+    $("activity-tools").innerHTML = `<div class="empty">${d.reason || "no activity"}</div>`;
+    $("activity-recent").innerHTML = "";
+    return;
+  }
+  const s = d.snapshot;
+  $("inflight").textContent = `${s.in_flight} in-flight · ${s.total_calls} calls · ${s.total_errors} errors`;
+
+  const tools = s.tools || [];
+  if (!tools.length) {
+    $("activity-tools").innerHTML = '<div class="empty">No tool calls yet.</div>';
+  } else {
+    let t = `<table><thead><tr><th>Tool</th><th class="num">calls</th><th class="num">err</th>
+      <th class="num">cancel</th><th class="num">p50</th><th class="num">p95</th><th class="num">max</th></tr></thead><tbody>`;
+    for (const x of tools) {
+      t += `<tr><td>${x.tool}</td><td class="num">${x.count}</td><td class="num">${x.errors}</td>
+        <td class="num">${x.cancels}</td><td class="num">${secs(x.p50_seconds)}</td>
+        <td class="num">${secs(x.p95_seconds)}</td><td class="num">${secs(x.max_seconds)}</td></tr>`;
+    }
+    $("activity-tools").innerHTML = t + "</tbody></table>";
+  }
+
+  const recent = s.recent || [];
+  if (!recent.length) { $("activity-recent").innerHTML = '<div class="empty">—</div>'; return; }
+  $("activity-recent").innerHTML = recent.map((r) => {
+    const when = new Date(r.at).toLocaleTimeString();
+    const detail = r.outcome === "cancelled" && r.reason ? ` (${r.reason})` : "";
+    const cnt = r.count ? ` · ${r.count} results` : "";
+    return `<div class="row"><span class="when">${when}</span><span class="tool">${r.tool}</span>
+      <span class="out-${r.outcome}">${r.outcome}${detail}</span><span>${secs(r.seconds)}${cnt}</span></div>`;
+  }).join("");
+}
+
+function renderCapabilities(d) {
+  const ct = d.content_types || { total: 0, families: [] };
+  const fams = (ct.families || []).map((f) =>
+    `<span class="chip" title="${(f.types || []).join(", ")}">${f.family} · ${f.count}</span>`).join("");
+  const projects = (d.project_types || []).map((p) =>
+    `<span class="chip" title="${p.description || ""}">${p.name}</span>`).join("");
+  const ocr = d.ocr || {};
+  const ocrLine = ocr.available
+    ? `<span class="pill pill-ok">${ocr.active_provider}</span>`
+    : `<span class="pill pill-unknown">none (registered: ${(ocr.registered || []).join(", ") || "—"})</span>`;
+  const emb = d.embedder || {};
+  const embLine = emb.reachable
+    ? `<span class="pill pill-ok">reachable</span>`
+    : `<span class="pill pill-unknown">unreachable</span>`;
+
+  $("capabilities").innerHTML = `<div class="caps-grid">
+    <div><h3 class="sub">Content types (${ct.total})</h3>${fams || '<div class="empty">—</div>'}</div>
+    <div><h3 class="sub">Project types (${(d.project_types || []).length})</h3>${projects || '<div class="empty">—</div>'}</div>
+    <div><h3 class="sub">OCR</h3>${ocrLine}</div>
+    <div><h3 class="sub">Embedder</h3>
+      <div>${embLine} <span class="muted">${emb.model || "no model"} @ ${emb.server || "—"}</span></div>
+    </div>
+  </div>`;
+}
+
+function setHealth(ok) {
+  const el = $("health");
+  el.textContent = ok ? "healthy" : "unreachable";
+  el.className = "pill " + (ok ? "pill-ok" : "pill-err");
+}
+
+async function tick() {
+  try {
+    const [o, c, a, caps] = await Promise.all([
+      getJSON("api/overview"), getJSON("api/cache"),
+      getJSON("api/activity"), getJSON("api/capabilities"),
+    ]);
+    renderOverview(o);
+    renderCache(c);
+    renderActivity(a);
+    renderCapabilities(caps);
+    setHealth(true);
+  } catch (e) {
+    setHealth(false);
+  }
+}
+
+tick();
+setInterval(tick, 2000);

--- a/internal/monitor/static/index.html
+++ b/internal/monitor/static/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>file-search-on · monitor</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>file-search-on <span class="muted">monitor</span></h1>
+    <div class="hdr-meta">
+      <span id="health" class="pill pill-unknown">connecting…</span>
+      <span id="hdr-version" class="muted"></span>
+      <span id="hdr-mode" class="tag"></span>
+      <span id="hdr-uptime" class="muted"></span>
+    </div>
+  </header>
+
+  <main>
+    <section class="panel">
+      <h2>Overview</h2>
+      <div id="overview" class="kv-grid"></div>
+    </section>
+
+    <section class="panel">
+      <h2>Cache</h2>
+      <div id="cache" class="cache-grid"></div>
+    </section>
+
+    <section class="panel">
+      <h2>Activity <span id="inflight" class="badge"></span></h2>
+      <div id="activity-tools"></div>
+      <h3 class="sub">Recent calls</h3>
+      <div id="activity-recent" class="feed"></div>
+    </section>
+
+    <section class="panel">
+      <h2>Capabilities</h2>
+      <div id="capabilities"></div>
+    </section>
+  </main>
+
+  <footer class="muted">polling every 2s · localhost only · read-only</footer>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/internal/monitor/static/style.css
+++ b/internal/monitor/static/style.css
@@ -1,0 +1,72 @@
+:root {
+  --bg: #0f1419;
+  --panel: #1a2029;
+  --card: #232b36;
+  --fg: #d8dee9;
+  --muted: #7b8794;
+  --accent: #5cc8ff;
+  --ok: #46c93a;
+  --warn: #e6b450;
+  --err: #ff5370;
+  --line: #2c3440;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+header {
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 8px;
+  padding: 14px 20px; border-bottom: 1px solid var(--line); background: var(--panel);
+}
+h1 { font-size: 18px; margin: 0; font-weight: 600; }
+h2 { font-size: 14px; margin: 0 0 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+h3.sub { font-size: 12px; margin: 16px 0 8px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; }
+.muted { color: var(--muted); font-size: 12px; }
+.hdr-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+main { padding: 20px; display: grid; gap: 16px; grid-template-columns: 1fr 1fr; }
+.panel { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 16px; }
+.panel:nth-child(3), .panel:nth-child(4) { grid-column: 1 / -1; }
+footer { padding: 12px 20px; text-align: center; }
+
+.pill { padding: 2px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+.pill-ok { background: rgba(70,201,58,.18); color: var(--ok); }
+.pill-err { background: rgba(255,83,112,.18); color: var(--err); }
+.pill-unknown { background: rgba(123,135,148,.18); color: var(--muted); }
+.tag { background: var(--card); padding: 2px 8px; border-radius: 4px; font-size: 12px; }
+.badge { background: var(--card); padding: 1px 8px; border-radius: 999px; font-size: 12px; color: var(--accent); }
+
+.kv-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 10px; }
+.kv { background: var(--card); border-radius: 6px; padding: 8px 10px; }
+.kv .k { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
+.kv .v { font-size: 15px; font-weight: 600; margin-top: 2px; word-break: break-all; }
+
+.cache-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+.cache-card { background: var(--card); border-radius: 6px; padding: 12px; }
+.cache-card .title { font-weight: 600; margin-bottom: 8px; display: flex; justify-content: space-between; align-items: baseline; }
+.cache-card .hr { font-size: 20px; font-weight: 700; color: var(--accent); }
+.counters { display: grid; grid-template-columns: 1fr 1fr; gap: 4px 12px; font-size: 12px; }
+.counters .lbl { color: var(--muted); }
+.counters .num { text-align: right; font-variant-numeric: tabular-nums; }
+.counters .num.warn { color: var(--warn); }
+.spark { margin-top: 8px; }
+
+table { width: 100%; border-collapse: collapse; font-size: 13px; }
+th, td { text-align: left; padding: 5px 8px; border-bottom: 1px solid var(--line); }
+th { color: var(--muted); font-weight: 500; font-size: 11px; text-transform: uppercase; }
+td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+.feed { max-height: 280px; overflow-y: auto; }
+.feed .row { display: grid; grid-template-columns: 70px 1fr auto auto; gap: 10px; align-items: center;
+  padding: 4px 0; border-bottom: 1px solid var(--line); font-size: 12px; }
+.feed .tool { font-weight: 600; }
+.feed .when { color: var(--muted); }
+.out-ok { color: var(--ok); } .out-error { color: var(--err); } .out-cancelled { color: var(--warn); }
+
+.caps-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.chip { display: inline-block; background: var(--card); border-radius: 4px; padding: 2px 8px; margin: 2px; font-size: 12px; }
+.empty { color: var(--muted); font-style: italic; padding: 8px 0; }
+@media (max-width: 760px) { main, .caps-grid { grid-template-columns: 1fr; } }


### PR DESCRIPTION
Implements the [approved monitoring proposal](https://github.com/richardwooding/file-search-on) — a read-only web dashboard for observing internal state while a long-running mode is active.

## What it does
`--monitor-addr :9090` on `mcp` or `watch` starts a localhost-only dashboard at `http://localhost:9090/`:

```sh
file-search-on mcp --monitor-addr :9090                    # stdio MCP + dashboard
file-search-on mcp --transport http --addr :8080 --monitor-addr :9090
file-search-on watch 'is_image' -d ~/Screenshots --monitor-addr :9090
```

**Four panels:** Overview (version/uptime/mode/runtime/index backing), Cache (attr/body/embed hit-rates + sparklines, evictions/oversize/model-mismatch flags), Activity (live MCP tool-call feed, per-tool p50/p95/max latency, in-flight gauge), Capabilities (content types by family, project types, OCR, embedder + reachability).

## Design (per the approved plan)
- **Off by default; localhost-only.** Binds `127.0.0.1` — the host part of `--monitor-addr` is ignored (only the port). The activity feed can surface searched paths, so it never binds a routable interface.
- **Zero new dependencies.** UI is a single `embed.FS` page + vanilla JS polling a JSON API every 2s + inline SVG sparklines. No web framework, no build step.
- **New `internal/monitor` package**: `Collector` (concurrency-safe per-tool telemetry + ring buffer + in-flight gauge) and `Server` (localhost http.Server with graceful shutdown, `/api/{overview,cache,activity,capabilities}` + `/healthz`).
- **mcpserver instrumentation**: optional `WithCollector` option (nil-safe — existing `New(...)` call sites and the no-monitor path are untouched) + a generic `instrument[In,Out]` wrapper at the 19 tool registrations. Outputs with `Count`/`Cancelled` implement an optional `callReporter` so the feed shows result counts + cancellations.

**Deferred** (noted in the proposal): Prometheus `/metrics`, dedicated watch-mode panel, SSE push, non-loopback bind + token auth.

## Test plan
- [x] `internal/monitor` — collector concurrency (`-race`), percentiles, recent-cap/in-flight, and all server endpoints via `httptest` incl. `forceLoopback` (loopback enforcement).
- [x] `internal/mcpserver/instrument_test.go` — a real `search` call through the in-memory transport records on the collector (count via `callReporter`, outcome=ok).
- [x] Existing mcpserver suite passes unchanged (nil collector = pass-through).
- [x] `go vet`, `go fix` (idempotent), `golangci-lint` (0 issues), full `go test -race ./...`; cross-compiles linux + windows.
- [x] **Manual end-to-end**: dashboard + all 4 APIs + `/healthz` + `app.js` serve; `/api/capabilities` reports 129 content types / 18 project types / OCR; confirmed reachable on `127.0.0.1:<port>` but **refused on the LAN IP**; watch mode shows the "no MCP activity" notice; clean graceful shutdown on Ctrl-C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)