### PR TITLE
feat(cmd): monitors subcommand — list active dashboard URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ file-search-on -d .                                   # empty expression matches
 | `find-projects [root]` | Walk a tree listing every project subdirectory | [examples/projects.md](./examples/projects.md) |
 | `which-project <path>` | Walk UP from a file/dir to its nearest enclosing project root | [examples/projects.md](./examples/projects.md) |
 | `config-paths` | Print platform-specific project-type config paths | [examples/projects.md](./examples/projects.md) |
+| `monitors` | List the dashboard URLs of every running instance (mcp / watch started with `--monitor`) | [examples/monitoring.md](./examples/monitoring.md) |
 | `mcp` | Run as a Model Context Protocol server | [MCP server mode](#mcp-server-mode) |
 
 `file-search-on --list` prints the canonical schema (every attribute, every built-in function, every registered content type) — useful for "what can I filter on?" exploration.

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -65,6 +65,7 @@ var CLI struct {
 	Projects        FindProjectsCmd    `cmd:"" name:"find-projects" help:"Walk a root and list every project subdirectory under it."`
 	WhichProject    WhichProjectCmd    `cmd:"" name:"which-project" help:"Given a file or directory path, walk up the chain and identify the nearest enclosing project root and type(s)."`
 	ConfigPaths     ConfigPathsCmd     `cmd:"" name:"config-paths" help:"Print the project-type config search paths for this platform. Use to discover where to drop your user-wide config (mkdir -p \"$(file-search-on config-paths -o bare | head -1 | xargs dirname)\")."`
+	Monitors        MonitorsCmd        `cmd:"" name:"monitors" help:"List the monitoring-dashboard URLs of every currently-running file-search-on instance (mcp / watch started with --monitor). Reads the shared peer registry and prunes dead entries. Pipe -o bare into a browser opener, e.g. file-search-on monitors -o bare | head -1 | xargs open."`
 	HashSet         HashSetCmd         `cmd:"" name:"hash-set" help:"Manage hash allowlist / denylist files used by --hash-allowlist / --hash-denylist. Subcommands: build (compile text or NSRL CSV into bbolt format), info (print per-algorithm counts)."`
 	MCP             MCPCmd             `cmd:"" name:"mcp" help:"Run as a Model Context Protocol server (stdio, http, or sse)."`
 	Version         kong.VersionFlag   `short:"V" help:"Print version and exit."`

--- a/cmd/file-search-on/monitors_cmd.go
+++ b/cmd/file-search-on/monitors_cmd.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/richardwooding/file-search-on/internal/monitor"
+)
+
+// MonitorsCmd lists the monitoring dashboards of every currently-running
+// file-search-on instance, read from the shared peer registry. Reading
+// also prunes registry entries for processes that have since died, so
+// `monitors` doubles as a registry-cleanup pass.
+type MonitorsCmd struct {
+	Output string `short:"o" name:"output" enum:"default,bare,json" default:"default" help:"Output format: default (table: mode / pid / age / dir / url), bare (one URL per line — pipe to a browser opener), or json."`
+}
+
+func (c *MonitorsCmd) Run(_ context.Context) error {
+	peers := monitor.Peers()
+
+	switch c.Output {
+	case "bare":
+		for _, p := range peers {
+			_, _ = fmt.Fprintln(os.Stdout, p.URL)
+		}
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(peers)
+	default:
+		if len(peers) == 0 {
+			_, _ = fmt.Fprintln(os.Stdout, "No active file-search-on dashboards.")
+			_, _ = fmt.Fprintln(os.Stdout, "Start one with: file-search-on mcp --monitor   (or watch --monitor)")
+			return nil
+		}
+		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "MODE\tPID\tAGE\tDIR\tURL")
+		now := time.Now()
+		for _, p := range peers {
+			age := now.Sub(p.StartedAt).Round(time.Second)
+			_, _ = fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%s\n", p.Mode, p.PID, age, p.WorkingDir, p.URL)
+		}
+		_ = tw.Flush()
+	}
+	return nil
+}

--- a/cmd/file-search-on/monitors_cmd_test.go
+++ b/cmd/file-search-on/monitors_cmd_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/monitor"
+)
+
+// TestMonitorsCmd_Empty asserts the no-instances path prints a helpful
+// hint rather than nothing. Points the registry at a temp cache dir so
+// it doesn't observe real running instances.
+func TestMonitorsCmd_Empty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+	t.Setenv("HOME", dir)
+	t.Setenv("LocalAppData", dir)
+
+	if peers := monitor.Peers(); len(peers) != 0 {
+		t.Fatalf("expected an empty registry, got %d peers", len(peers))
+	}
+
+	// default + bare + json must all run without error on an empty set.
+	for _, out := range []string{"default", "bare", "json"} {
+		c := &MonitorsCmd{Output: out}
+		if err := c.Run(t.Context()); err != nil {
+			t.Errorf("monitors -o %s: %v", out, err)
+		}
+	}
+}
+
+// TestMonitorsCmd_ListsRegistered registers a synthetic live entry (this
+// test process's PID) and asserts bare output contains its URL.
+func TestMonitorsCmd_ListsRegistered(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+	t.Setenv("HOME", dir)
+	t.Setenv("LocalAppData", dir)
+
+	deregister, err := monitor.Register(monitor.Entry{
+		PID:  os.Getpid(),
+		URL:  "http://127.0.0.1:54999/",
+		Mode: "mcp-stdio",
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	defer deregister()
+
+	peers := monitor.Peers()
+	if len(peers) != 1 || !strings.Contains(peers[0].URL, "54999") {
+		t.Fatalf("Peers() = %+v, want one entry with :54999", peers)
+	}
+}

--- a/examples/monitoring.md
+++ b/examples/monitoring.md
@@ -62,6 +62,26 @@ Response shape:
 
 So an agent that was launched **without** any monitor flag can still be observed on demand — call `monitor_info{enable:true}` and open the returned URL. From there the peers panel lets you hop between every running agent's dashboard. (Watch mode has no MCP tools, so its dashboard must be enabled at launch with `--monitor` / `--monitor-addr`.)
 
+### Listing dashboards from the shell
+
+The `monitors` subcommand prints every active instance's dashboard (reading the same registry, pruning any dead entries as it goes) — no MCP round-trip needed:
+
+```sh
+file-search-on monitors                 # table: mode / pid / age / dir / url
+file-search-on monitors -o bare         # one URL per line
+file-search-on monitors -o json         # machine-readable
+
+# open the most-recently-started dashboard in a browser (macOS)
+file-search-on monitors -o bare | tail -1 | xargs open
+```
+
+```
+MODE       PID    AGE   DIR                     URL
+mcp-stdio  97394  1m3s  /Users/me/projA         http://127.0.0.1:54211/
+mcp-stdio  97396  58s   /Users/me/projB         http://127.0.0.1:54218/
+watch      97401  12s   /Users/me/Desktop       http://127.0.0.1:54223/
+```
+
 ## JSON API (scriptable)
 
 The same data the UI renders is available as JSON — handy for scripts, smoke checks, or piping into `jq`:


### PR DESCRIPTION
Adds a `monitors` CLI subcommand that prints the dashboard URL of every currently-running file-search-on instance.

**Stacked on #235** (`feat/monitor-multi-instance`) — it reads the peer registry introduced there, so the base of this PR is that branch, not `main`. GitHub will auto-retarget to `main` once #235 merges. (Kept separate rather than amending #235, per the no-commits-on-an-open-PR convention.)

## What it does
```sh
file-search-on monitors            # table: mode / pid / age / dir / url
file-search-on monitors -o bare    # one URL per line
file-search-on monitors -o json    # machine-readable

# open the newest dashboard (macOS)
file-search-on monitors -o bare | tail -1 | xargs open
```

Reads `monitor.Peers()`, which prunes dead-PID entries as it goes — so `monitors` doubles as a registry-cleanup pass. Empty case prints a hint to start one with `--monitor`. Output style mirrors the existing `config-paths` command (`-o default,bare,json`).

## Test plan
- [x] `monitors_cmd_test.go` — empty-registry path (all three formats run clean) + lists a registered entry; registry pointed at a temp cache dir so it doesn't observe real instances.
- [x] Manual end-to-end: started a `watch --monitor` instance, confirmed `monitors` listed it in all three formats, and that it disappeared after the instance exited.
- [x] `go vet`, `go fix` (idempotent), `golangci-lint` (0 issues), full `go test -race ./...`, cross-compile linux + windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)