### PR TITLE
chore(slides): consolidate demo corpora into ~/Demo/

### DIFF
--- a/slides/README.md
+++ b/slides/README.md
@@ -7,10 +7,10 @@ A Marp deck for a ~15 minute Show-&-Tell talk on `file-search-on`.
 - `deck.md` — the slides. Speaker notes are inline as HTML comments.
 - `demo.sh` — the live commands, one block per demo slide.
 - `scripts/build_semantic_corpus.sh` — generates the Demo 2 corpus
-  (12 markdown notes in `~/Documents/semantic-demo/`). Run once before
+  (12 markdown notes in `~/Demo/semantic-demo/`). Run once before
   the talk.
 - `scripts/build_ocr_corpus.sh` — generates the Demo 4 OCR corpus
-  (12 synthetic text-bearing JPGs in `~/Pictures/ocr-demo/`). Run once
+  (12 synthetic text-bearing JPGs in `~/Demo/ocr-demo/`). Run once
   before the talk. Requires ImageMagick.
 - `README.md` — you are here.
 
@@ -21,7 +21,7 @@ A Marp deck for a ~15 minute Show-&-Tell talk on `file-search-on`.
 3. Make sure Ollama is running: `ollama serve &` (or open the Ollama app).
 4. Build the semantic corpus: `./scripts/build_semantic_corpus.sh`
 5. Build the OCR corpus: `./scripts/build_ocr_corpus.sh`
-6. Confirm the SA photo corpus is still at `~/Pictures/south-africa-holiday/` (66 GPS-tagged JPGs).
+6. Confirm the SA photo corpus is still at `~/Demo/south-africa-holiday/` (66 GPS-tagged JPGs).
 7. `rm -f /tmp/ocr.db /tmp/semantic.db` (wipe the caches so the cold/warm timing demos land).
 8. Have a Claude Code / Claude Desktop window with `file-search-on mcp` registered, sitting on a blank prompt for Demo 6.
 
@@ -61,7 +61,7 @@ its own beat in the talk. Two tips:
 1. Run the talks's terminal at a **bigger font** than your IDE
    (`Cmd-+` ×2 in Terminal.app / iTerm2). The default is unreadable
    from row 5.
-2. Pre-stage the photo corpus (`~/Pictures/south-africa-holiday/`) and
+2. Pre-stage the photo corpus (`~/Demo/south-africa-holiday/`) and
    the file-search-on binary on `PATH` before going live.
 
 ## Timing

--- a/slides/deck.md
+++ b/slides/deck.md
@@ -303,13 +303,13 @@ that's the kind of distinction the is_test_file predicate makes easy.
 
 ## Demo 2 — semantic search over a docs folder
 
-12 short technical notes in `~/Documents/semantic-demo/`. Find the
+12 short technical notes in `~/Demo/semantic-demo/`. Find the
 right document when the query *paraphrases* the file.
 
 **Plain English query — no keyword overlap with the matching file**
 
 ```sh
-file-search-on search -d ~/Documents/semantic-demo \
+file-search-on search -d ~/Demo/semantic-demo \
   --semantic-query "container orchestration deployment strategies" \
   --embedding-model nomic-embed-text --similarity-threshold 0.50
 ```
@@ -317,14 +317,14 @@ file-search-on search -d ~/Documents/semantic-demo \
 → `k8s-scheduling.md`. None of those words appear in the file:
 
 ```sh
-grep -rli 'orchestration\|container\|deployment strateg' ~/Documents/semantic-demo
+grep -rli 'orchestration\|container\|deployment strateg' ~/Demo/semantic-demo
 # (nothing)
 ```
 
 **A second query — warm cache, sub-second**
 
 ```sh
-file-search-on search -d ~/Documents/semantic-demo \
+file-search-on search -d ~/Demo/semantic-demo \
   --semantic-query "what happens when two writers update the same record" \
   --embedding-model nomic-embed-text --similarity-threshold 0.50
 ```
@@ -336,7 +336,7 @@ SCRIPT:
 Demo two — semantic search.
 
 The corpus is twelve short technical notes I dropped in
-~/Documents/semantic-demo. Things like an incident post-mortem, a Go
+~/Demo/semantic-demo. Things like an incident post-mortem, a Go
 GC tuning note, a Mongo migration write-up, kubernetes pod scheduling,
 TLS handshake, transaction isolation. Real-shaped writing, eight
 hundred to a thousand bytes each.
@@ -390,14 +390,14 @@ This morning I curated 66 geotagged South African photos from Wikimedia Commons.
 **Histogram by camera**
 
 ```sh
-file-search-on stats -d ~/Pictures/south-africa-holiday \
+file-search-on stats -d ~/Demo/south-africa-holiday \
   'is_image' --group-by camera_make
 ```
 
 **Bounding box — central Cape Town (rectangle) → 5 photos**
 
 ```sh
-file-search-on -d ~/Pictures/south-africa-holiday \
+file-search-on -d ~/Demo/south-africa-holiday \
   'is_image && gps_lat > -33.96 && gps_lat < -33.7
             && gps_lon >  18.3 && gps_lon <  18.7'
 ```
@@ -405,7 +405,7 @@ file-search-on -d ~/Pictures/south-africa-holiday \
 **Polygon — the Cape Peninsula (any shape) → 12 photos**
 
 ```sh
-file-search-on -d ~/Pictures/south-africa-holiday \
+file-search-on -d ~/Demo/south-africa-holiday \
   'is_image && point_in_polygon(gps_lat, gps_lon,
        [-33.85, 18.30,  -33.85, 18.55,
         -34.15, 18.55,  -34.40, 18.50,
@@ -458,14 +458,14 @@ script.
 ## Demo 4 — text inside images (OCR)
 
 A separate corpus of synthetic text-bearing JPGs in
-`~/Pictures/ocr-demo/`: error screenshots, receipts, signs, meeting
+`~/Demo/ocr-demo/`: error screenshots, receipts, signs, meeting
 notes, code, posters.
 
 **Cold pass — 12 images, OCR'd by macOS Vision (~2.5s wall-clock)**
 
 ```sh
 file-search-on search --ocr --index-path /tmp/ocr.db \
-  -d ~/Pictures/ocr-demo \
+  -d ~/Demo/ocr-demo \
   'is_image && body.contains("ERROR")'
 ```
 
@@ -473,13 +473,13 @@ file-search-on search --ocr --index-path /tmp/ocr.db \
 
 ```sh
 file-search-on search --ocr --index-path /tmp/ocr.db \
-  -d ~/Pictures/ocr-demo \
+  -d ~/Demo/ocr-demo \
   'is_image && body.matches("(?i)\\b(invoice|total)\\b")'
 ```
 
 ```sh
 file-search-on search --ocr --index-path /tmp/ocr.db \
-  -d ~/Pictures/ocr-demo \
+  -d ~/Demo/ocr-demo \
   'is_image && body.contains("Athena")'
 ```
 
@@ -545,9 +545,9 @@ distance ≤ a few bits means the eye sees the same thing.
 
 ```sh
 file-search-on search \
-  -d ~/Pictures/south-africa-holiday \
+  -d ~/Demo/south-africa-holiday \
   "is_image && image_similar_to(phash, \
-     '~/Pictures/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg', \
+     '~/Demo/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg', \
      0.60)"
 ```
 
@@ -611,7 +611,7 @@ is exposed as 20 MCP tools.
 **Live**: in Claude Code, ask:
 
 > "I love this Cape Point shot. Find me other photos in
-> `~/Pictures/south-africa-holiday` that are visually in the same style —
+> `~/Demo/south-africa-holiday` that are visually in the same style —
 > coastal scenes, similar composition. Use a loose threshold; I want
 > scene resemblance, not byte-identical duplicates."
 

--- a/slides/demo.doitlive.sh
+++ b/slides/demo.doitlive.sh
@@ -44,7 +44,7 @@ file-search-on find-matches '//\\s*(TODO|FIXME)\\b' \\
 
 # Demo 2, command 1 — natural-language query. The matching file
 # (k8s-scheduling.md) contains none of the query words. ~1.5s cold.
-file-search-on search -d ~/Documents/semantic-demo \\
+file-search-on search -d ~/Demo/semantic-demo \\
   --semantic-query "container orchestration deployment strategies" \\
   --embedding-model nomic-embed-text \\
   --similarity-threshold 0.50 --limit 5 \\
@@ -52,11 +52,11 @@ file-search-on search -d ~/Documents/semantic-demo \\
 
 # Demo 2, punchline — confirm with grep that NONE of those words appear
 # in any file. Use BSD grep (default on macOS). Expected output: empty.
-grep -rli 'orchestration\\|container\\|deployment strateg' ~/Documents/semantic-demo
+grep -rli 'orchestration\\|container\\|deployment strateg' ~/Demo/semantic-demo
 
 # Demo 2, command 2 — second semantic query, warm (~90ms). Top hit is
 # transaction-isolation.md, found by meaning not keyword.
-file-search-on search -d ~/Documents/semantic-demo \\
+file-search-on search -d ~/Demo/semantic-demo \\
   --semantic-query "what happens when two writers update the same record" \\
   --embedding-model nomic-embed-text \\
   --similarity-threshold 0.50 --limit 5 \\
@@ -65,14 +65,14 @@ file-search-on search -d ~/Documents/semantic-demo \\
 # ---------------------------------------------------------------------------
 # Demo 3, command 1 — photos by camera_make
 # ---------------------------------------------------------------------------
-file-search-on stats -d ~/Pictures/south-africa-holiday \\
+file-search-on stats -d ~/Demo/south-africa-holiday \\
   'is_image' --group-by camera_make
 
 # ---------------------------------------------------------------------------
 # Demo 3, command 2 — photos inside a Cape Town bounding box (rectangle)
 # Expected hits: ~5 on the curated corpus (central CT only).
 # ---------------------------------------------------------------------------
-file-search-on -d ~/Pictures/south-africa-holiday \\
+file-search-on -d ~/Demo/south-africa-holiday \\
   'is_image && gps_lat > -33.96 && gps_lat < -33.7 && gps_lon > 18.3 && gps_lon < 18.7'
 
 # ---------------------------------------------------------------------------
@@ -82,7 +82,7 @@ file-search-on -d ~/Pictures/south-africa-holiday \\
 # False Bay coast, Cape Point, Cape of Good Hope. Expected hits: ~12,
 # including the 7 Cape Point / Boulders Beach shots the bbox misses.
 # ---------------------------------------------------------------------------
-file-search-on -d ~/Pictures/south-africa-holiday \\
+file-search-on -d ~/Demo/south-africa-holiday \\
   'is_image && point_in_polygon(gps_lat, gps_lon,
        [-33.85, 18.30,  -33.85, 18.55,
         -34.15, 18.55,  -34.40, 18.50,
@@ -91,7 +91,7 @@ file-search-on -d ~/Pictures/south-africa-holiday \\
 # ---------------------------------------------------------------------------
 # Demo 4, prep — build the OCR corpus once (synthetic JPGs with text):
 #   ./scripts/build_ocr_corpus.sh
-# This drops 12 images in ~/Pictures/ocr-demo/. Run any time the corpus
+# This drops 12 images in ~/Demo/ocr-demo/. Run any time the corpus
 # gets nuked; rebuilds are idempotent.
 #
 # Wipe the persistent index between rehearsals to keep the cold/warm
@@ -103,20 +103,20 @@ file-search-on -d ~/Pictures/south-africa-holiday \\
 # Expected hits: 2 (error_terminal.jpg, log_entry.jpg).
 # The footer line "index: 0 hits, 12 misses, 12 stored" proves OCR ran.
 file-search-on search --ocr --index-path /tmp/ocr.db \\
-  -d ~/Pictures/ocr-demo \\
+  -d ~/Demo/ocr-demo \\
   'is_image && body.contains("ERROR")'
 
 # Demo 4, command 2 — WARM pass: cache hit. <50ms.
 # Expected hits: 3 (receipt.jpg, invoice.jpg, printed_email.jpg — the
 # email mentions "invoice 2026-0042" so it's a legit hit, not noise).
 file-search-on search --ocr --index-path /tmp/ocr.db \\
-  -d ~/Pictures/ocr-demo \\
+  -d ~/Demo/ocr-demo \\
   'is_image && body.matches("(?i)\\b(invoice|total)\\b")'
 
 # Demo 4, command 3 — WARM pass: another sub-second query against the
 # same cached body strings. Expected hits: 1 (meeting_notes.jpg).
 file-search-on search --ocr --index-path /tmp/ocr.db \\
-  -d ~/Pictures/ocr-demo \\
+  -d ~/Demo/ocr-demo \\
   'is_image && body.contains("Athena")'
 
 # ---------------------------------------------------------------------------
@@ -128,9 +128,9 @@ file-search-on search --ocr --index-path /tmp/ocr.db \\
 # runs (if you reuse --index-path).
 # ---------------------------------------------------------------------------
 file-search-on search \\
-  -d ~/Pictures/south-africa-holiday \\
+  -d ~/Demo/south-africa-holiday \\
   "is_image && image_similar_to(phash, \\
-     '$HOME/Pictures/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg', \\
+     '$HOME/Demo/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg', \\
      0.60)"
 
 # ---------------------------------------------------------------------------
@@ -141,8 +141,8 @@ file-search-on search \\
 #
 # Question to paste into the agent UI:
 #   "I love this Cape Point shot:
-#    ~/Pictures/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg
-#    Find me other photos in ~/Pictures/south-africa-holiday that are
+#    ~/Demo/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg
+#    Find me other photos in ~/Demo/south-africa-holiday that are
 #    visually in the same style — coastal scenes, similar composition.
 #    Use a loose threshold; I want scene resemblance, not byte-identical
 #    duplicates."

--- a/slides/demo.sh
+++ b/slides/demo.sh
@@ -44,7 +44,7 @@ file-search-on find-matches '//\s*(TODO|FIXME)\b' \
 
 # Demo 2, command 1 — natural-language query. The matching file
 # (k8s-scheduling.md) contains none of the query words. ~1.5s cold.
-file-search-on search -d ~/Documents/semantic-demo \
+file-search-on search -d ~/Demo/semantic-demo \
   --semantic-query "container orchestration deployment strategies" \
   --embedding-model nomic-embed-text \
   --similarity-threshold 0.50 --limit 5 \
@@ -52,11 +52,11 @@ file-search-on search -d ~/Documents/semantic-demo \
 
 # Demo 2, punchline — confirm with grep that NONE of those words appear
 # in any file. Use BSD grep (default on macOS). Expected output: empty.
-grep -rli 'orchestration\|container\|deployment strateg' ~/Documents/semantic-demo
+grep -rli 'orchestration\|container\|deployment strateg' ~/Demo/semantic-demo
 
 # Demo 2, command 2 — second semantic query, warm (~90ms). Top hit is
 # transaction-isolation.md, found by meaning not keyword.
-file-search-on search -d ~/Documents/semantic-demo \
+file-search-on search -d ~/Demo/semantic-demo \
   --semantic-query "what happens when two writers update the same record" \
   --embedding-model nomic-embed-text \
   --similarity-threshold 0.50 --limit 5 \
@@ -65,14 +65,14 @@ file-search-on search -d ~/Documents/semantic-demo \
 # ---------------------------------------------------------------------------
 # Demo 3, command 1 — photos by camera_make
 # ---------------------------------------------------------------------------
-file-search-on stats -d ~/Pictures/south-africa-holiday \
+file-search-on stats -d ~/Demo/south-africa-holiday \
   'is_image' --group-by camera_make
 
 # ---------------------------------------------------------------------------
 # Demo 3, command 2 — photos inside a Cape Town bounding box (rectangle)
 # Expected hits: ~5 on the curated corpus (central CT only).
 # ---------------------------------------------------------------------------
-file-search-on -d ~/Pictures/south-africa-holiday \
+file-search-on -d ~/Demo/south-africa-holiday \
   'is_image && gps_lat > -33.96 && gps_lat < -33.7 && gps_lon > 18.3 && gps_lon < 18.7'
 
 # ---------------------------------------------------------------------------
@@ -82,7 +82,7 @@ file-search-on -d ~/Pictures/south-africa-holiday \
 # False Bay coast, Cape Point, Cape of Good Hope. Expected hits: ~12,
 # including the 7 Cape Point / Boulders Beach shots the bbox misses.
 # ---------------------------------------------------------------------------
-file-search-on -d ~/Pictures/south-africa-holiday \
+file-search-on -d ~/Demo/south-africa-holiday \
   'is_image && point_in_polygon(gps_lat, gps_lon,
        [-33.85, 18.30,  -33.85, 18.55,
         -34.15, 18.55,  -34.40, 18.50,
@@ -91,7 +91,7 @@ file-search-on -d ~/Pictures/south-africa-holiday \
 # ---------------------------------------------------------------------------
 # Demo 4, prep — build the OCR corpus once (synthetic JPGs with text):
 #   ./scripts/build_ocr_corpus.sh
-# This drops 12 images in ~/Pictures/ocr-demo/. Run any time the corpus
+# This drops 12 images in ~/Demo/ocr-demo/. Run any time the corpus
 # gets nuked; rebuilds are idempotent.
 #
 # Wipe the persistent index between rehearsals to keep the cold/warm
@@ -103,20 +103,20 @@ file-search-on -d ~/Pictures/south-africa-holiday \
 # Expected hits: 2 (error_terminal.jpg, log_entry.jpg).
 # The footer line "index: 0 hits, 12 misses, 12 stored" proves OCR ran.
 file-search-on search --ocr --index-path /tmp/ocr.db \
-  -d ~/Pictures/ocr-demo \
+  -d ~/Demo/ocr-demo \
   'is_image && body.contains("ERROR")'
 
 # Demo 4, command 2 — WARM pass: cache hit. <50ms.
 # Expected hits: 3 (receipt.jpg, invoice.jpg, printed_email.jpg — the
 # email mentions "invoice 2026-0042" so it's a legit hit, not noise).
 file-search-on search --ocr --index-path /tmp/ocr.db \
-  -d ~/Pictures/ocr-demo \
+  -d ~/Demo/ocr-demo \
   'is_image && body.matches("(?i)\b(invoice|total)\b")'
 
 # Demo 4, command 3 — WARM pass: another sub-second query against the
 # same cached body strings. Expected hits: 1 (meeting_notes.jpg).
 file-search-on search --ocr --index-path /tmp/ocr.db \
-  -d ~/Pictures/ocr-demo \
+  -d ~/Demo/ocr-demo \
   'is_image && body.contains("Athena")'
 
 # ---------------------------------------------------------------------------
@@ -128,9 +128,9 @@ file-search-on search --ocr --index-path /tmp/ocr.db \
 # runs (if you reuse --index-path).
 # ---------------------------------------------------------------------------
 file-search-on search \
-  -d ~/Pictures/south-africa-holiday \
+  -d ~/Demo/south-africa-holiday \
   "is_image && image_similar_to(phash, \
-     '$HOME/Pictures/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg', \
+     '$HOME/Demo/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg', \
      0.60)"
 
 # ---------------------------------------------------------------------------
@@ -141,8 +141,8 @@ file-search-on search \
 #
 # Question to paste into the agent UI:
 #   "I love this Cape Point shot:
-#    ~/Pictures/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg
-#    Find me other photos in ~/Pictures/south-africa-holiday that are
+#    ~/Demo/south-africa-holiday/cape-of-good-hope_Cape_Point_Cape_Town_IMG_20180717_174658.jpg
+#    Find me other photos in ~/Demo/south-africa-holiday that are
 #    visually in the same style — coastal scenes, similar composition.
 #    Use a loose threshold; I want scene resemblance, not byte-identical
 #    duplicates."

--- a/slides/scripts/build_ocr_corpus.sh
+++ b/slides/scripts/build_ocr_corpus.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Generate the OCR demo corpus.
 #
-# Produces 12 synthetic text-bearing JPGs in ~/Pictures/ocr-demo/ using
+# Produces 12 synthetic text-bearing JPGs in ~/Demo/ocr-demo/ using
 # ImageMagick. No real screenshots or private content. Re-runnable;
 # overwrites in place.
 #
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-DEST="${HOME}/Pictures/ocr-demo"
+DEST="${HOME}/Demo/ocr-demo"
 mkdir -p "$DEST"
 
 # Pick a monospace + a sans-serif font that ship with macOS. ImageMagick

--- a/slides/scripts/build_semantic_corpus.sh
+++ b/slides/scripts/build_semantic_corpus.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build the semantic-search demo corpus in ~/Documents/semantic-demo.
+# Build the semantic-search demo corpus in ~/Demo/semantic-demo.
 #
 # Twelve short markdown notes on distinct technical topics. None of the
 # query phrases the demo uses appear verbatim in the matching file's
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-DEST="${HOME}/Documents/semantic-demo"
+DEST="${HOME}/Demo/semantic-demo"
 mkdir -p "$DEST"
 
 # --- 1. database outage post-mortem ------------------------------------


### PR DESCRIPTION
The three demo corpora used by the talk now live under a single \`~/Demo/\` root instead of being scattered across \`~/Pictures/\` and \`~/Documents/\`:

| Before | After |
| --- | --- |
| \`~/Pictures/south-africa-holiday/\` | \`~/Demo/south-africa-holiday/\` |
| \`~/Pictures/ocr-demo/\` | \`~/Demo/ocr-demo/\` |
| \`~/Documents/semantic-demo/\` | \`~/Demo/semantic-demo/\` |

Every reference across \`slides/\` updated in one sweep — slide bodies, speaker notes, both demo.sh variants, the README's pre-talk checklist, and both build scripts' \`DEST\` variables.

## Verified live before commit

- \`file-search-on stats -d ~/Demo/south-africa-holiday 'is_image && gps_lat != 0.0 && gps_lon != 0.0' --group-by camera_make\` → same 13-camera histogram (Canon 15, Sony 12, ...)
- \`file-search-on search --ocr -d ~/Demo/ocr-demo 'is_image && body.contains("ERROR")'\` → expected 2 hits (\`error_terminal\`, \`log_entry\`), cache populated with 12 stored

## Test plan
- [ ] \`cd slides && marp deck.md --pdf\` produces a clean render
- [ ] Walk \`slides/demo.sh\` block-by-block; every command works against \`~/Demo/...\`
- [ ] \`./scripts/build_ocr_corpus.sh\` regenerates into \`~/Demo/ocr-demo/\` (idempotent)
- [ ] \`./scripts/build_semantic_corpus.sh\` regenerates into \`~/Demo/semantic-demo/\` (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)