### PR TITLE
feat(monitor): dynamic-port dashboards + monitor_info tool + peer discovery/switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,22 +445,30 @@ Built on [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcont
 
 ## Monitoring dashboard
 
-Both long-running modes (`mcp` and `watch`) can expose a read-only monitoring dashboard with `--monitor-addr`. It's off by default, binds **127.0.0.1 only** (the host part of the address is ignored — only the port is used), needs no auth, and adds no dependencies — the UI is a single embedded page that polls a small JSON API.
+Both long-running modes (`mcp` and `watch`) can expose a read-only monitoring dashboard. It's off by default, binds **127.0.0.1 only** (the host part of any address is ignored — only the port is used), needs no auth, and adds no dependencies — the UI is a single embedded page that polls a small JSON API.
 
 ```sh
-file-search-on mcp --monitor-addr :9090                       # stdio MCP + dashboard
-file-search-on mcp --transport http --addr :8080 --monitor-addr :9090
-file-search-on watch 'is_image' -d ~/Screenshots --monitor-addr :9090
+file-search-on mcp --monitor                                  # dynamic OS-assigned port (no collisions)
+file-search-on mcp --monitor-addr :9090                       # pin a fixed port
+file-search-on mcp --transport http --addr :8080 --monitor
+file-search-on watch 'is_image' -d ~/Screenshots --monitor
 ```
 
-Open `http://localhost:9090/`. Four panels:
+`--monitor` picks a free localhost port (so **many concurrent stdio agents** each get their own dashboard without colliding); `--monitor-addr :PORT` pins a fixed one. Find the URL in the stderr log line, or — for an `mcp` server — ask it via the **`monitor_info` MCP tool**, which also reports sibling instances.
+
+Open the URL. Five panels:
 
 - **Overview** — version, uptime, run mode, PID / Go version / GOMAXPROCS, default worker count, index backing (path or in-memory), body-cache cap.
 - **Cache** — the attribute / body / embedding cache counters as live cards with derived **hit-rate %** and sparklines; body evictions / oversize rejects / embed model-mismatches flagged.
 - **Activity** — live MCP tool-call feed (tool, elapsed, outcome, result count), per-tool call / error / cancel counts and p50 / p95 / max latency, and an in-flight gauge. (Watch mode has no MCP calls, so this panel shows a notice.)
 - **Capabilities** — registered content types grouped by family, project types, OCR provider availability, embedder model / server + a reachability check.
+- **Peer switcher** — when more than one instance is running, a header dropdown lists every sibling dashboard (mode · working dir · port) and switches to it. Instances discover each other through a shared registry under the user cache dir; crashed instances self-prune.
 
-The JSON API is scriptable too: `curl -s localhost:9090/api/cache | jq`, plus `/api/overview`, `/api/activity`, `/api/capabilities`, and `/healthz` (liveness). See [examples/monitoring.md](./examples/monitoring.md).
+### Multiple concurrent instances
+
+Each instance with a dashboard registers itself, so they're mutually discoverable. For `mcp` servers, the **`monitor_info`** tool is the entry point: it returns this server's dashboard URL + the peer list, and `monitor_info{enable:true}` **starts the dashboard on demand** (a dynamic port) even if the server was launched without a monitor flag. That makes monitoring reachable per-agent without editing every launch config.
+
+The JSON API is scriptable too: `curl -s localhost:<port>/api/cache | jq`, plus `/api/overview`, `/api/activity`, `/api/capabilities`, `/api/peers`, and `/healthz` (liveness). See [examples/monitoring.md](./examples/monitoring.md).
 
 ## Contributing
 

--- a/cmd/file-search-on/mcp_cmd.go
+++ b/cmd/file-search-on/mcp_cmd.go
@@ -21,7 +21,8 @@ type MCPCmd struct {
 	EmbeddingServer   string        `name:"embedding-server" default:"http://localhost:11434" help:"Default Ollama base URL for the search_semantic tool. Per-call 'embedding_server' input overrides. Lazy connect — server starts without Ollama running; search_semantic fails clearly on first call if Ollama is unreachable."`
 	EmbeddingModel    string        `name:"embedding-model" help:"Default Ollama embedding model for the search_semantic tool (e.g. nomic-embed-text, mxbai-embed-large). No default — pick a model you've pulled via 'ollama pull <name>'. Per-call 'model' input overrides. If neither is set, search_semantic returns 'no embedding model configured'."`
 	Timeout           time.Duration `name:"timeout" default:"60s" help:"Default per-tool-call timeout (Go duration: 30s, 2m, 5m). Each search/read_attributes invocation is wrapped with this deadline. Per-call 'timeout_seconds' input on the search tool overrides this. Set to 0 to disable the default (not recommended — long-running calls can exceed MCP client read deadlines)."`
-	MonitorAddr       string        `name:"monitor-addr" help:"Enable the read-only monitoring dashboard on this port (e.g. ':9090'). Binds 127.0.0.1 only — the host part is ignored. Off when empty. Shows index cache stats, live tool-call activity, and registered capabilities at http://localhost:<port>/."`
+	Monitor           bool          `name:"monitor" help:"Enable the read-only monitoring dashboard on an OS-assigned localhost port (no collision when many stdio servers run concurrently). Discover the URL via the monitor_info MCP tool or the stderr log line. Use --monitor-addr to pin a fixed port instead. Even without either flag, the dashboard can be started later via monitor_info{enable:true}."`
+	MonitorAddr       string        `name:"monitor-addr" help:"Enable the monitoring dashboard on this fixed port (e.g. ':9090'). Binds 127.0.0.1 only. Overrides --monitor. Shows index cache stats, live tool-call activity, capabilities, and a peer switcher at http://localhost:<port>/."`
 }
 
 func (m *MCPCmd) Run(ctx context.Context) error {
@@ -36,37 +37,55 @@ func (m *MCPCmd) Run(ctx context.Context) error {
 		Model:  m.EmbeddingModel,
 	}
 
-	// Optional monitoring dashboard. When enabled, attach a collector so
-	// tool calls are recorded, and run the dashboard concurrently under
-	// the same ctx. The deferred wait runs BEFORE idx.Close() (LIFO) so
-	// the dashboard drains before the index is released.
-	var mcpOpts []mcpserver.Option
-	if m.MonitorAddr != "" {
-		collector := monitor.NewCollector()
-		mcpOpts = append(mcpOpts, mcpserver.WithCollector(collector))
+	// Derive a cancellable child of the signal context so the dashboard
+	// shuts down (and deregisters) when this command returns for ANY
+	// reason — including stdio-transport EOF (client disconnect), which
+	// does not cancel the parent signal context. The cancel defer is
+	// registered AFTER controller.Wait() below so, by LIFO, the order on
+	// return is: cancel() → Wait() (drains the dashboard) → idx.Close().
+	ctx, cancelMonitor := context.WithCancel(ctx)
 
-		bodyCap := int64(0)
-		if m.IndexPath != "" && !m.NoBodyCache {
-			bodyCap = int64(m.BodyCacheMaxBytes)
+	// The monitoring dashboard is always *wireable* in MCP mode: we
+	// build a collector (so tool-call history exists if the dashboard is
+	// started later) and a controller (which owns the dashboard's lazy
+	// lifecycle). The controller binds nothing until started — either
+	// eagerly here when --monitor / --monitor-addr is set, or on demand
+	// via the monitor_info MCP tool.
+	collector := monitor.NewCollector()
+	bodyCap := int64(0)
+	if m.IndexPath != "" && !m.NoBodyCache {
+		bodyCap = int64(m.BodyCacheMaxBytes)
+	}
+	monAddr := m.MonitorAddr // fixed port wins
+	if monAddr == "" && m.Monitor {
+		monAddr = ":0" // dynamic, OS-assigned
+	}
+	controller := monitor.NewController(ctx, monitor.Config{
+		Version:      version,
+		Mode:         "mcp-" + m.Transport,
+		Index:        idx,
+		Collector:    collector,
+		EmbedServer:  m.EmbeddingServer,
+		EmbedModel:   m.EmbeddingModel,
+		IndexPath:    m.IndexPath,
+		BodyCacheCap: bodyCap,
+	}, addrOrDynamic(monAddr))
+	// Drain the dashboard (and deregister from the peer registry) before
+	// the index closes. Registered before cancelMonitor so, by LIFO,
+	// cancelMonitor() runs first (triggering shutdown), then Wait()
+	// blocks until the dashboard goroutine exits, then idx.Close() runs.
+	defer controller.Wait()
+	defer cancelMonitor()
+
+	if monAddr != "" {
+		if _, err := controller.EnsureStarted(); err != nil {
+			fmt.Fprintln(os.Stderr, "monitor:", err)
 		}
-		mon := monitor.NewServer(monitor.Config{
-			Version:      version,
-			Mode:         "mcp-" + m.Transport,
-			Index:        idx,
-			Collector:    collector,
-			EmbedServer:  m.EmbeddingServer,
-			EmbedModel:   m.EmbeddingModel,
-			IndexPath:    m.IndexPath,
-			BodyCacheCap: bodyCap,
-		})
-		monDone := make(chan struct{})
-		go func() {
-			defer close(monDone)
-			if err := mon.Run(ctx, m.MonitorAddr); err != nil {
-				fmt.Fprintln(os.Stderr, "monitor:", err)
-			}
-		}()
-		defer func() { <-monDone }()
+	}
+
+	mcpOpts := []mcpserver.Option{
+		mcpserver.WithCollector(collector),
+		mcpserver.WithMonitor(controller),
 	}
 
 	switch m.Transport {
@@ -78,4 +97,13 @@ func (m *MCPCmd) Run(ctx context.Context) error {
 	default:
 		return mcpserver.Run(ctx, version, idx, m.Timeout, embedDefaults, mcpOpts...)
 	}
+}
+
+// addrOrDynamic maps an empty monitor address to ":0" so the controller
+// always has a bind target if started on demand (monitor_info{enable:true}).
+func addrOrDynamic(addr string) string {
+	if addr == "" {
+		return ":0"
+	}
+	return addr
 }

--- a/cmd/file-search-on/watch_cmd.go
+++ b/cmd/file-search-on/watch_cmd.go
@@ -34,7 +34,8 @@ type WatchCmd struct {
 	WithHashes       bool          `name:"with-hashes" help:"Compute md5 / sha1 / sha256 for each matched file."`
 	WithPHash        bool          `name:"with-phash" help:"Compute the perceptual hash (phash) of each new image."`
 	WithXattrs       bool          `name:"with-xattrs" help:"Read macOS extended attributes for each new file (Darwin only)."`
-	MonitorAddr      string        `name:"monitor-addr" help:"Enable the read-only monitoring dashboard on this port (e.g. ':9090'). Binds 127.0.0.1 only. Off when empty. Shows index cache stats + registered capabilities at http://localhost:<port>/ (no MCP activity panel in watch mode)."`
+	Monitor          bool          `name:"monitor" help:"Enable the read-only monitoring dashboard on an OS-assigned localhost port (no collision when many instances run concurrently). The URL is printed to stderr; sibling instances appear in each dashboard's peer switcher. Use --monitor-addr to pin a fixed port. (Watch mode has no MCP tools, so the dashboard can only be enabled at launch, not on demand.)"`
+	MonitorAddr      string        `name:"monitor-addr" help:"Enable the monitoring dashboard on this fixed port (e.g. ':9090'). Binds 127.0.0.1 only. Overrides --monitor. Shows index cache stats + capabilities + a peer switcher at http://localhost:<port>/ (no MCP activity panel in watch mode)."`
 }
 
 func (c *WatchCmd) Run(ctx context.Context) error {
@@ -94,7 +95,11 @@ func (c *WatchCmd) Run(ctx context.Context) error {
 	// so no collector is attached — the dashboard shows cache stats +
 	// capabilities only. Runs concurrently under the same ctx; the
 	// deferred wait runs before idx.Close() (LIFO).
-	if c.MonitorAddr != "" {
+	monAddr := c.MonitorAddr // fixed port wins
+	if monAddr == "" && c.Monitor {
+		monAddr = ":0" // dynamic, OS-assigned
+	}
+	if monAddr != "" {
 		mon := monitor.NewServer(monitor.Config{
 			Version:   version,
 			Mode:      "watch",
@@ -104,7 +109,7 @@ func (c *WatchCmd) Run(ctx context.Context) error {
 		monDone := make(chan struct{})
 		go func() {
 			defer close(monDone)
-			if err := mon.Run(ctx, c.MonitorAddr); err != nil {
+			if err := mon.Run(ctx, monAddr); err != nil {
 				fmt.Fprintln(os.Stderr, "monitor:", err)
 			}
 		}()

--- a/examples/monitoring.md
+++ b/examples/monitoring.md
@@ -2,20 +2,23 @@
 
 The long-running modes — the `mcp` server and the `watch` command — can serve a small **read-only** monitoring dashboard so you can watch file-search-on's internal state while it runs: is the cache working, what is the agent doing right now, is OCR / embedding available.
 
-Enable it with `--monitor-addr`. It's **off by default**, binds **127.0.0.1 only** (the host part of the address is ignored — only the port matters), has **no auth**, and adds **no dependencies** (the UI is a single embedded page polling a JSON API).
+It's **off by default**, binds **127.0.0.1 only** (the host part of any address is ignored — only the port matters), has **no auth**, and adds **no dependencies** (the UI is a single embedded page polling a JSON API).
 
 ```sh
-# stdio MCP server (the common agent setup) + dashboard
+# stdio MCP server + dashboard on a dynamic (OS-assigned) port
+file-search-on mcp --monitor
+
+# pin a fixed port instead
 file-search-on mcp --monitor-addr :9090
 
-# HTTP MCP server + dashboard on a separate port
-file-search-on mcp --transport http --addr :8080 --monitor-addr :9090
+# HTTP MCP server + dashboard
+file-search-on mcp --transport http --addr :8080 --monitor
 
 # watch mode + dashboard
-file-search-on watch 'is_image && body.contains("error")' --ocr -d ~/Desktop --monitor-addr :9090
+file-search-on watch 'is_image && body.contains("error")' --ocr -d ~/Desktop --monitor
 ```
 
-Then open **http://localhost:9090/**.
+`--monitor` picks a free localhost port; `--monitor-addr :PORT` pins one. The chosen URL is printed to stderr (`monitor dashboard: http://127.0.0.1:<port>/`) — or, for an `mcp` server, ask it via the `monitor_info` tool. Then open that URL.
 
 ## Panels
 
@@ -25,19 +28,52 @@ Then open **http://localhost:9090/**.
 | **Cache** | attribute / body / embedding cache counters with derived **hit-rate %** + sparklines; body evictions / oversize rejects and embed model-mismatches highlighted |
 | **Activity** | live MCP tool-call feed (tool, elapsed, outcome, result count), per-tool call/error/cancel counts + p50/p95/max latency, in-flight gauge |
 | **Capabilities** | registered content types grouped by family, project types, OCR provider availability, embedder model/server + reachability |
+| **Peer switcher** | header dropdown listing every other running instance's dashboard (mode · working dir · port); switch with one click. Hidden when only one instance is running |
 
 In **watch mode** there are no MCP tool calls, so the Activity panel shows a notice; Overview / Cache / Capabilities still populate.
+
+## Multiple concurrent instances
+
+Running many `file-search-on mcp` agents at once? `--monitor` gives each its own dynamic port, and every dashboard discovers the others through a shared registry under the user cache dir (`<UserCacheDir>/file-search-on/monitors/`). Crashed instances self-prune on the next read; clean shutdowns deregister immediately.
+
+The **`monitor_info`** MCP tool is the per-agent entry point:
+
+```jsonc
+// returns this server's dashboard URL + every sibling instance
+{ "name": "monitor_info" }
+
+// start this server's dashboard on a dynamic port if it wasn't
+// launched with a monitor flag (idempotent — same URL on repeat calls)
+{ "name": "monitor_info", "arguments": { "enable": true } }
+```
+
+Response shape:
+
+```json
+{
+  "enabled": true,
+  "url": "http://127.0.0.1:54211/",
+  "peers": [
+    {"pid": 97394, "url": "http://127.0.0.1:54211/", "mode": "mcp-stdio", "working_dir": "/Users/me/projA", "is_self": true},
+    {"pid": 97396, "url": "http://127.0.0.1:54218/", "mode": "mcp-stdio", "working_dir": "/Users/me/projB"}
+  ]
+}
+```
+
+So an agent that was launched **without** any monitor flag can still be observed on demand — call `monitor_info{enable:true}` and open the returned URL. From there the peers panel lets you hop between every running agent's dashboard. (Watch mode has no MCP tools, so its dashboard must be enabled at launch with `--monitor` / `--monitor-addr`.)
 
 ## JSON API (scriptable)
 
 The same data the UI renders is available as JSON — handy for scripts, smoke checks, or piping into `jq`:
 
 ```sh
-curl -s localhost:9090/api/overview      | jq          # version, uptime, mode, index backing
-curl -s localhost:9090/api/cache         | jq .attr    # attribute-cache hit rate + counters
-curl -s localhost:9090/api/activity      | jq '.snapshot.tools'   # per-tool latency
-curl -s localhost:9090/api/capabilities  | jq '.content_types.total'
-curl -s localhost:9090/healthz                          # liveness: {status, uptime_seconds, index_open}
+PORT=9090   # the dynamic port from stderr / monitor_info when using --monitor
+curl -s localhost:$PORT/api/overview      | jq          # version, uptime, mode, index backing
+curl -s localhost:$PORT/api/cache         | jq .attr    # attribute-cache hit rate + counters
+curl -s localhost:$PORT/api/activity      | jq '.snapshot.tools'   # per-tool latency
+curl -s localhost:$PORT/api/capabilities  | jq '.content_types.total'
+curl -s localhost:$PORT/api/peers         | jq '.peers' # other running instances
+curl -s localhost:$PORT/healthz                          # liveness: {status, uptime_seconds, index_open}
 ```
 
 The cache numbers match the `index_stats` MCP tool for the same running index — the dashboard is just a friendlier, pollable view of it.
@@ -46,7 +82,8 @@ The cache numbers match the `index_stats` MCP tool for the same running index �
 
 - **Loopback only.** The dashboard can surface searched file paths (in the activity feed), so it never binds a routable interface. Passing `--monitor-addr 0.0.0.0:9090` still binds `127.0.0.1:9090` (with a one-line warning). For remote/container monitoring, front it with your own authenticated proxy or an SSH tunnel.
 - **Read-only.** There are no mutation endpoints — the dashboard can't change the server's behaviour, only observe it.
-- **Negligible overhead.** Tool-call instrumentation is a timestamp + a bounded ring-buffer append per call; the cache panel reads atomic counters. With `--monitor-addr` unset there is zero instrumentation.
+- **Negligible overhead.** Tool-call instrumentation is a timestamp + a bounded ring-buffer append per call; the cache panel reads atomic counters. (In `mcp` mode the collector is always attached so the Activity panel has history if you enable the dashboard mid-session via `monitor_info` — that cost is a tiny per-call append, dwarfed by any filesystem walk.)
+- **Registry is per-user.** Peer registration files live under your user cache dir and are readable only by you; they hold the dashboard URL, mode, PID, and working directory of each running instance.
 
 ## Related
 

--- a/internal/mcpserver/monitor_info_tool.go
+++ b/internal/mcpserver/monitor_info_tool.go
@@ -1,0 +1,70 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/richardwooding/file-search-on/internal/monitor"
+)
+
+// MonitorInfoInput is the input for the `monitor_info` tool.
+type MonitorInfoInput struct {
+	// Enable, when true, starts the monitoring dashboard on a dynamic
+	// localhost port if it isn't already running, then returns its URL.
+	// Idempotent — a second call returns the same URL.
+	Enable bool `json:"enable,omitempty" jsonschema:"When true, start the monitoring dashboard on an OS-assigned localhost port if it isn't already running, and return its URL. Idempotent."`
+}
+
+// MonitorInfoOutput reports this server's monitoring dashboard state plus
+// the registry of sibling file-search-on instances that also have a
+// dashboard running, so an agent / operator can open or switch between
+// them.
+type MonitorInfoOutput struct {
+	CommonOutput
+	// Enabled is true when this server's dashboard is currently serving.
+	Enabled bool `json:"enabled"`
+	// URL is this server's dashboard URL (empty when not enabled).
+	URL string `json:"url,omitempty"`
+	// Peers is every live dashboard instance discovered via the shared
+	// registry, including this one (flagged is_self). Newest-startup
+	// last. Empty when peer discovery is unavailable.
+	Peers []monitor.Entry `json:"peers"`
+	// Note carries a human-readable hint when monitoring isn't wired at
+	// all (e.g. the server was built without a controller).
+	Note string `json:"note,omitempty"`
+}
+
+func (h *handlers) monitorInfoHandler(_ context.Context, _ *mcp.CallToolRequest, in MonitorInfoInput) (*mcp.CallToolResult, MonitorInfoOutput, error) {
+	out := MonitorInfoOutput{CommonOutput: CommonOutput{ServerVersion: h.version}}
+
+	if h.monitorCtl == nil {
+		out.Note = "monitoring is not available for this server; relaunch with --monitor (dynamic port) or --monitor-addr :PORT"
+		out.Peers = []monitor.Entry{}
+		return nil, out, nil
+	}
+
+	if in.Enable {
+		if _, err := h.monitorCtl.EnsureStarted(); err != nil {
+			return nil, MonitorInfoOutput{}, fmt.Errorf("start monitor dashboard: %w", err)
+		}
+	}
+
+	url, running := h.monitorCtl.Info()
+	out.Enabled = running
+	out.URL = url
+	out.Peers = monitor.Peers()
+	if out.Peers == nil {
+		out.Peers = []monitor.Entry{}
+	}
+	for i := range out.Peers {
+		if out.Peers[i].URL == url && url != "" {
+			out.Peers[i].IsSelf = true
+		}
+	}
+	if !running {
+		out.Note = "dashboard not started; call monitor_info with enable=true to start it on a dynamic localhost port"
+	}
+	return nil, out, nil
+}

--- a/internal/mcpserver/monitor_info_tool_test.go
+++ b/internal/mcpserver/monitor_info_tool_test.go
@@ -1,0 +1,91 @@
+package mcpserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/monitor"
+)
+
+// sessionWithMonitor builds an in-memory MCP session whose server has a
+// monitor controller attached (dynamic port).
+func sessionWithMonitor(t *testing.T, ctl *monitor.Controller) (context.Context, *mcp.ClientSession) {
+	t.Helper()
+	ctx := t.Context()
+	server := New("test", index.NewMemory(), 0, EmbedDefaults{}, WithMonitor(ctl))
+	t1, t2 := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+	return ctx, cs
+}
+
+func TestMonitorInfo_LazyEnableAndPeers(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+	t.Setenv("HOME", dir)
+	t.Setenv("LocalAppData", dir)
+
+	serveCtx := t.Context()
+	ctl := monitor.NewController(serveCtx, monitor.Config{Version: "test", Mode: "mcp-stdio", Index: index.NewMemory()}, ":0")
+	ctx, cs := sessionWithMonitor(t, ctl)
+
+	// Before enable: reports disabled, no URL, but valid response.
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "monitor_info", Arguments: MonitorInfoInput{}})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	var before MonitorInfoOutput
+	mustDecodeStructured(t, res, &before)
+	if before.Enabled {
+		t.Errorf("expected disabled before enable, got enabled=%v url=%q", before.Enabled, before.URL)
+	}
+
+	// enable=true starts the dashboard and returns its URL.
+	res, err = cs.CallTool(ctx, &mcp.CallToolParams{Name: "monitor_info", Arguments: MonitorInfoInput{Enable: true}})
+	if err != nil {
+		t.Fatalf("CallTool enable: %v", err)
+	}
+	var after MonitorInfoOutput
+	mustDecodeStructured(t, res, &after)
+	if !after.Enabled || after.URL == "" {
+		t.Fatalf("after enable: enabled=%v url=%q, want running with a URL", after.Enabled, after.URL)
+	}
+	// This instance should appear in its own peer list, flagged is_self.
+	var selfSeen bool
+	for _, p := range after.Peers {
+		if p.URL == after.URL && p.IsSelf {
+			selfSeen = true
+		}
+	}
+	if !selfSeen {
+		t.Errorf("self not found (flagged is_self) in peers: %+v", after.Peers)
+	}
+}
+
+func TestMonitorInfo_NoControllerReportsUnavailable(t *testing.T) {
+	ctx, cs := newSession(t) // built without WithMonitor
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "monitor_info", Arguments: MonitorInfoInput{}})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	var out MonitorInfoOutput
+	mustDecodeStructured(t, res, &out)
+	if out.Enabled {
+		t.Errorf("expected disabled with no controller")
+	}
+	if out.Note == "" {
+		t.Errorf("expected a note explaining monitoring is unavailable")
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -30,6 +30,11 @@ type handlers struct {
 	// metrics, when non-nil, records per-tool-call telemetry for the
 	// monitoring dashboard. nil disables instrumentation entirely.
 	metrics *monitor.Collector
+	// monitorCtl, when non-nil, owns the monitoring dashboard's lazy
+	// lifecycle so the monitor_info tool can report its URL + peers and
+	// (optionally) start it on demand. nil when monitoring isn't wired
+	// (e.g. tests, or transports that never attach it).
+	monitorCtl *monitor.Controller
 }
 
 // Option configures the MCP server at construction. Used to attach
@@ -42,6 +47,13 @@ type Option func(*handlers)
 // the dashboard can read it back.
 func WithCollector(c *monitor.Collector) Option {
 	return func(h *handlers) { h.metrics = c }
+}
+
+// WithMonitor attaches the monitoring dashboard controller so the
+// monitor_info tool can report the dashboard URL + peer instances and
+// (when asked) start the dashboard on demand.
+func WithMonitor(ctl *monitor.Controller) Option {
+	return func(h *handlers) { h.monitorCtl = ctl }
 }
 
 // resolveTimeout returns a child ctx bounded by the effective per-call
@@ -373,6 +385,11 @@ func New(version string, idx index.Index, defaultTimeout time.Duration, embedDef
 		Name:        "resolve_project_for_path",
 		Description: "Given an arbitrary file or directory path, walk up the directory chain (unbounded — terminates at the filesystem root) and return the nearest ancestor that matches a registered project type (go.mod → go, package.json → node, Cargo.toml → rust, pyproject.toml/requirements.txt/Pipfile → python, Gemfile → ruby, pom.xml → java-maven, build.gradle → java-gradle, *.csproj → dotnet, *.tf → terraform, docker-compose.yml → docker-compose; plus static-site generators hugo / jekyll / eleventy / astro / gatsby / mkdocs / docusaurus / pelican). The MIDDLE question between detect_project (single-dir, what is THIS dir?) and find_projects (recursive, what's under this tree?): given a file path, what project owns it? Returns project_root (matched directory; empty when no ancestor matches), project_types (all matching types — a Go module that also ships docker-compose.yml hits both), and the indicators that fired. Use when an agent has a path from elsewhere and needs the project context — e.g. to scope a follow-up search or decide which language-specific tool to invoke.",
 	}, instrument(h.metrics, "resolve_project_for_path", h.resolveProjectForPathHandler))
+
+	mcp.AddTool(s, &mcp.Tool{
+		Name:        "monitor_info",
+		Description: "Report this file-search-on server's monitoring-dashboard URL and the registry of sibling instances (other concurrently-running file-search-on processes that have a dashboard). Use to find the live dashboard to open, or to switch between multiple agents' dashboards. Pass enable=true to start this server's dashboard on an OS-assigned localhost port if it wasn't launched with --monitor / --monitor-addr (idempotent — returns the same URL on repeat calls). Output: enabled + url for this server, and peers[] (each with url / mode / pid / working_dir / version / started_at; the entry for this server is flagged is_self). Dashboards are localhost-only.",
+	}, instrument(h.metrics, "monitor_info", h.monitorInfoHandler))
 
 	return s
 }

--- a/internal/mcpserver/server_version_test.go
+++ b/internal/mcpserver/server_version_test.go
@@ -204,6 +204,17 @@ func TestServerVersionInResponses(t *testing.T) {
 			},
 		},
 		{
+			// No controller attached in this test server, so monitor_info
+			// reports unavailable — but still stamps ServerVersion.
+			name: "monitor_info",
+			args: MonitorInfoInput{},
+			decode: func(t *testing.T, res *mcp.CallToolResult) string {
+				var o MonitorInfoOutput
+				mustDecodeStructured(t, res, &o)
+				return o.ServerVersion
+			},
+		},
+		{
 			name: "list_presets",
 			args: ListPresetsInput{},
 			decode: func(t *testing.T, res *mcp.CallToolResult) string {

--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -1,0 +1,82 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+)
+
+// Controller owns the lazy lifecycle of a monitoring dashboard so it can
+// be started eagerly at launch (--monitor / --monitor-addr) OR on demand
+// mid-session via the monitor_info MCP tool. EnsureStarted is idempotent
+// and concurrency-safe; once started, the dashboard runs under the
+// serveCtx captured at construction (the command's signal context), so
+// it outlives the per-tool-call context that may have triggered it.
+type Controller struct {
+	serveCtx context.Context
+	cfg      Config
+	addr     string
+
+	mu      sync.Mutex
+	started bool
+	url     string
+	done    chan struct{} // closed when the serve goroutine exits; nil until started
+}
+
+// NewController returns a controller that serves cfg's dashboard on addr
+// (":0" for an OS-assigned port) when first started. serveCtx MUST be the
+// long-lived command context, never a request context — a lazily-started
+// dashboard keeps serving after the tool call that started it returns.
+func NewController(serveCtx context.Context, cfg Config, addr string) *Controller {
+	return &Controller{serveCtx: serveCtx, cfg: cfg, addr: addr}
+}
+
+// EnsureStarted binds + serves the dashboard on first success and returns
+// its URL. Subsequent calls return the same URL without rebinding. A
+// failed bind is NOT cached, so a later call can retry (e.g. after a
+// port frees up).
+func (c *Controller) EnsureStarted() (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.started {
+		return c.url, nil
+	}
+	srv := NewServer(c.cfg)
+	url, err := srv.Listen(c.addr)
+	if err != nil {
+		return "", err
+	}
+	c.started = true
+	c.url = url
+	c.done = make(chan struct{})
+	go func() {
+		defer close(c.done)
+		if serr := srv.Serve(c.serveCtx); serr != nil {
+			fmt.Fprintln(os.Stderr, "monitor:", serr)
+		}
+	}()
+	<-srv.Ready() // block until registered so a follow-up Peers() sees us
+	return url, nil
+}
+
+// Info reports the dashboard URL and whether it is currently running.
+func (c *Controller) Info() (url string, running bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.url, c.started
+}
+
+// Wait blocks until the dashboard's serve goroutine has fully exited
+// (after serveCtx is cancelled and graceful shutdown + deregistration
+// complete). Returns immediately if the dashboard was never started.
+// The CLI defers this before closing the index so the registry entry is
+// removed cleanly on shutdown.
+func (c *Controller) Wait() {
+	c.mu.Lock()
+	d := c.done
+	c.mu.Unlock()
+	if d != nil {
+		<-d
+	}
+}

--- a/internal/monitor/controller_test.go
+++ b/internal/monitor/controller_test.go
@@ -1,0 +1,73 @@
+package monitor
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+)
+
+func TestServer_ListenReturnsDynamicURL(t *testing.T) {
+	s := NewServer(Config{Version: "test", Mode: "mcp-stdio", Index: index.NewMemory()})
+	url, err := s.Listen(":0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = s.ln.Close() }()
+	if !strings.HasPrefix(url, "http://127.0.0.1:") || strings.HasSuffix(url, ":0/") {
+		t.Errorf("Listen URL = %q, want http://127.0.0.1:<nonzero>/", url)
+	}
+	if s.URL() != url {
+		t.Errorf("URL() = %q, want %q", s.URL(), url)
+	}
+}
+
+func TestController_EnsureStartedIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+	t.Setenv("HOME", dir)
+	t.Setenv("LocalAppData", dir)
+
+	ctx := t.Context()
+	c := NewController(ctx, Config{Version: "test", Mode: "mcp-stdio", Index: index.NewMemory()}, ":0")
+
+	url1, err := c.EnsureStarted()
+	if err != nil {
+		t.Fatalf("EnsureStarted: %v", err)
+	}
+	url2, err := c.EnsureStarted()
+	if err != nil {
+		t.Fatalf("EnsureStarted (2nd): %v", err)
+	}
+	if url1 != url2 {
+		t.Errorf("EnsureStarted not idempotent: %q vs %q", url1, url2)
+	}
+	if _, running := c.Info(); !running {
+		t.Error("Info() running = false after EnsureStarted")
+	}
+
+	// The lazily-started dashboard should actually be serving + registered.
+	if !waitHealthy(url1, time.Second) {
+		t.Fatalf("dashboard at %s never became healthy", url1)
+	}
+	if got := len(Peers()); got != 1 {
+		t.Errorf("Peers() = %d after lazy start, want 1", got)
+	}
+}
+
+func waitHealthy(url string, d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url + "healthz")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return true
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}

--- a/internal/monitor/liveness_unix.go
+++ b/internal/monitor/liveness_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package monitor
+
+import (
+	"errors"
+	"syscall"
+)
+
+// processAlive reports whether a process with the given PID is currently
+// running. Signal 0 performs error checking without delivering a signal:
+// a nil error means the process exists and we can signal it; EPERM means
+// it exists but is owned by another user (still alive); ESRCH means no
+// such process (dead). Used to prune crashed instances from the monitor
+// registry.
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
+}

--- a/internal/monitor/liveness_windows.go
+++ b/internal/monitor/liveness_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package monitor
+
+import "os"
+
+// processAlive reports whether a process with the given PID is running.
+//
+// Windows has no signal-0 probe, and os.FindProcess always succeeds, so
+// we open the process handle via os.FindProcess and treat a Signal probe
+// result as the liveness answer. In practice the more reliable backstop
+// is graceful deregistration on shutdown; a crashed Windows instance's
+// stale entry is tolerated until its PID is reused (rare) or the file is
+// cleaned up manually. Conservative default: assume alive on any
+// ambiguity so we never hide a genuinely-running peer.
+func processAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// Signal(nil) returns nil if the process is still running, and an
+	// error ("not supported by windows"/"already finished") otherwise.
+	// Go's windows runtime returns nil for a live handle.
+	if err := p.Signal(os.Signal(nil)); err != nil {
+		return false
+	}
+	return true
+}

--- a/internal/monitor/registry.go
+++ b/internal/monitor/registry.go
@@ -1,0 +1,112 @@
+package monitor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// registrySubdir is the per-user cache location for monitor-instance
+// registration files, mirroring the os.UserConfigDir()/file-search-on/…
+// convention used by internal/projecttype for config discovery.
+const registrySubdir = "file-search-on/monitors"
+
+// Entry is one running dashboard instance's registration record, written
+// as <pid>.json in the registry directory. Concurrent file-search-on
+// processes read each other's entries to build the peer switcher.
+type Entry struct {
+	PID        int       `json:"pid"`
+	URL        string    `json:"url"`  // http://127.0.0.1:<port>/
+	Mode       string    `json:"mode"` // mcp-stdio | mcp-http | mcp-sse | watch
+	Version    string    `json:"version"`
+	StartedAt  time.Time `json:"started_at"`
+	WorkingDir string    `json:"working_dir"`
+	IndexPath  string    `json:"index_path,omitempty"` // "" = in-memory
+	// IsSelf is set only on the /api/peers response for the entry that
+	// matches the serving instance; it is never persisted (the registry
+	// files omit it via the zero value).
+	IsSelf bool `json:"is_self,omitempty"`
+}
+
+// registryDir returns the monitor registry directory, creating it if
+// needed. Falls back to os.TempDir() when the user cache dir is
+// unavailable so registration degrades rather than fails.
+func registryDir() (string, error) {
+	base, err := os.UserCacheDir()
+	if err != nil {
+		base = os.TempDir()
+	}
+	dir := filepath.Join(base, registrySubdir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// Register writes e as <pid>.json in the registry directory and returns
+// a deregister func that removes it. Registration failures are returned
+// so the caller can log-and-continue; a missing registry only disables
+// peer discovery, not the dashboard itself.
+func Register(e Entry) (func(), error) {
+	dir, err := registryDir()
+	if err != nil {
+		return func() {}, err
+	}
+	path := filepath.Join(dir, entryFile(e.PID))
+	data, err := json.Marshal(e)
+	if err != nil {
+		return func() {}, err
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return func() {}, err
+	}
+	return func() { _ = os.Remove(path) }, nil
+}
+
+// Peers returns every live registered instance, sorted by StartedAt.
+// Entries whose process is no longer alive are pruned from disk as a
+// side effect (best-effort), so a crashed instance self-heals out of
+// every peer's switcher on the next read.
+func Peers() []Entry {
+	dir, err := registryDir()
+	if err != nil {
+		return nil
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return nil
+	}
+	var out []Entry
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal(data, &e); err != nil {
+			// Corrupt / partially-written file — drop it.
+			_ = os.Remove(path)
+			continue
+		}
+		if e.PID <= 0 || !processAlive(e.PID) {
+			_ = os.Remove(path)
+			continue
+		}
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].StartedAt.Equal(out[j].StartedAt) {
+			return out[i].StartedAt.Before(out[j].StartedAt)
+		}
+		return out[i].PID < out[j].PID
+	})
+	return out
+}
+
+// entryFile is the registration filename for a PID.
+func entryFile(pid int) string {
+	return strconv.Itoa(pid) + ".json"
+}

--- a/internal/monitor/registry_test.go
+++ b/internal/monitor/registry_test.go
@@ -1,0 +1,82 @@
+package monitor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// withTempRegistry points the registry at a throwaway dir for the test
+// by overriding XDG_CACHE_HOME / the OS cache base. os.UserCacheDir
+// honours XDG_CACHE_HOME on Linux but not macOS, so to stay portable we
+// just exercise the exported funcs against a temp HOME-independent dir
+// by setting the relevant env. Simpler + portable: drive the helpers
+// that take an explicit dir. Since Register/Peers resolve registryDir
+// internally, we redirect via the cache-dir env vars understood on each
+// OS, falling back to asserting behaviour through a temp dir we control.
+func TestRegistry_RoundTripAndPrune(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir) // Linux
+	t.Setenv("HOME", dir)           // macOS UserCacheDir = $HOME/Library/Caches
+	t.Setenv("LocalAppData", dir)   // Windows
+
+	// A live entry for THIS process should round-trip through Peers.
+	self := Entry{
+		PID:       os.Getpid(),
+		URL:       "http://127.0.0.1:54211/",
+		Mode:      "mcp-stdio",
+		Version:   "test",
+		StartedAt: time.Now(),
+	}
+	deregister, err := Register(self)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	peers := Peers()
+	if len(peers) != 1 {
+		t.Fatalf("Peers() = %d, want 1 (self)", len(peers))
+	}
+	if peers[0].PID != self.PID || peers[0].URL != self.URL {
+		t.Errorf("peer = %+v, want self", peers[0])
+	}
+
+	// Plant a dead-PID entry directly; Peers must prune it.
+	rdir, _ := registryDir()
+	dead := filepath.Join(rdir, "999999999.json")
+	if err := os.WriteFile(dead, []byte(`{"pid":999999999,"url":"http://127.0.0.1:1/","mode":"mcp-stdio"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(Peers()); got != 1 {
+		t.Errorf("after planting dead PID, Peers() = %d, want 1 (dead pruned)", got)
+	}
+	if _, err := os.Stat(dead); !os.IsNotExist(err) {
+		t.Errorf("dead-PID file should have been removed by Peers()")
+	}
+
+	// Corrupt file is dropped too.
+	if err := os.WriteFile(filepath.Join(rdir, "123.json"), []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(Peers()); got != 1 {
+		t.Errorf("after planting corrupt entry, Peers() = %d, want 1", got)
+	}
+
+	// Deregister removes self.
+	deregister()
+	if got := len(Peers()); got != 0 {
+		t.Errorf("after deregister, Peers() = %d, want 0", got)
+	}
+}
+
+func TestProcessAlive(t *testing.T) {
+	if !processAlive(os.Getpid()) {
+		t.Error("processAlive(self) = false, want true")
+	}
+	// PID 1 (init/launchd) is always alive on unix; on Windows the stub
+	// is conservative. Just assert a clearly-dead PID reads as dead.
+	if processAlive(999999999) {
+		t.Error("processAlive(999999999) = true, want false")
+	}
+}

--- a/internal/monitor/server.go
+++ b/internal/monitor/server.go
@@ -39,10 +39,16 @@ type Config struct {
 	BodyCacheCap int64  // 0 → in-memory / no cap
 }
 
-// Server is the read-only monitoring HTTP server.
+// Server is the read-only monitoring HTTP server. Bind with Listen
+// (which assigns the URL) then run with Serve; Run is the eager
+// convenience wrapper that does both.
 type Server struct {
 	cfg       Config
 	startedAt time.Time
+	srv       *http.Server
+	ln        net.Listener
+	url       string
+	ready     chan struct{} // closed by Serve once registered; see Ready
 }
 
 // NewServer builds a monitoring server from cfg.
@@ -50,43 +56,94 @@ func NewServer(cfg Config) *Server {
 	return &Server{cfg: cfg, startedAt: time.Now()}
 }
 
-// Run binds a localhost-only HTTP listener and serves the dashboard +
-// JSON API until ctx is cancelled, then shuts down gracefully. addr's
-// host is forced to 127.0.0.1 — only the port is honoured — so the
-// dashboard (which can surface searched file paths) never binds a
-// routable interface.
-func (s *Server) Run(ctx context.Context, addr string) error {
-	addr = forceLoopback(addr)
-
+// routes builds the dashboard mux. Returns an error only if the embedded
+// static assets are missing (compile-time guaranteed, but surfaced
+// rather than panicked).
+func (s *Server) routes() (http.Handler, error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/overview", s.handleOverview)
 	mux.HandleFunc("GET /api/cache", s.handleCache)
 	mux.HandleFunc("GET /api/activity", s.handleActivity)
 	mux.HandleFunc("GET /api/capabilities", s.handleCapabilities)
+	mux.HandleFunc("GET /api/peers", s.handlePeers)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
-
 	sub, err := fs.Sub(staticFiles, "static")
 	if err != nil {
-		return fmt.Errorf("monitor static assets: %w", err)
+		return nil, fmt.Errorf("monitor static assets: %w", err)
 	}
 	mux.Handle("GET /", http.FileServerFS(sub))
+	return mux, nil
+}
 
-	srv := &http.Server{
-		Addr:              addr,
-		Handler:           mux,
+// Listen binds a localhost-only TCP listener and returns the dashboard
+// URL. addr's host is forced to 127.0.0.1 — only the port is honoured —
+// so the dashboard (which can surface searched file paths) never binds a
+// routable interface. Pass ":0" for an OS-assigned port (used by the
+// dynamic --monitor mode so concurrent instances don't collide). Call
+// Serve next to start serving.
+func (s *Server) Listen(addr string) (string, error) {
+	ln, err := net.Listen("tcp", forceLoopback(addr))
+	if err != nil {
+		return "", fmt.Errorf("monitor listen: %w", err)
+	}
+	handler, err := s.routes()
+	if err != nil {
+		_ = ln.Close()
+		return "", err
+	}
+	s.ln = ln
+	s.url = fmt.Sprintf("http://127.0.0.1:%d/", ln.Addr().(*net.TCPAddr).Port)
+	s.ready = make(chan struct{})
+	s.srv = &http.Server{
+		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
+	return s.url, nil
+}
+
+// URL returns the bound dashboard URL, or "" before Listen.
+func (s *Server) URL() string { return s.url }
+
+// Ready returns a channel closed once Serve has registered this instance
+// in the peer registry and is about to accept connections. Callers that
+// launch Serve in a goroutine (the lazy Controller) wait on it so a
+// follow-up Peers() read reflects this instance.
+func (s *Server) Ready() <-chan struct{} { return s.ready }
+
+// Serve serves the dashboard on the bound listener until ctx is
+// cancelled, registering the instance in the peer registry for the
+// duration so concurrent file-search-on processes can discover it. Listen
+// must have been called first.
+func (s *Server) Serve(ctx context.Context) error {
+	if s.ln == nil {
+		return errors.New("monitor: Serve called before Listen")
+	}
+
+	deregister, regErr := Register(Entry{
+		PID:        os.Getpid(),
+		URL:        s.url,
+		Mode:       s.cfg.Mode,
+		Version:    s.cfg.Version,
+		StartedAt:  s.startedAt,
+		WorkingDir: workingDir(),
+		IndexPath:  s.cfg.IndexPath,
+	})
+	if regErr != nil {
+		fmt.Fprintln(os.Stderr, "monitor: peer registry unavailable:", regErr)
+	}
+	defer deregister()
+	close(s.ready) // registered; Peers() now reflects this instance
 
 	errCh := make(chan error, 1)
-	go func() { errCh <- srv.ListenAndServe() }()
+	go func() { errCh <- s.srv.Serve(s.ln) }()
 
-	fmt.Fprintf(os.Stderr, "monitor dashboard: http://%s/\n", addr)
+	fmt.Fprintf(os.Stderr, "monitor dashboard: %s\n", s.url)
 
 	select {
 	case <-ctx.Done():
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		if err := srv.Shutdown(shutdownCtx); err != nil {
+		if err := s.srv.Shutdown(shutdownCtx); err != nil {
 			return fmt.Errorf("monitor shutdown: %w", err)
 		}
 		return nil
@@ -96,6 +153,37 @@ func (s *Server) Run(ctx context.Context, addr string) error {
 		}
 		return err
 	}
+}
+
+// Run binds and serves in one call — the eager path used when the
+// dashboard is enabled at launch.
+func (s *Server) Run(ctx context.Context, addr string) error {
+	if _, err := s.Listen(addr); err != nil {
+		return err
+	}
+	return s.Serve(ctx)
+}
+
+// workingDir returns the process working directory, or "" on error.
+// Surfaced in the peer switcher so an operator can tell instances apart.
+func workingDir() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return wd
+}
+
+// handlePeers returns every live registered dashboard instance, flagging
+// the one that matches this server so the UI can mark "you".
+func (s *Server) handlePeers(w http.ResponseWriter, _ *http.Request) {
+	peers := Peers()
+	for i := range peers {
+		if peers[i].URL == s.url {
+			peers[i].IsSelf = true
+		}
+	}
+	writeJSON(w, map[string]any{"self_url": s.url, "peers": peers})
 }
 
 // forceLoopback returns a 127.0.0.1 address preserving only the port of

--- a/internal/monitor/static/app.js
+++ b/internal/monitor/static/app.js
@@ -152,16 +152,49 @@ function setHealth(ok) {
   el.className = "pill " + (ok ? "pill-ok" : "pill-err");
 }
 
+// shortDir trims a working dir to its last two path segments for compact
+// display (e.g. /Users/me/Code/projA → …/Code/projA).
+function shortDir(d) {
+  if (!d) return "";
+  const parts = d.split("/").filter(Boolean);
+  return (parts.length > 2 ? "…/" : "/") + parts.slice(-2).join("/");
+}
+
+function renderPeers(d) {
+  const peers = (d && d.peers) || [];
+  const el = $("peers");
+  // A lone instance (just us) doesn't need a switcher.
+  if (peers.length <= 1) { el.innerHTML = ""; return; }
+  const opts = peers.map((p) => {
+    const label = `${p.mode} ${shortDir(p.working_dir)} :${(p.url.match(/:(\d+)\//) || [])[1] || "?"}${p.is_self ? " (you)" : ""}`;
+    return `<option value="${p.url}" ${p.is_self ? "selected" : ""}>${label}</option>`;
+  }).join("");
+  el.innerHTML = `<label class="peers-label">${peers.length} instances</label>
+    <select id="peer-select">${opts}</select>`;
+  const sel = $("peer-select");
+  sel.onchange = () => {
+    const url = sel.value;
+    if (url && !peers.find((p) => p.url === url && p.is_self)) {
+      window.open(url, "_blank");
+      // reset selection back to self so the dropdown keeps showing "you"
+      const self = peers.find((p) => p.is_self);
+      if (self) sel.value = self.url;
+    }
+  };
+}
+
 async function tick() {
   try {
-    const [o, c, a, caps] = await Promise.all([
+    const [o, c, a, caps, peers] = await Promise.all([
       getJSON("api/overview"), getJSON("api/cache"),
       getJSON("api/activity"), getJSON("api/capabilities"),
+      getJSON("api/peers"),
     ]);
     renderOverview(o);
     renderCache(c);
     renderActivity(a);
     renderCapabilities(caps);
+    renderPeers(peers);
     setHealth(true);
   } catch (e) {
     setHealth(false);

--- a/internal/monitor/static/index.html
+++ b/internal/monitor/static/index.html
@@ -14,6 +14,7 @@
       <span id="hdr-version" class="muted"></span>
       <span id="hdr-mode" class="tag"></span>
       <span id="hdr-uptime" class="muted"></span>
+      <div id="peers" class="peers"></div>
     </div>
   </header>
 

--- a/internal/monitor/static/style.css
+++ b/internal/monitor/static/style.css
@@ -37,6 +37,10 @@ footer { padding: 12px 20px; text-align: center; }
 .pill-err { background: rgba(255,83,112,.18); color: var(--err); }
 .pill-unknown { background: rgba(123,135,148,.18); color: var(--muted); }
 .tag { background: var(--card); padding: 2px 8px; border-radius: 4px; font-size: 12px; }
+.peers { display: flex; align-items: center; gap: 6px; }
+.peers-label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
+.peers select { background: var(--card); color: var(--fg); border: 1px solid var(--line);
+  border-radius: 4px; padding: 3px 6px; font-size: 12px; max-width: 320px; }
 .badge { background: var(--card); padding: 1px 8px; border-radius: 999px; font-size: 12px; color: var(--accent); }
 
 .kv-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 10px; }


### PR DESCRIPTION
Extends the monitoring dashboard (#230) for the **multi-agent** case: many `file-search-on mcp` stdio servers running concurrently, each needing its own dashboard, mutual awareness, and an easy switch between them.

## What's new
- **Dynamic port** — `--monitor` enables the dashboard on an OS-assigned loopback port (no collisions across concurrent stdio agents); `--monitor-addr :P` still pins a fixed one. `Server.Run` is split into `Listen()` (binds `127.0.0.1:0`, reads back the real port) + `Serve(ctx)`.
- **Cross-process registry** (`internal/monitor/registry.go`) — each dashboard instance writes `<pid>.json` under `<UserCacheDir>/file-search-on/monitors/` and removes it on shutdown. `Peers()` prunes dead PIDs via a **build-tagged** liveness check (`syscall.Kill(pid,0)` on unix, stub on windows — mirrors the repo's existing `*_darwin.go` splits).
- **`monitor_info` MCP tool** — returns this server's dashboard URL + the peer list (self flagged `is_self`), and `monitor_info{enable:true}` **lazily starts** the dashboard mid-session via a `Controller`, so an agent launched without a monitor flag is still observable on demand. Wired through a new nil-safe `WithMonitor(*monitor.Controller)` option (existing `New(...)` call sites untouched).
- **Peer switcher** — `/api/peers` endpoint + a header dropdown in the dashboard listing every sibling (mode · working dir · port); click to switch.

## Lifecycle detail (the subtle bit)
The `mcp` command derives a cancellable child of the signal ctx so the dashboard shuts down **and deregisters on stdio-EOF** (client disconnect), not only on OS signal. Defer ordering is load-bearing — `cancel()` → `controller.Wait()` (drains the dashboard) → `idx.Close()`. In `mcp` mode the collector is always attached so the Activity panel has history if the dashboard is enabled lazily (a tiny per-call append; negligible vs a walk).

## Test plan
- [x] `internal/monitor`: registry round-trip + **dead-PID prune** + corrupt-file drop; `Listen()` returns a usable dynamic `127.0.0.1:<nonzero>` URL; `Controller.EnsureStarted` idempotent + actually serving + registered; `processAlive` self vs dead PID.
- [x] `internal/mcpserver`: `monitor_info` via in-memory transport — lazy `enable=true` starts + returns a URL + flags self in peers; no-controller path reports unavailable; `server_version` covers `monitor_info`.
- [x] **Manual two-instance**: two concurrent `mcp` stdio servers each `monitor_info{enable:true}` → each reports its own dynamic URL and sees the other as a peer with correct `is_self`. Confirmed clean stdin-EOF exit **deregisters** (registry empty after).
- [x] `go vet`, `go fix` (idempotent), `golangci-lint` (0 issues), full `go test -race ./...`; cross-compiles linux + windows (exercises the build-tagged liveness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)