### PR TITLE
docs(slides): Marp deck for the file-search-on Show & Tell talk

### DIFF
--- a/slides/.gitignore
+++ b/slides/.gitignore
@@ -1,0 +1,4 @@
+# Marp render artifacts
+*.html
+*.pdf
+*.pptx

--- a/slides/README.md
+++ b/slides/README.md
@@ -1,0 +1,82 @@
+# Slides — file-search-on talk
+
+A Marp deck for a ~15 minute Show-&-Tell talk on `file-search-on`.
+
+## Files
+
+- `deck.md` — the slides. Speaker notes are inline as HTML comments.
+- `demo.sh` — the live commands, one block per demo slide.
+- `scripts/build_semantic_corpus.sh` — generates the Demo 2 corpus
+  (12 markdown notes in `~/Documents/semantic-demo/`). Run once before
+  the talk.
+- `scripts/build_ocr_corpus.sh` — generates the Demo 4 OCR corpus
+  (12 synthetic text-bearing JPGs in `~/Pictures/ocr-demo/`). Run once
+  before the talk. Requires ImageMagick.
+- `README.md` — you are here.
+
+## Pre-talk checklist
+
+1. `brew install marp-cli imagemagick ollama` (renderer + image builder + embeddings).
+2. Pull the embedding model once: `ollama pull nomic-embed-text`.
+3. Make sure Ollama is running: `ollama serve &` (or open the Ollama app).
+4. Build the semantic corpus: `./scripts/build_semantic_corpus.sh`
+5. Build the OCR corpus: `./scripts/build_ocr_corpus.sh`
+6. Confirm the SA photo corpus is still at `~/Pictures/south-africa-holiday/` (66 GPS-tagged JPGs).
+7. `rm -f /tmp/ocr.db /tmp/semantic.db` (wipe the caches so the cold/warm timing demos land).
+8. Have a Claude Code / Claude Desktop window with `file-search-on mcp` registered, sitting on a blank prompt for Demo 6.
+
+## Render
+
+The deck uses [Marp](https://marp.app). Install once:
+
+```sh
+brew install marp-cli       # or: npm i -g @marp-team/marp-cli
+```
+
+Then render or preview:
+
+```sh
+marp deck.md --pdf          # → deck.pdf
+marp deck.md --html         # → deck.html
+marp deck.md --pptx         # → deck.pptx
+marp -s .                   # local preview server (auto-reloads on edit)
+```
+
+`marp -s .` (the server mode) is the most useful when iterating on the
+deck — it watches the directory and live-reloads on save.
+
+## Speaker notes
+
+The script for each slide lives in `<!-- SCRIPT: ... -->` comments. Marp's
+HTML / PPTX renders surface them as presenter notes. For PDF, install the
+[VS Code Marp extension](https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode)
+and use "Marp: Show Preview" to see slides + notes side-by-side while
+practising.
+
+## Running the demos
+
+Drive `demo.sh` line-by-line rather than `bash demo.sh` — each block is
+its own beat in the talk. Two tips:
+
+1. Run the talks's terminal at a **bigger font** than your IDE
+   (`Cmd-+` ×2 in Terminal.app / iTerm2). The default is unreadable
+   from row 5.
+2. Pre-stage the photo corpus (`~/Pictures/south-africa-holiday/`) and
+   the file-search-on binary on `PATH` before going live.
+
+## Timing
+
+| Section | Time |
+| --- | --- |
+| Slides 1-2 (intro) | ~1m |
+| Slides 3-5 (problem + pitch) | ~2m |
+| Demo 1 (Go codebase tour) | ~2m |
+| Demo 2 (semantic search over docs) | ~2m |
+| Demo 3 (SA photos, bbox + polygon) | ~2.5m |
+| Demo 4 (OCR over images) | ~2m |
+| Demo 5 (visual similarity / phash) | ~1.5m |
+| Demo 6 (MCP / agent) | ~2.5m |
+| Slides 11-13 (under the hood / learned / open) | ~3m |
+| Summary + Q&A | ~2m + open |
+
+Total floor: ~20-21 minutes plus questions.

--- a/slides/deck.md
+++ b/slides/deck.md
@@ -1,0 +1,765 @@
+---
+marp: true
+theme: default
+paginate: true
+size: 16:9
+title: file-search-on
+author: Richard Wooding
+style: |
+  section {
+    font-size: 26px;
+    padding: 50px 60px;
+    line-height: 1.4;
+  }
+  section h1 { font-size: 56px; }
+  section h2 { font-size: 36px; margin-bottom: 0.35em; }
+  section h3 { font-size: 28px; }
+  pre, code {
+    font-size: 17px;
+    line-height: 1.35;
+  }
+  pre {
+    padding: 0.6em 0.8em;
+    margin: 0.4em 0;
+  }
+  table { font-size: 22px; }
+  th, td { padding: 0.3em 0.6em; }
+  ul, ol { margin: 0.3em 0; }
+  li { margin: 0.15em 0; }
+  blockquote { font-size: 24px; margin: 0.4em 0; }
+  section.lead { font-size: 32px; }
+  section.lead h1 { font-size: 72px; }
+---
+
+<!-- _class: lead -->
+
+# `file-search-on`
+
+### A content-type-aware file search, in CEL
+
+Richard Wooding — Span Digital — 2026
+
+<!--
+SCRIPT:
+Good [morning / afternoon] everyone, and thanks for the time.
+
+I'm Richard Wooding, I'm a staff engineer at Span Digital. Over the next
+fifteen minutes I'm going to show you a tool I've been building called
+file-search-on — what it is, why it exists, and what surprised me along
+the way.
+
+Hold questions to the end — there'll be a Q&A — but please flag me if
+anything on screen is hard to read.
+-->
+
+---
+
+## Who I am
+
+- Staff engineer at Span Digital — we build content and dev tooling
+- I scratch my own itches in Go
+- Background: search, indexing, content systems
+- Today's project lives at **github.com/richardwooding/file-search-on**
+
+<!--
+SCRIPT:
+Quick "who am I" — I'm a staff engineer at Span Digital, where we work
+on content platforms and developer tooling. I write Go for fun and for
+work.
+
+Most of my projects start the same way: I have a question I want to ask
+of my filesystem, my tools won't answer it cleanly, and I get annoyed
+enough to write code. file-search-on is the latest one.
+
+It's open source, on GitHub at richardwooding/file-search-on. I'll
+share that link again at the end.
+-->
+
+---
+
+## What you'll see today
+
+1. The **problem** — what `find`, `grep`, and `glob` cannot answer
+2. The **pitch** — one-line CEL expressions over typed file attributes
+3. Six live **demos**:
+   1. **Touring a Go codebase** — the file-search-on repo itself
+   2. **Semantic search** over a docs folder (local Ollama embeddings)
+   3. A photo corpus by camera, by GPS bbox, by polygon
+   4. Finding **text inside images** with OCR
+   5. Finding **visually similar photos** by perceptual hash
+   6. An AI agent driving file-search-on through MCP
+4. What I **learned** and what's still **open**
+
+<!--
+SCRIPT:
+Here's the shape of the next twelve minutes. I'll set up the problem,
+give you the elevator pitch, then run three short demos — a CLI tour, a
+photo-by-GPS query, and an AI agent driving file-search-on through the
+Model Context Protocol. I'll close with what surprised me building it,
+plus a couple of open issues I haven't cracked yet.
+
+Three demos sounds like a lot for fifteen minutes — they're short and I
+won't be typing live. The commands are scripted; I'll talk you through
+what each one does as it runs.
+-->
+
+---
+
+## The problem
+
+| Question | Tool | Works? |
+| --- | --- | --- |
+| "Find files named `*.go`" | `find` / glob | yes |
+| "Find files **containing** the word panic" | `grep` | yes |
+| "Find **PDFs with more than 10 pages**" | — | no |
+| "Find **photos taken in Cape Town**" | — | no |
+| "Find **MP3s with a missing artist tag**" | — | no |
+| "Find **ARM64 binaries** over 100 MB" | — | no |
+
+`find` knows about **paths**. `grep` knows about **bytes**. Neither knows what the file *is*.
+
+<!--
+SCRIPT:
+Here's the gap that bothered me.
+
+Find and glob are great when you can describe the file by its name —
+"give me everything ending in .go". Grep is great when you can describe
+the file by its bytes — "give me lines mentioning the word panic".
+
+But a huge class of useful questions don't fit either shape. "Show me
+PDFs longer than ten pages." "Show me photos taken inside this GPS
+polygon." "Show me MP3s where the artist tag is empty." "Show me ARM64
+Mach-O binaries over a hundred megs."
+
+These are all questions about *what the file is* — its typed attributes,
+its semantic identity. There was no clean way to ask them on the command
+line, so I wrote one.
+-->
+
+---
+
+## The pitch
+
+`file-search-on` evaluates a **CEL expression** against **typed file attributes**:
+
+```sh
+file-search-on 'is_image && iso > 1600 && gps_lat != 0.0'
+file-search-on 'is_pdf && page_count > 10 && word_count > 5000'
+file-search-on 'is_source && language == "go" && loc > 200'
+```
+
+- **50+ content types** detected by extension + magic bytes
+- **200+ attributes** — EXIF, ID3, page counts, video codecs, archive entries, source LOC, binary architectures
+- **CEL** — Google's expression language, declarative, sandboxed, fast
+- **MCP server** — 20 tools so AI agents get the same query surface
+
+<!--
+SCRIPT:
+The pitch fits on one slide. file-search-on runs a CEL expression — CEL
+is Common Expression Language, Google's safe little expression DSL — over
+typed attributes the tool extracts from each file.
+
+So instead of grepping bytes, I write a one-liner that says "is this
+file an image, AND was the ISO above sixteen hundred, AND does it have
+GPS coordinates". That's a real query I run. Or I might ask for PDFs
+over ten pages and over five thousand words — long reads. Or Go source
+files with more than two hundred lines of code.
+
+Under the hood there are about fifty content types — markdown, PDF,
+image, audio, video, office, all the source-code languages, archive
+formats, executables, even disk images and email — and about two
+hundred attributes you can filter and sort on. Roughly anything you'd
+get out of EXIF, ID3, file headers, you can put in your where-clause.
+
+And it also runs as a Model Context Protocol server, so AI agents like
+Claude Code get exactly the same surface through twenty MCP tools. That
+last part is the bit that excited me most, and I'll come back to it.
+-->
+
+---
+
+## Demo 1 — touring a Go codebase
+
+The corpus is the file-search-on repo itself — dogfooding.
+
+**1. Parse `go.mod` — module + Go version**
+
+```sh
+file-search-on attrs ~/Code/Personal/file-search-on/go.mod
+```
+
+**2. Top-5 largest Go files by LOC**
+
+```sh
+file-search-on -d ~/Code/Personal/file-search-on \
+  'is_source && language == "go" && loc > 300' \
+  --sort loc --order desc --limit 5
+```
+
+**3. TODO / FIXME in production Go (skip test fixtures)**
+
+```sh
+file-search-on find-matches '//\s*(TODO|FIXME)\b' \
+  --expr 'is_source && language == "go" && !is_test_file' \
+  -C 1 --prune-build-artefacts \
+  -d ~/Code/Personal/file-search-on
+```
+
+<!--
+SCRIPT:
+First demo — touring a Go codebase. I'm pointing file-search-on at its
+own source tree, which is about ten thousand lines of Go. Three
+commands.
+
+[run: file-search-on attrs ~/Code/Personal/file-search-on/go.mod]
+
+First — the `attrs` subcommand on go.mod. file-search-on detects this
+file as a Go module manifest, parses it, and surfaces the module name
+and the required Go version. Five lines of output, no flags, just a
+path. That `manifest/gomod` content type is one of about fifty the tool
+recognises.
+
+This is the vocabulary I write queries in, and the point is: it's the
+tool telling me what's queryable, not docs that drift.
+
+[run: top-5 Go files by LOC]
+
+Second — top five Go files in the repo by lines of code. CEL expression
+filters to Go source over three hundred lines; sort_by loc descending;
+limit five. The biggest files come back. Notice what's NOT there: no
+language-specific tooling, no "if Go then count LOC" code in the
+command. The content-type detector identifies each file as Go, the LOC
+counter runs as part of the attribute pass, and CEL sorts on the
+attribute name. Same surface I'd use for a Python or Rust codebase.
+
+[run: find-matches TODO/FIXME with !is_test_file]
+
+Third — every TODO and FIXME comment in production Go source. The
+pattern is a regex matching slash-slash optionally followed by
+TODO-or-FIXME. The pre-filter is is_source and language equals go AND
+NOT is_test_file. The is_test_file predicate is true for any source
+file matching the per-language test convention — *_test.go in Go,
+test_*.py in Python, and so on. With the dash-C-one flag, we get one
+line of context above and below each match.
+
+[pause for the result]
+
+Zero hits. The codebase has no actual TODOs in production code. If I
+drop the !is_test_file filter, ten matches come back — all in
+*_test.go files, all of them string fixtures for the find-matches tests
+themselves. Which is itself a fun bit of recursion: a tool that finds
+TODOs has TODO strings in its tests for the TODO-finding tests. But
+that's the kind of distinction the is_test_file predicate makes easy.
+-->
+
+---
+
+## Demo 2 — semantic search over a docs folder
+
+12 short technical notes in `~/Documents/semantic-demo/`. Find the
+right document when the query *paraphrases* the file.
+
+**Plain English query — no keyword overlap with the matching file**
+
+```sh
+file-search-on search -d ~/Documents/semantic-demo \
+  --semantic-query "container orchestration deployment strategies" \
+  --embedding-model nomic-embed-text --similarity-threshold 0.50
+```
+
+→ `k8s-scheduling.md`. None of those words appear in the file:
+
+```sh
+grep -rli 'orchestration\|container\|deployment strateg' ~/Documents/semantic-demo
+# (nothing)
+```
+
+**A second query — warm cache, sub-second**
+
+```sh
+file-search-on search -d ~/Documents/semantic-demo \
+  --semantic-query "what happens when two writers update the same record" \
+  --embedding-model nomic-embed-text --similarity-threshold 0.50
+```
+
+→ `transaction-isolation.md`.
+
+<!--
+SCRIPT:
+Demo two — semantic search.
+
+The corpus is twelve short technical notes I dropped in
+~/Documents/semantic-demo. Things like an incident post-mortem, a Go
+GC tuning note, a Mongo migration write-up, kubernetes pod scheduling,
+TLS handshake, transaction isolation. Real-shaped writing, eight
+hundred to a thousand bytes each.
+
+[run: the kubernetes query]
+
+The query is "container orchestration deployment strategies". Watch:
+file-search-on returns k8s-scheduling.md. Here's the trick.
+
+[run: the grep command]
+
+That same query phrasing — "container", "orchestration", "deployment
+strategies" — appears NOWHERE in any file in the corpus. Grep returns
+nothing. Zero matches. The k8s-scheduling.md file is talking about
+node selectors, affinity rules, taints and tolerations. None of the
+query words appear in it.
+
+Semantic search found it because the EMBEDDING vector of the document
+sits close to the embedding vector of the query. That's the entire
+point of semantic search versus keyword search: similarity in meaning
+space, not character space.
+
+[run: the transaction query]
+
+Second query — "what happens when two writers update the same record".
+That's a question, not a search term. The top hit is
+transaction-isolation.md, which is exactly the file talking about
+READ COMMITTED, REPEATABLE READ, SERIALIZABLE, and what postgres does
+when two transactions touch the same row. Again, no overlap between
+the question words and the matching document.
+
+A few notes on the stack. The embeddings come from a local Ollama
+instance running the nomic-embed-text model. No cloud, no API keys, no
+data leaving your laptop. The embeddings cache per file by size and
+mtime, so the first walk does the work — about a second and a half
+for these twelve documents — and every subsequent query is sub-second.
+And the similarity score is exposed as a CEL variable so you can
+compose it with the rest of the query — "is_pdf AND similarity is
+above zero point seven" works.
+
+This isn't a separate product mode. It's a flag on the existing
+search tool.
+-->
+
+---
+
+## Demo 3 — the South Africa photo corpus
+
+This morning I curated 66 geotagged South African photos from Wikimedia Commons.
+
+**Histogram by camera**
+
+```sh
+file-search-on stats -d ~/Pictures/south-africa-holiday \
+  'is_image' --group-by camera_make
+```
+
+**Bounding box — central Cape Town (rectangle) → 5 photos**
+
+```sh
+file-search-on -d ~/Pictures/south-africa-holiday \
+  'is_image && gps_lat > -33.96 && gps_lat < -33.7
+            && gps_lon >  18.3 && gps_lon <  18.7'
+```
+
+**Polygon — the Cape Peninsula (any shape) → 12 photos**
+
+```sh
+file-search-on -d ~/Pictures/south-africa-holiday \
+  'is_image && point_in_polygon(gps_lat, gps_lon,
+       [-33.85, 18.30,  -33.85, 18.55,
+        -34.15, 18.55,  -34.40, 18.50,
+        -34.40, 18.32])'
+```
+
+<!--
+SCRIPT:
+Demo three — photos. This is where typed search really pays off.
+
+A bit of context: I built a small test corpus this morning of geotagged
+South African photos. Sixty-six images, all Creative Commons, all with
+GPS coordinates in EXIF. I'll talk about how I built it in a minute.
+
+[run: file-search-on stats -d ... 'is_image' --group-by camera_make]
+
+First command — bucket the photos by camera make. Canon's the biggest
+group, then Sony, then Panasonic. Notice nobody asked me to install an
+EXIF parser or write a histogram function. The stats subcommand takes a
+group_by attribute, runs through the corpus, and prints the histogram.
+
+[run: the GPS-bbox query]
+
+Second command — a bounding box around central Cape Town. Four greater-
+thans and less-thans on lat and lon. Five photos come back — the shots
+taken inside that rectangle.
+
+[run: the polygon query]
+
+Third command — same idea, but with `point_in_polygon`. The Cape
+Peninsula is a narrow finger pointing south from Cape Town. Cape Point
+and the Cape of Good Hope sit right at the southern tip — well below
+where any sensible Cape Town bbox would stop. If I expand the bbox to
+catch them, I also catch Stellenbosch and the winelands which I don't
+want. A polygon resolves that — I give it five vertices that hug the
+peninsula's shape and twelve photos come back, including the seven Cape
+Point and Cape of Good Hope shots the bbox missed.
+
+The polygon is a flat list of latitude-longitude pairs — no GeoJSON
+wrapper, no library to import. It's the same `is_image` predicate plus
+one more function call.
+
+The point: I went from "I have photos" to "I have photos taken on the
+Cape Peninsula" in three short commands. No SQL, no GIS library, no
+script.
+-->
+
+---
+
+## Demo 4 — text inside images (OCR)
+
+A separate corpus of synthetic text-bearing JPGs in
+`~/Pictures/ocr-demo/`: error screenshots, receipts, signs, meeting
+notes, code, posters.
+
+**Cold pass — 12 images, OCR'd by macOS Vision (~2.5s wall-clock)**
+
+```sh
+file-search-on search --ocr --index-path /tmp/ocr.db \
+  -d ~/Pictures/ocr-demo \
+  'is_image && body.contains("ERROR")'
+```
+
+**Warm pass — cache hit, sub-second**
+
+```sh
+file-search-on search --ocr --index-path /tmp/ocr.db \
+  -d ~/Pictures/ocr-demo \
+  'is_image && body.matches("(?i)\\b(invoice|total)\\b")'
+```
+
+```sh
+file-search-on search --ocr --index-path /tmp/ocr.db \
+  -d ~/Pictures/ocr-demo \
+  'is_image && body.contains("Athena")'
+```
+
+<!--
+SCRIPT:
+Demo four — text inside images. This is one of the most useful little
+features I've shipped, and it didn't exist three months ago.
+
+The corpus is a folder of twelve synthetic JPGs I generated with
+ImageMagick — terminal error screenshots, receipts, invoices, road
+signs, meeting notes, conference slides, code snapshots. Reproducible
+from a script, no real-world data. About 35 kB per image.
+
+[run: first query — `body.contains("ERROR")`]
+
+First command. The `--ocr` flag tells file-search-on to run macOS Vision
+over every image file as it walks. The query is is_image AND body
+contains "ERROR". That's the *recognized text* of each image. Watch the
+elapsed time — about two and a half seconds for twelve images, because
+the OCR is happening cold for the first time. Two hits — the terminal
+error screenshot and the log entry.
+
+The footer at the bottom is interesting: "index: 0 hits, 12 misses, 12
+stored". The on-disk cache is now populated.
+
+[run: second query — invoice|total regex]
+
+Second command. Same flags, different filter — a case-insensitive regex
+matching the words "invoice" or "total" on word boundaries. Watch the
+timing. [pause] Thirty milliseconds. The OCR results were cached from
+the previous walk, so we just replayed the matcher against the body
+strings. Twelve cache hits, zero misses, sub-second.
+
+The hits are the receipt, the invoice, and the printed email — that
+third one mentions "invoice 2026-0042" in the body, so it's a legit
+match, not a false positive.
+
+[run: third query — Athena]
+
+One more — a project codename, "Athena", lives only in the meeting
+notes image. One hit, instant.
+
+The point: OCR is expensive — point five to two seconds per image — but
+file-search-on caches the recognised text alongside the file's size
+and mtime. Touch the file, you re-OCR. Don't touch it, you don't.
+Useful for screenshots-as-knowledge-base workflows, scanned receipts,
+slide decks, design mockups — anything where the searchable signal is
+in the pixels, not the bytes.
+
+Caveat: today this runs on macOS Vision only. Linux Tesseract and the
+Windows Media OCR bridge are on the roadmap as drop-in providers, and
+I'll cover that on the open-issues slide.
+-->
+
+---
+
+## Demo 5 — finding visually similar photos
+
+Perceptual hash (pHash) — a 64-bit fingerprint per image. Hamming
+distance ≤ a few bits means the eye sees the same thing.
+
+**One reference photo, find its visual neighbours**
+
+```sh
+file-search-on search \
+  -d ~/Pictures/south-africa-holiday \
+  "is_image && image_similar_to(phash, \
+     '~/Pictures/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg', \
+     0.60)"
+```
+
+8 hits — the reference plus four Mossel Bay coastal shots, a Drakensberg
+landscape, a Knysna outdoor scene, a Plettenberg dune. All wide-frame
+nature shots; the function clusters by *visual layout*, not by EXIF tag
+or filename.
+
+`image_similar_to` auto-enables `--with-phash`, so you don't have to
+remember the flag. Threshold is a similarity score; 0.85 ≈ near-duplicate
+frame, 0.60 ≈ "same kind of scene".
+
+<!--
+SCRIPT:
+Demo five — visual similarity.
+
+This is where file-search-on stops being a "metadata filter" and starts
+being something closer to an image search engine. Watch.
+
+[run the command]
+
+The query says: "is_image AND image_similar_to of phash, this reference
+file, threshold zero point six". The image_similar_to function is a
+built-in. It computes a sixty-four-bit perceptual hash of each photo as
+the walk runs, and compares it to the reference photo's hash by Hamming
+distance.
+
+Eight hits come back. The first is the reference itself — every photo
+is perceptually identical to itself. Then four shots from Mossel Bay,
+all wide-frame coastal landscapes. A Drakensberg mountain shot. A
+Knysna outdoor scene. A Plettenberg dune. None of these have anything
+in common in their filenames, EXIF, or paths — the perceptual hash is
+clustering them by *visual layout*. Wide horizon, lots of sky or water.
+
+A couple of quality-of-life notes worth mentioning. First, I don't have
+to pass --with-phash on the CLI. The tool sees the function reference
+in my CEL expression and turns the flag on automatically. Second, the
+threshold maps to a similarity score, not a Hamming distance. Zero
+point eight five and up gets you near-duplicate frames — the same
+photo re-encoded, screenshots-of-screenshots. Zero point six is what I
+just ran — "same kind of scene". Anything below zero point five
+basically returns most of the corpus.
+
+The point: a content-type-aware search engine should be able to ask
+the question "show me photos that look like this one". With one
+function call in your CEL expression, file-search-on can.
+-->
+
+---
+
+## Demo 6 — an AI agent driving it via MCP
+
+```sh
+file-search-on mcp   # serves MCP over stdio
+```
+
+The same query surface — `search`, `stats`, `find_duplicates`,
+`diff_trees`, `find_matches`, `search_semantic`, `watch_search` … —
+is exposed as 20 MCP tools.
+
+**Live**: in Claude Code, ask:
+
+> "I love this Cape Point shot. Find me other photos in
+> `~/Pictures/south-africa-holiday` that are visually in the same style —
+> coastal scenes, similar composition. Use a loose threshold; I want
+> scene resemblance, not byte-identical duplicates."
+
+The agent picks `search` with `with_phash: true` and an
+`image_similar_to(phash, "<cape-point-path>", 0.60)` CEL filter, sorted
+by similarity. Returns ~8 coastal / landscape shots — the same cluster
+the CLI demo just showed.
+
+<!--
+SCRIPT:
+Last demo — agents.
+
+[switch to Claude Code window]
+
+file-search-on also runs as a Model Context Protocol server. Same query
+language, same content-type detection, but exposed as twenty tools an AI
+agent can call. Stuff like search, stats, diff_trees, find_matches, even
+semantic search through local embeddings.
+
+I'll paste a question into Claude Code. [paste the question on screen]
+
+"I love this Cape Point shot. Find me other photos in the
+south-africa-holiday folder that are visually in the same style —
+coastal scenes, similar composition. Use a loose threshold; I want
+scene resemblance, not byte-identical duplicates."
+
+Watch the tool calls in the timeline. Claude picks the `search` tool
+with `with_phash` turned on and an `image_similar_to` function in the
+CEL filter — exactly the same surface I just ran on the CLI in the
+previous demo, but now selected by the agent from the natural-language
+question. The "loose threshold" wording in my question nudges it down
+to around point six, matching the cluster from Demo 5. Then it sorts
+by similarity score and returns the same eight coastal shots. One tool
+call, one prose answer.
+
+The point I want to underline is: I didn't write a prompt template, I
+didn't tell Claude to use perceptual hashing, I didn't tell it which
+CEL function to call. The tool descriptions are good enough that the
+agent picks the right approach itself.
+
+And critically — this is NOT a sha256 hash check. Sha256 only finds
+byte-identical files, which for photos is almost never useful — every
+re-export or re-encode changes the bytes. Perceptual hashing catches
+near-duplicates even when the bytes are completely different. That's
+the kind of typed-attribute reasoning that's basically impossible with
+find and grep.
+-->
+
+---
+
+## Under the hood
+
+- **Go 1.26**, ~10k LOC
+- **cel-go** — Google's CEL implementation
+- **Content-type plugin registry** — each type self-registers in `init()`
+- **Detection**: exact-name → extension → magic-byte (512 B prefix)
+- **Pluggable extras** — OCR (macOS Vision), perceptual hashes, EXIF, Dublin Core
+- **Index cache** keyed by `(size, mtime)` — bbolt on disk or in-memory
+- **20-tool MCP server** built on the Go SDK, plus a localhost dashboard
+- Released via **GoReleaser + ko + Homebrew tap**
+
+<!--
+SCRIPT:
+Thirty seconds on what's inside.
+
+It's Go, about ten thousand lines, leaning on cel-go for the expression
+engine. The interesting design choice is the content-type registry —
+every file format is a Go file under internal/content that implements a
+four-method interface and self-registers. Adding a new format is one
+file plus, if it has new attributes, four corresponding edits to the CEL
+schema.
+
+Detection is three layers: exact filename match — package.json,
+Dockerfile, go.mod — falls through to extension, falls through to magic
+bytes on the first five hundred and twelve.
+
+There's an optional cache so you don't re-parse unchanged files. There's
+the MCP server I just demoed. Releases ship via GoReleaser, ko for the
+container image, and a Homebrew tap.
+
+Build steps are documented in CLAUDE.md if you want to dig in.
+-->
+
+---
+
+## What surprised me
+
+- **CEL is dramatically underused** outside of Google Cloud — it's
+  sandboxed, fast, declarative, and lets non-Go users extend queries
+  without a recompile.
+- **MCP changed the framing**. Once the same tools are available to a
+  human at a CLI *and* to an AI agent over a wire protocol, the surface
+  area you have to design becomes one surface, not two.
+- **Fuzz testing earned its keep** — five-minute nightly runs against
+  hand-rolled binary parsers (MP3 ID3, MP4 box walker, MKV EBML) caught
+  real panics on real files.
+
+<!--
+SCRIPT:
+A few things that surprised me building this.
+
+First — CEL is shockingly underused outside the Google ecosystem. It's
+sandboxed, it's fast, it lets non-Go contributors write filters without
+touching the source. If you're building any kind of policy or query
+engine, look at it.
+
+Second — the MCP angle reframed the design. Once the same query
+surface is exposed to a human at the CLI and to an agent through MCP, I
+stopped designing two interfaces and started designing one. That made
+the codebase simpler, not more complex.
+
+And — this isn't strictly surprising but worth noting — fuzz tests on
+the hand-rolled binary parsers have caught real bugs. I run them
+nightly for five minutes each. Cheap, high signal.
+-->
+
+---
+
+## Open issues
+
+- **OCR is Darwin-only** today — macOS Vision. Linux Tesseract + Windows
+  Media OCR bridges are on the roadmap (`#189`).
+- **Semantic search needs Ollama** running locally — works great when
+  it's there, fails clearly when it isn't. A hosted-embedding fallback is
+  in design.
+- **Browser-history content type** — Chromium / Safari bookmarks ship,
+  but History DBs don't. Wants a SQLite content-type extension.
+- **Watch is bounded** — `watch_search` returns after a window. An
+  unbounded streaming MCP transport is sketched but not built.
+- **Windows path semantics** — works, but the dashboard's localhost
+  registry uses `XDG_CACHE_HOME` first; Windows path conventions need a
+  pass.
+
+Track on **github.com/richardwooding/file-search-on/issues**.
+
+<!--
+SCRIPT:
+A few things I haven't solved yet, in case you're curious or want to
+contribute.
+
+OCR is Mac-only. I built against the macOS Vision framework because
+it's free and ships in the OS. Tesseract on Linux and Windows Media OCR
+are obvious follow-ups but I haven't done them. Issue 189.
+
+Semantic search runs through Ollama on localhost. That's deliberate — I
+don't want to ship anything that calls out to a hosted service by
+default — but if Ollama isn't installed, semantic just fails loudly. A
+sane fallback story is on the list.
+
+I'd love a browser-history content type. Chromium and Safari bookmarks
+work today; the SQLite history databases don't.
+
+Watch is currently bounded — you give it a duration and it returns when
+the window closes. Streaming over MCP is a design problem I haven't
+finished.
+
+And Windows works but the dashboard's cross-process registry leans on
+XDG conventions. Needs a portability pass.
+
+Everything's tracked on GitHub.
+-->
+
+---
+
+<!-- _class: lead -->
+
+## Summary
+
+`file-search-on`: typed CEL search for files, with first-class agent access.
+
+```sh
+brew install richardwooding/tap/file-search-on
+file-search-on --help
+file-search-on mcp     # add to claude_desktop_config.json
+```
+
+**github.com/richardwooding/file-search-on**
+
+Open to contributors. Questions?
+
+<!--
+SCRIPT:
+Wrapping up.
+
+file-search-on is content-type-aware file search. Write a CEL expression
+over typed attributes, get back paths plus structured metadata. Same
+surface for humans on the CLI and AI agents through MCP.
+
+It's on the homebrew tap if you want to try it — that command line at
+the top. The GitHub repo has install instructions for other platforms,
+plus an examples directory with thirty or forty recipes if you want to
+see what's possible.
+
+I'm open to contributors — there's a CONTRIBUTING file with the
+conventions, and I'm responsive on issues.
+
+That's me. Thanks for the time. Happy to take questions.
+-->

--- a/slides/deck.md
+++ b/slides/deck.md
@@ -6,14 +6,33 @@ size: 16:9
 title: file-search-on
 author: Richard Wooding
 style: |
+  /* SPAN Digital brand palette (per Span Handbook brand platform +
+     revealjs-presentation framework). */
+  :root {
+    --span-orange: #F7941D;
+    --span-cream:  #FFF5E6;
+    --span-dark:   #333333;
+    --span-gray:   #4A4A4A;
+  }
   section {
+    background: var(--span-cream);
+    color: var(--span-dark);
     font-size: 26px;
     padding: 50px 60px;
     line-height: 1.4;
+    border-right: 20px solid var(--span-orange);
   }
-  section h1 { font-size: 56px; }
-  section h2 { font-size: 36px; margin-bottom: 0.35em; }
-  section h3 { font-size: 28px; }
+  section h1 { font-size: 56px; color: var(--span-dark); }
+  section h2 {
+    font-size: 36px;
+    margin-bottom: 0.35em;
+    color: var(--span-dark);
+    border-bottom: 3px solid var(--span-orange);
+    padding-bottom: 0.12em;
+  }
+  section h3 { font-size: 28px; color: var(--span-dark); }
+  strong { color: var(--span-orange); }
+  a { color: var(--span-orange); }
   pre, code {
     font-size: 17px;
     line-height: 1.35;
@@ -21,14 +40,42 @@ style: |
   pre {
     padding: 0.6em 0.8em;
     margin: 0.4em 0;
+    background: #fdfaf3;
+    border-left: 3px solid var(--span-orange);
   }
+  code { color: var(--span-dark); }
   table { font-size: 22px; }
+  th {
+    background: var(--span-orange);
+    color: white;
+  }
   th, td { padding: 0.3em 0.6em; }
   ul, ol { margin: 0.3em 0; }
   li { margin: 0.15em 0; }
-  blockquote { font-size: 24px; margin: 0.4em 0; }
-  section.lead { font-size: 32px; }
-  section.lead h1 { font-size: 72px; }
+  blockquote {
+    font-size: 24px;
+    margin: 0.4em 0;
+    border-left: 4px solid var(--span-orange);
+    padding-left: 0.8em;
+    color: var(--span-gray);
+  }
+  /* Title slide — no stripe, larger type, orange title. */
+  section.lead {
+    font-size: 32px;
+    border-right: none;
+  }
+  section.lead h1 {
+    font-size: 72px;
+    color: var(--span-orange);
+  }
+  /* Thank-you / summary slide — no stripe, orange heading. */
+  section.thank-you {
+    border-right: none;
+  }
+  section.thank-you h2 {
+    color: var(--span-orange);
+    border-bottom: none;
+  }
 ---
 
 <!-- _class: lead -->
@@ -56,16 +103,16 @@ anything on screen is hard to read.
 
 ## Who I am
 
-- Staff engineer at Span Digital — we build content and dev tooling
+- Staff engineer at Span Digital — we take on the complex technical challenges that demand real expertise
 - I scratch my own itches in Go
 - Background: search, indexing, content systems
 - Today's project lives at **github.com/richardwooding/file-search-on**
 
 <!--
 SCRIPT:
-Quick "who am I" — I'm a staff engineer at Span Digital, where we work
-on content platforms and developer tooling. I write Go for fun and for
-work.
+Quick "who am I" — I'm a staff engineer at Span Digital, where we take
+on the complex technical challenges that demand real expertise. I write
+Go for fun and for work.
 
 Most of my projects start the same way: I have a question I want to ask
 of my filesystem, my tools won't answer it cleanly, and I get annoyed
@@ -729,7 +776,7 @@ Everything's tracked on GitHub.
 
 ---
 
-<!-- _class: lead -->
+<!-- _class: thank-you -->
 
 ## Summary
 

--- a/slides/demo.doitlive.sh
+++ b/slides/demo.doitlive.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Demo script for the file-search-on talk.
+# Each block matches a slide; run them in order, NOT in one shot.
+# Suggested workflow: keep this file open in a second pane and
+# copy-paste each block as the talk progresses. If you want a "type
+# for me" presenter tool, doitlive or demo-magic.sh both work.
+
+set -eu
+
+# ---------------------------------------------------------------------------
+# Demo 1, command 1 — attrs on the repo's go.mod (manifest/gomod content
+# type — surfaces module name + go_version).
+# ---------------------------------------------------------------------------
+file-search-on attrs ~/Code/Personal/file-search-on/go.mod
+
+# ---------------------------------------------------------------------------
+# Demo 1, command 2 — top-5 Go source files by LOC across the repo.
+# ---------------------------------------------------------------------------
+file-search-on search -d ~/Code/Personal/file-search-on \\
+  'is_source && language == "go" && loc > 300' \\
+  --sort loc --order desc --limit 5
+
+# ---------------------------------------------------------------------------
+# Demo 1, command 3 — TODO / FIXME comments in PRODUCTION Go source.
+# The `!is_test_file` predicate excludes *_test.go fixture strings.
+# Expected: 0 matches (this codebase has no real TODOs in prod). Drop
+# the `!is_test_file` filter to see ~10 fixture hits in test files.
+# ---------------------------------------------------------------------------
+file-search-on find-matches '//\\s*(TODO|FIXME)\\b' \\
+  --expr 'is_source && language == "go" && !is_test_file' \\
+  -C 1 --prune-build-artefacts \\
+  -d ~/Code/Personal/file-search-on
+
+# ---------------------------------------------------------------------------
+# Demo 2, prep — build the semantic-search corpus once (12 markdown notes):
+#   ./scripts/build_semantic_corpus.sh
+# Requires Ollama running locally with the nomic-embed-text model pulled:
+#   ollama pull nomic-embed-text
+#
+# Wipe the embedding cache between rehearsals to keep the cold/warm
+# story honest:
+#   rm -f /tmp/semantic.db
+# ---------------------------------------------------------------------------
+
+# Demo 2, command 1 — natural-language query. The matching file
+# (k8s-scheduling.md) contains none of the query words. ~1.5s cold.
+file-search-on search -d ~/Documents/semantic-demo \\
+  --semantic-query "container orchestration deployment strategies" \\
+  --embedding-model nomic-embed-text \\
+  --similarity-threshold 0.50 --limit 5 \\
+  --index-path /tmp/semantic.db
+
+# Demo 2, punchline — confirm with grep that NONE of those words appear
+# in any file. Use BSD grep (default on macOS). Expected output: empty.
+grep -rli 'orchestration\\|container\\|deployment strateg' ~/Documents/semantic-demo
+
+# Demo 2, command 2 — second semantic query, warm (~90ms). Top hit is
+# transaction-isolation.md, found by meaning not keyword.
+file-search-on search -d ~/Documents/semantic-demo \\
+  --semantic-query "what happens when two writers update the same record" \\
+  --embedding-model nomic-embed-text \\
+  --similarity-threshold 0.50 --limit 5 \\
+  --index-path /tmp/semantic.db
+
+# ---------------------------------------------------------------------------
+# Demo 3, command 1 — photos by camera_make
+# ---------------------------------------------------------------------------
+file-search-on stats -d ~/Pictures/south-africa-holiday \\
+  'is_image' --group-by camera_make
+
+# ---------------------------------------------------------------------------
+# Demo 3, command 2 — photos inside a Cape Town bounding box (rectangle)
+# Expected hits: ~5 on the curated corpus (central CT only).
+# ---------------------------------------------------------------------------
+file-search-on -d ~/Pictures/south-africa-holiday \\
+  'is_image && gps_lat > -33.96 && gps_lat < -33.7 && gps_lon > 18.3 && gps_lon < 18.7'
+
+# ---------------------------------------------------------------------------
+# Demo 3, command 3 — photos inside the Cape Peninsula polygon
+# (the narrow finger pointing south from Cape Town through Cape Point).
+# Polygon vertices (clockwise from NW): Atlantic Seaboard, Table Bay,
+# False Bay coast, Cape Point, Cape of Good Hope. Expected hits: ~12,
+# including the 7 Cape Point / Boulders Beach shots the bbox misses.
+# ---------------------------------------------------------------------------
+file-search-on -d ~/Pictures/south-africa-holiday \\
+  'is_image && point_in_polygon(gps_lat, gps_lon,
+       [-33.85, 18.30,  -33.85, 18.55,
+        -34.15, 18.55,  -34.40, 18.50,
+        -34.40, 18.32])'
+
+# ---------------------------------------------------------------------------
+# Demo 4, prep — build the OCR corpus once (synthetic JPGs with text):
+#   ./scripts/build_ocr_corpus.sh
+# This drops 12 images in ~/Pictures/ocr-demo/. Run any time the corpus
+# gets nuked; rebuilds are idempotent.
+#
+# Wipe the persistent index between rehearsals to keep the cold/warm
+# story honest:
+#   rm -f /tmp/ocr.db
+# ---------------------------------------------------------------------------
+
+# Demo 4, command 1 — COLD pass: OCR runs over all 12 images. ~2.5s.
+# Expected hits: 2 (error_terminal.jpg, log_entry.jpg).
+# The footer line "index: 0 hits, 12 misses, 12 stored" proves OCR ran.
+file-search-on search --ocr --index-path /tmp/ocr.db \\
+  -d ~/Pictures/ocr-demo \\
+  'is_image && body.contains("ERROR")'
+
+# Demo 4, command 2 — WARM pass: cache hit. <50ms.
+# Expected hits: 3 (receipt.jpg, invoice.jpg, printed_email.jpg — the
+# email mentions "invoice 2026-0042" so it's a legit hit, not noise).
+file-search-on search --ocr --index-path /tmp/ocr.db \\
+  -d ~/Pictures/ocr-demo \\
+  'is_image && body.matches("(?i)\\b(invoice|total)\\b")'
+
+# Demo 4, command 3 — WARM pass: another sub-second query against the
+# same cached body strings. Expected hits: 1 (meeting_notes.jpg).
+file-search-on search --ocr --index-path /tmp/ocr.db \\
+  -d ~/Pictures/ocr-demo \\
+  'is_image && body.contains("Athena")'
+
+# ---------------------------------------------------------------------------
+# Demo 5 — visual similarity by perceptual hash.
+# `image_similar_to` auto-enables --with-phash, so the flag is optional.
+# Threshold 0.60 was tuned against the 66-photo corpus: returns the
+# reference photo + ~7 visually-similar wide-frame outdoor shots.
+# Cold pass ~2.5s (phash compute for all 66 images); cached for subsequent
+# runs (if you reuse --index-path).
+# ---------------------------------------------------------------------------
+file-search-on search \\
+  -d ~/Pictures/south-africa-holiday \\
+  "is_image && image_similar_to(phash, \\
+     '$HOME/Pictures/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg', \\
+     0.60)"
+
+# ---------------------------------------------------------------------------
+# Demo 6 — the MCP server. Launch in one terminal; talk to it from another.
+# In Claude Desktop / Code, register this as a stdio MCP server.
+# ---------------------------------------------------------------------------
+# file-search-on mcp
+#
+# Question to paste into the agent UI:
+#   "I love this Cape Point shot:
+#    ~/Pictures/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg
+#    Find me other photos in ~/Pictures/south-africa-holiday that are
+#    visually in the same style — coastal scenes, similar composition.
+#    Use a loose threshold; I want scene resemblance, not byte-identical
+#    duplicates."
+#
+# Expected agent move: a single `search` call with `with_phash: true` and an
+# `image_similar_to(phash, "<cape-point-path>", ~0.60)` CEL filter, sorted
+# by similarity. Same surface Demo 5 just ran on the CLI — the punchline
+# is that the agent picked it from natural language, not from a prompt
+# template.
+#
+# Why a moderate threshold: at 0.85+ (the tool description's default) you
+# get near-duplicates only, which this 66-photo corpus doesn't really have.
+# At 0.60 you get ~8 coastal / landscape shots that visually cluster.
+# Anything below 0.50 returns most of the corpus. The "loose threshold"
+# wording in the question nudges the agent away from the 0.85 default.

--- a/slides/demo.sh
+++ b/slides/demo.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Demo script for the file-search-on talk.
+# Each block matches a slide; run them in order, NOT in one shot.
+# Suggested workflow: keep this file open in a second pane and
+# copy-paste each block as the talk progresses. If you want a "type
+# for me" presenter tool, doitlive or demo-magic.sh both work.
+
+set -eu
+
+# ---------------------------------------------------------------------------
+# Demo 1, command 1 — attrs on the repo's go.mod (manifest/gomod content
+# type — surfaces module name + go_version).
+# ---------------------------------------------------------------------------
+file-search-on attrs ~/Code/Personal/file-search-on/go.mod
+
+# ---------------------------------------------------------------------------
+# Demo 1, command 2 — top-5 Go source files by LOC across the repo.
+# ---------------------------------------------------------------------------
+file-search-on search -d ~/Code/Personal/file-search-on \
+  'is_source && language == "go" && loc > 300' \
+  --sort loc --order desc --limit 5
+
+# ---------------------------------------------------------------------------
+# Demo 1, command 3 — TODO / FIXME comments in PRODUCTION Go source.
+# The `!is_test_file` predicate excludes *_test.go fixture strings.
+# Expected: 0 matches (this codebase has no real TODOs in prod). Drop
+# the `!is_test_file` filter to see ~10 fixture hits in test files.
+# ---------------------------------------------------------------------------
+file-search-on find-matches '//\s*(TODO|FIXME)\b' \
+  --expr 'is_source && language == "go" && !is_test_file' \
+  -C 1 --prune-build-artefacts \
+  -d ~/Code/Personal/file-search-on
+
+# ---------------------------------------------------------------------------
+# Demo 2, prep — build the semantic-search corpus once (12 markdown notes):
+#   ./scripts/build_semantic_corpus.sh
+# Requires Ollama running locally with the nomic-embed-text model pulled:
+#   ollama pull nomic-embed-text
+#
+# Wipe the embedding cache between rehearsals to keep the cold/warm
+# story honest:
+#   rm -f /tmp/semantic.db
+# ---------------------------------------------------------------------------
+
+# Demo 2, command 1 — natural-language query. The matching file
+# (k8s-scheduling.md) contains none of the query words. ~1.5s cold.
+file-search-on search -d ~/Documents/semantic-demo \
+  --semantic-query "container orchestration deployment strategies" \
+  --embedding-model nomic-embed-text \
+  --similarity-threshold 0.50 --limit 5 \
+  --index-path /tmp/semantic.db
+
+# Demo 2, punchline — confirm with grep that NONE of those words appear
+# in any file. Use BSD grep (default on macOS). Expected output: empty.
+grep -rli 'orchestration\|container\|deployment strateg' ~/Documents/semantic-demo
+
+# Demo 2, command 2 — second semantic query, warm (~90ms). Top hit is
+# transaction-isolation.md, found by meaning not keyword.
+file-search-on search -d ~/Documents/semantic-demo \
+  --semantic-query "what happens when two writers update the same record" \
+  --embedding-model nomic-embed-text \
+  --similarity-threshold 0.50 --limit 5 \
+  --index-path /tmp/semantic.db
+
+# ---------------------------------------------------------------------------
+# Demo 3, command 1 — photos by camera_make
+# ---------------------------------------------------------------------------
+file-search-on stats -d ~/Pictures/south-africa-holiday \
+  'is_image' --group-by camera_make
+
+# ---------------------------------------------------------------------------
+# Demo 3, command 2 — photos inside a Cape Town bounding box (rectangle)
+# Expected hits: ~5 on the curated corpus (central CT only).
+# ---------------------------------------------------------------------------
+file-search-on -d ~/Pictures/south-africa-holiday \
+  'is_image && gps_lat > -33.96 && gps_lat < -33.7 && gps_lon > 18.3 && gps_lon < 18.7'
+
+# ---------------------------------------------------------------------------
+# Demo 3, command 3 — photos inside the Cape Peninsula polygon
+# (the narrow finger pointing south from Cape Town through Cape Point).
+# Polygon vertices (clockwise from NW): Atlantic Seaboard, Table Bay,
+# False Bay coast, Cape Point, Cape of Good Hope. Expected hits: ~12,
+# including the 7 Cape Point / Boulders Beach shots the bbox misses.
+# ---------------------------------------------------------------------------
+file-search-on -d ~/Pictures/south-africa-holiday \
+  'is_image && point_in_polygon(gps_lat, gps_lon,
+       [-33.85, 18.30,  -33.85, 18.55,
+        -34.15, 18.55,  -34.40, 18.50,
+        -34.40, 18.32])'
+
+# ---------------------------------------------------------------------------
+# Demo 4, prep — build the OCR corpus once (synthetic JPGs with text):
+#   ./scripts/build_ocr_corpus.sh
+# This drops 12 images in ~/Pictures/ocr-demo/. Run any time the corpus
+# gets nuked; rebuilds are idempotent.
+#
+# Wipe the persistent index between rehearsals to keep the cold/warm
+# story honest:
+#   rm -f /tmp/ocr.db
+# ---------------------------------------------------------------------------
+
+# Demo 4, command 1 — COLD pass: OCR runs over all 12 images. ~2.5s.
+# Expected hits: 2 (error_terminal.jpg, log_entry.jpg).
+# The footer line "index: 0 hits, 12 misses, 12 stored" proves OCR ran.
+file-search-on search --ocr --index-path /tmp/ocr.db \
+  -d ~/Pictures/ocr-demo \
+  'is_image && body.contains("ERROR")'
+
+# Demo 4, command 2 — WARM pass: cache hit. <50ms.
+# Expected hits: 3 (receipt.jpg, invoice.jpg, printed_email.jpg — the
+# email mentions "invoice 2026-0042" so it's a legit hit, not noise).
+file-search-on search --ocr --index-path /tmp/ocr.db \
+  -d ~/Pictures/ocr-demo \
+  'is_image && body.matches("(?i)\b(invoice|total)\b")'
+
+# Demo 4, command 3 — WARM pass: another sub-second query against the
+# same cached body strings. Expected hits: 1 (meeting_notes.jpg).
+file-search-on search --ocr --index-path /tmp/ocr.db \
+  -d ~/Pictures/ocr-demo \
+  'is_image && body.contains("Athena")'
+
+# ---------------------------------------------------------------------------
+# Demo 5 — visual similarity by perceptual hash.
+# `image_similar_to` auto-enables --with-phash, so the flag is optional.
+# Threshold 0.60 was tuned against the 66-photo corpus: returns the
+# reference photo + ~7 visually-similar wide-frame outdoor shots.
+# Cold pass ~2.5s (phash compute for all 66 images); cached for subsequent
+# runs (if you reuse --index-path).
+# ---------------------------------------------------------------------------
+file-search-on search \
+  -d ~/Pictures/south-africa-holiday \
+  "is_image && image_similar_to(phash, \
+     '$HOME/Pictures/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg', \
+     0.60)"
+
+# ---------------------------------------------------------------------------
+# Demo 6 — the MCP server. Launch in one terminal; talk to it from another.
+# In Claude Desktop / Code, register this as a stdio MCP server.
+# ---------------------------------------------------------------------------
+# file-search-on mcp
+#
+# Question to paste into the agent UI:
+#   "I love this Cape Point shot:
+#    ~/Pictures/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg
+#    Find me other photos in ~/Pictures/south-africa-holiday that are
+#    visually in the same style — coastal scenes, similar composition.
+#    Use a loose threshold; I want scene resemblance, not byte-identical
+#    duplicates."
+#
+# Expected agent move: a single `search` call with `with_phash: true` and an
+# `image_similar_to(phash, "<cape-point-path>", ~0.60)` CEL filter, sorted
+# by similarity. Same surface Demo 5 just ran on the CLI — the punchline
+# is that the agent picked it from natural language, not from a prompt
+# template.
+#
+# Why a moderate threshold: at 0.85+ (the tool description's default) you
+# get near-duplicates only, which this 66-photo corpus doesn't really have.
+# At 0.60 you get ~8 coastal / landscape shots that visually cluster.
+# Anything below 0.50 returns most of the corpus. The "loose threshold"
+# wording in the question nudges the agent away from the 0.85 default.

--- a/slides/scripts/build_ocr_corpus.sh
+++ b/slides/scripts/build_ocr_corpus.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Generate the OCR demo corpus.
+#
+# Produces 12 synthetic text-bearing JPGs in ~/Pictures/ocr-demo/ using
+# ImageMagick. No real screenshots or private content. Re-runnable;
+# overwrites in place.
+#
+# Why JPG and not PNG: file-search-on's image_similar_to / EXIF / OCR
+# pipeline detects JPEGs uniformly via the `image/jpeg` content type,
+# matching the existing south-africa-holiday corpus.
+
+set -euo pipefail
+
+DEST="${HOME}/Pictures/ocr-demo"
+mkdir -p "$DEST"
+
+# Pick a monospace + a sans-serif font that ship with macOS. ImageMagick
+# on Homebrew can't resolve font names without a fontconfig file, so we
+# point at the .ttc files directly. Bold is selected via the SAME .ttc
+# with -weight 700 (Helvetica.ttc is a collection containing Bold).
+MONO="/System/Library/Fonts/Menlo.ttc"
+SANS="/System/Library/Fonts/Helvetica.ttc"
+BOLD="/System/Library/Fonts/Helvetica.ttc"
+
+# Helper: render a multi-line caption onto a coloured rectangle, save as
+# JPG. Args: filename bg-colour fg-colour font pointsize text(literal \n).
+render() {
+  local out="$1" bg="$2" fg="$3" font="$4" size="$5" text="$6"
+  convert -size 1200x800 "xc:${bg}" \
+    -font "$font" -pointsize "$size" -fill "$fg" \
+    -gravity center -annotate +0+0 "$text" \
+    -quality 88 "${DEST}/${out}"
+}
+
+# 1. Terminal error — "ERROR ... Connection refused ..."
+render error_terminal.jpg black "#5fff5f" "$MONO" 36 \
+  "ERROR: Connection refused
+at db.internal:5432
+retry attempt 3/5"
+
+# 2. Log entry — also contains "ERROR" but in different formatting
+render log_entry.jpg white black "$MONO" 28 \
+  "[2026-05-28 09:14:32] ERROR
+worker.go:47
+timeout exceeded after 30s"
+
+# 3. Receipt — "TOTAL"
+render receipt.jpg "#fafafa" black "$SANS" 38 \
+  "Pick n Pay
+Greenpoint Mall
+
+2 x bread       R 24.99
+1 x milk        R 18.50
+1 x rooibos tea R 84.01
+
+TOTAL: R 127.50"
+
+# 4. Invoice — "INVOICE"
+render invoice.jpg white black "$SANS" 44 \
+  "INVOICE
+Number: 2026-0042
+Due: 2026-06-15
+Amount: ZAR 8,450.00
+
+Span Digital (Pty) Ltd"
+
+# 5. Welcome sign — "WELCOME TO CAPE TOWN"
+render welcome_sign.jpg "#f5c518" black "$BOLD" 90 \
+  "WELCOME TO
+CAPE TOWN"
+
+# 6. Meeting notes — "Athena" (the unique-keyword test)
+render meeting_notes.jpg white black "$SANS" 38 \
+  "MEETING NOTES
+
+Project Athena Q3
+
+Action items:
+1. Migrate primary DB
+2. Update onboarding docs
+3. Audit feature flags"
+
+# 7. Meetup poster — pretty colour, big text
+render meetup_poster.jpg "#5b2a86" white "$BOLD" 72 \
+  "GoLang Meetup
+
+Thursday 7pm
+The Workshop, Salt River
+
+RSVP on meetup.com"
+
+# 8. Road sign — "JOHANNESBURG" / "DURBAN"
+render road_sign.jpg "#117030" white "$BOLD" 70 \
+  "N1 -> JOHANNESBURG
+N2 -> DURBAN"
+
+# 9. Whiteboard — bullets
+render whiteboard.jpg "#fdf6e3" "#222222" "$SANS" 40 \
+  "Decisions
+
+- Adopt OpenTelemetry
+- Defer GraphQL migration
+- Postpone Q4 launch
+- Hire 2 SRE engineers"
+
+# 10. Conference slide — "Why CEL?"
+render conf_slide.jpg white black "$SANS" 44 \
+  "Why CEL?
+
+- Sandboxed
+- Fast
+- Declarative
+
+Used by GCP, Kubernetes, Istio"
+
+# 11. Printed email
+render printed_email.jpg white black "$SANS" 32 \
+  "From: alice@example.com
+To: bob@example.com
+Subject: Urgent payment overdue
+
+Dear Bob,
+Please remit invoice 2026-0042
+by Friday or interest applies."
+
+# 12. Code screenshot — Go panic
+render code_screenshot.jpg "#1e1e1e" "#dcdcdc" "$MONO" 32 \
+  "func main() {
+    err := db.Connect()
+    if err != nil {
+        log.Fatal(err)
+    }
+    panic(\"unreachable\")
+}"
+
+ls -lh "$DEST"/*.jpg | awk '{print $9, $5}'
+echo "[done] $(ls "$DEST"/*.jpg | wc -l | tr -d ' ') images in $DEST"

--- a/slides/scripts/build_semantic_corpus.sh
+++ b/slides/scripts/build_semantic_corpus.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Build the semantic-search demo corpus in ~/Documents/semantic-demo.
+#
+# Twelve short markdown notes on distinct technical topics. None of the
+# query phrases the demo uses appear verbatim in the matching file's
+# body — that's the whole point of semantic search vs grep.
+#
+# Re-runnable; overwrites in place.
+
+set -euo pipefail
+
+DEST="${HOME}/Documents/semantic-demo"
+mkdir -p "$DEST"
+
+# --- 1. database outage post-mortem ------------------------------------
+cat > "$DEST/incident-2024-q3.md" <<'EOF'
+# What went wrong on the night of 2024-09-14
+
+At 23:47 UTC the primary started rejecting connections. The on-call
+engineer paged within ninety seconds and we declared a Sev-1 at 23:51.
+
+Root cause: a runaway analytical query had exhausted the connection
+pool. The query had been added three days earlier as part of a
+reporting endpoint; nobody had tested it at production scale.
+
+Detection was slower than it should have been because our alerting
+keyed off CPU rather than wait events. The reporting endpoint kept
+serving slow responses without tripping the threshold; only when the
+pool saturated did pager fire.
+
+Mitigation: we killed the offending query and rotated the credential.
+Service recovered by 00:23. The reporting endpoint was rolled back the
+next morning.
+
+Action items: connection-pool-saturation alert, statement timeout on
+the read-only role, and a load test before any new endpoint ships.
+EOF
+
+# --- 2. kubernetes pod scheduling --------------------------------------
+cat > "$DEST/k8s-scheduling.md" <<'EOF'
+# Pod placement controls
+
+Three knobs decide where a pod lands.
+
+**Node selectors** are the simplest — a flat label match. Use them
+when you want a workload pinned to a specific hardware class
+(GPU nodes, SSD nodes, that one machine with the FPGA).
+
+**Affinity rules** are richer. A pod can prefer (soft) or require
+(hard) co-location with another pod, or anti-co-location to spread
+replicas across zones. Anti-affinity is how you stop the scheduler
+from cramming three replicas of the same deployment onto one node and
+then losing them all when the node reboots.
+
+**Taints and tolerations** invert the relationship: the node refuses
+to accept pods that don't carry the matching toleration. Use them for
+nodes that have a side effect — paid licences, security zones,
+specialty hardware that costs real money per pod-hour.
+EOF
+
+# --- 3. database transaction isolation ---------------------------------
+cat > "$DEST/transaction-isolation.md" <<'EOF'
+# What happens when two writers touch the same row
+
+Postgres defaults to READ COMMITTED. Each statement sees a snapshot
+taken at statement start, so two transactions can each read the same
+row, modify it, and last-write-wins.
+
+REPEATABLE READ pins the snapshot to transaction start. Now if
+transaction A reads a row that transaction B has updated and
+committed, A sees the old value. Phantom reads are still possible —
+inserts by other transactions show up.
+
+SERIALIZABLE is what most people mean when they say "isolated".
+Postgres implements it with predicate locks plus an abort-on-conflict
+strategy. If two transactions interleave in a way that couldn't have
+arisen from any serial order, one of them gets thrown out and has to
+retry.
+
+The level you want is almost always SERIALIZABLE for anything
+touching money. The cost is conflict-retry traffic under contention.
+EOF
+
+# --- 4. TLS handshake --------------------------------------------------
+cat > "$DEST/tls-1.3.md" <<'EOF'
+# Setting up an encrypted channel
+
+The 1.3 handshake collapses to one round trip. ClientHello carries
+the supported cipher suites, the supported groups, and a key share
+for whichever group the client is most optimistic about. ServerHello
+echoes the chosen suite and a matching key share.
+
+Once both sides have the shared secret, the rest of the handshake is
+encrypted — the certificate, the verify, the finished message. That's
+the big departure from 1.2, where the certificate was in the clear
+and an on-path observer could see who you were talking to.
+
+Session resumption uses pre-shared keys derived from the previous
+session. A client can attach early data ("0-RTT") to the first
+message, with the caveat that 0-RTT data isn't forward-secret and is
+replayable, so it should only carry idempotent requests.
+EOF
+
+# --- 5. GC pauses ------------------------------------------------------
+cat > "$DEST/gc-tuning.md" <<'EOF'
+# Stop-the-world latency in Go services
+
+The Go runtime's collector is concurrent for most of its work but
+still needs brief stop-the-world phases — marking roots and finalising
+the mark phase. Modern releases have squeezed these into sub-millisecond
+intervals on small heaps; on heaps over 20 GB you start seeing tens of
+milliseconds, which is enough to matter for tail-latency-sensitive
+endpoints.
+
+The biggest lever for hot paths is allocation rate. Every megabyte you
+allocate per second is more work the collector has to do. Pooling
+short-lived buffers via sync.Pool is the simplest fix. Switching from
+interface-typed return values to concrete types removes a heap
+escape. Switching from map of string to map of int when the keys are
+bounded saves a string allocation per lookup.
+
+GOGC controls the trigger ratio. Lower it for less memory at the cost
+of more frequent collection; raise it for fewer cycles at the cost of
+larger working set.
+EOF
+
+# --- 6. moving off MongoDB --------------------------------------------
+cat > "$DEST/why-we-left-mongo.md" <<'EOF'
+# Lessons from migrating a document store
+
+We picked Mongo in 2019 for schema flexibility. The application data
+genuinely was tree-shaped, the team was new to operating databases,
+and the ergonomics of "just shove the JSON in" were attractive.
+
+By 2023 we had three reasons to leave. First, every interesting
+query had grown into an aggregation pipeline that nobody could read.
+Second, our analytics team had given up trying to query the document
+store and was nightly-snapshotting to Postgres anyway. Third, the
+schema HAD stabilised — we were enforcing JSON Schema at the
+application layer, which is the worst of both worlds.
+
+The migration took eleven weeks. The dual-write phase ran for four of
+those. We discovered three bugs that had been silently corrupting the
+Mongo collections for years; the migration script choked on them and
+forced us to actually look. Postgres rejected the broken rows on
+INSERT, which is the kind of "good loud failure" you want.
+EOF
+
+# --- 7. observability / OpenTelemetry ---------------------------------
+cat > "$DEST/tracing.md" <<'EOF'
+# Watching requests cross service boundaries
+
+A trace is a tree of spans. Each span has a parent, a duration, and
+some attributes. Spans propagate across processes via a context
+header — W3C traceparent these days — so the receiving service can
+make its spans children of the caller's.
+
+The two interesting failure modes are sampling and clock skew.
+Sampling: most services can't afford to record every request, so they
+sample with some probability and only the sampled requests show up in
+the trace store. Skew: if two services have clocks that differ by
+more than the request duration, the child span can appear to start
+before its parent. Most viewers paper over this by lying about the
+timestamps.
+
+OpenTelemetry is now the industry's lingua franca — instrumentation
+libraries for every language, a wire format both Jaeger and Tempo
+ingest, vendor backends that pick it up without translation.
+EOF
+
+# --- 8. caching strategies --------------------------------------------
+cat > "$DEST/caching-patterns.md" <<'EOF'
+# Living with stale data
+
+Three patterns cover most of the design space.
+
+Cache-aside: the application checks the cache, falls through to the
+source of truth on miss, writes the result into the cache. Simple,
+but the cache is updated by every reader, which can produce a
+stampede when a popular key expires.
+
+Write-through: writes go to the cache and the source in the same
+operation. The cache is always fresh. The price is that writes are
+slower and a partial failure leaves the two stores disagreeing.
+
+Write-behind: writes go to the cache immediately and to the source
+asynchronously. Writes are fast; reads are warm; durability is the
+worry — if the cache node dies before the async write lands, that
+update is gone.
+
+Whichever you pick, the question of "when does this entry expire" is
+where the real decisions live. Wall-clock TTL is the default but the
+wrong default for anything event-driven.
+EOF
+
+# --- 9. rate limiting --------------------------------------------------
+cat > "$DEST/throttling.md" <<'EOF'
+# Limiting how often a client can call you
+
+The token bucket is the most flexible algorithm. The bucket holds N
+tokens; each request consumes one; tokens refill at a fixed rate.
+Bursts up to N are allowed; the steady-state ceiling is the refill
+rate. Implementations are a few lines if you allow the bucket to be
+fractional.
+
+The leaky bucket inverts the framing: requests enter a queue at any
+rate, the queue drains at the configured rate, and overflow gets
+rejected. Same steady-state behaviour, different burst semantics.
+
+Fixed and sliding windows are easier to reason about for billing
+periods but mishandle the edges. A client that times its calls right
+can get 2N requests in two seconds when the limit is N per second.
+
+For distributed enforcement, the actual hard problem is shared state.
+Each replica seeing its own slice of the traffic will collectively
+over- or under-shoot. Redis with INCR-then-EXPIRE is the usual
+compromise.
+EOF
+
+# --- 10. monorepo vs polyrepo ------------------------------------------
+cat > "$DEST/code-organization.md" <<'EOF'
+# Where to draw repository boundaries
+
+The case for one repo: refactors across components are atomic. The
+build system can dedupe shared dependencies. Search and code review
+work on the obvious unit. Tooling investment pays off everywhere at
+once.
+
+The case for many repos: ownership boundaries are explicit. CI runs
+are smaller. The repo's contents fit in one engineer's head. Open-
+sourcing or selling a piece is a matter of changing a remote URL.
+
+In practice the line is drawn around release cadence. Things that
+ship together belong in one repo. Things that ship on independent
+schedules and have stable API contracts belong apart.
+
+Tooling is the asymmetric multiplier. A monorepo without remote build
+caching, sparse checkouts, and a build-graph-aware CI is a tax on
+every engineer. A polyrepo without dependency-update automation
+collects security alerts faster than anyone can review them.
+EOF
+
+# --- 11. dependency management ----------------------------------------
+cat > "$DEST/dependency-hygiene.md" <<'EOF'
+# Keeping third-party code under control
+
+The first rule is "pin every version". Floating ranges break
+reproducible builds and make compromise surface area unpredictable.
+Lock files exist for a reason; commit them.
+
+The second rule is "audit transitive depth". A direct dependency you
+chose carries an indirect graph you didn't. The 2021 left-pad story
+and every npm supply-chain incident since has been about transitive
+trust, not direct trust.
+
+Automation closes the loop: tools that open a PR per upgrade make the
+review surface small and predictable. The expensive habit is
+batching upgrades for a quarterly cleanup; by then the diff is huge
+and risky and nobody wants to do it.
+EOF
+
+# --- 12. zero-downtime migrations -------------------------------------
+cat > "$DEST/schema-migrations.md" <<'EOF'
+# Changing the shape of a live database without breaking it
+
+The pattern is expand-then-contract. To rename a column from foo to
+bar, you first add bar as a nullable column, then deploy code that
+writes to both foo and bar (with a default-old behaviour on conflict),
+then backfill bar from foo, then deploy code that reads bar, then
+finally drop foo.
+
+It's slower than just rewriting the schema. It's also the only way to
+do it without a maintenance window. Every step is independently
+revertible, which means a bug discovered in step three doesn't require
+unwinding two and one.
+
+The expensive bit is patience. Each step needs to bake — sometimes
+hours, sometimes a release cycle — before the next step is safe. The
+team that tries to compress this into one PR is the team that learns
+why this pattern exists.
+EOF
+
+echo "[done] $(ls "$DEST"/*.md | wc -l | tr -d ' ') markdown files in $DEST"
+ls -lh "$DEST"/*.md | awk '{print $9, $5}'


### PR DESCRIPTION
A self-contained Marp slide deck for a Show-&-Tell talk on file-search-on. ~15 slides covering the end-to-end story; speaker notes inline as HTML comments.

## Demos (all verified live against real corpora before commit)

1. **Touring a Go codebase** — `attrs go.mod` → top-K Go LOC → `find-matches` for TODO/FIXME with the `!is_test_file` predicate as the punchline (production code is genuinely TODO-free; only test fixtures match).
2. **Semantic search over a docs folder** — 12 markdown notes; natural-language query finds `k8s-scheduling.md` from *"container orchestration deployment strategies"* — none of those words appear in any file. Local Ollama + `nomic-embed-text`.
3. **SA photo corpus** — 66 GPS-tagged JPGs; histogram by `camera_make` → bbox query → `point_in_polygon` over the Cape Peninsula (12 hits vs 5 for the bbox, because the peninsula's not a rectangle).
4. **OCR over images** — 12 synthetic text-bearing JPGs; `--ocr` + `body.contains` / `body.matches`. Cold ~2.5s, warm ~30ms (the cache-hit footer counter lands the story).
5. **Visual similarity** — `image_similar_to(phash, ref, 0.60)` finds 8 visually-clustered coastal/landscape shots from a single reference. `--with-phash` auto-enables.
6. **Agent via MCP** — Claude Code picks `search` + `with_phash` + `image_similar_to` from natural language; the same surface Demo 5 just ran.

## Files

- `slides/deck.md` — the Marp deck (~15 slides, frontmatter style block for tight typography that survives projector-back-of-room)
- `slides/demo.sh` — paste-ready demo commands, one block per slide
- `slides/demo.doitlive.sh` — same script with backslashes doubled, for doitlive setups that need it
- `slides/README.md` — render instructions + pre-talk checklist + timing budget (~20-21 min + Q&A)
- `slides/scripts/build_semantic_corpus.sh` — generates `~/Documents/semantic-demo/` (12 markdown notes)
- `slides/scripts/build_ocr_corpus.sh` — generates `~/Pictures/ocr-demo/` (12 synthetic text JPGs via ImageMagick)
- `slides/.gitignore` — keeps Marp render artifacts (`*.html`, `*.pdf`, `*.pptx`) out of git

## Test plan

- [ ] `cd slides && marp deck.md --pdf` produces a clean PDF (no slide overflow)
- [ ] `cd slides && marp -s .` live-preview server renders cleanly with the tighter typography
- [ ] Run each block of `slides/demo.sh` end-to-end against the prepared corpora to confirm hit counts match the speaker-note expectations
- [ ] Confirm Ollama is running with `nomic-embed-text` pulled before rehearsing Demo 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)