### PR TITLE
feat(index): default on-disk index at OS cache location, multi-instance safe

### DIFF
--- a/cmd/file-search-on/archive_cmd.go
+++ b/cmd/file-search-on/archive_cmd.go
@@ -20,7 +20,8 @@ type ArchiveContentsCmd struct {
 	Body              bool          `name:"body" help:"Read entry bodies so body.contains() / body.matches() CEL filters fire. Capped at --entry-read-cap. Bypasses the entry-list cache (bodies aren't cached)."`
 	EntryReadCap      int64         `name:"entry-read-cap" default:"0" help:"Cap on per-entry bytes read into memory for detection and body evaluation (bytes). 0 uses the 8 MiB default — enough for typical PDF / DOCX / EPUB / email bodies inside archives. Raise for archives containing huge documents; lower if memory pressure matters on large collections."`
 	MaxEntries        int           `name:"max" default:"0" help:"Cap on entries returned. 0 = unlimited."`
-	IndexPath         string        `name:"index-path" help:"Persistent attribute index file (bbolt). When set, per-archive entry-list cache is consulted before each walk and populated on miss."`
+	IndexPath         string        `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/. The per-archive entry-list cache is consulted before each walk and populated on miss."`
+	NoIndex           bool          `name:"no-index" help:"Disable the on-disk index entirely; use only in-memory caching for the process lifetime."`
 	Timeout           time.Duration `name:"timeout" help:"Maximum walk duration. On expiry the partial set is still printed and the process exits 124."`
 	Output            string        `short:"o" name:"output" enum:"default,json" default:"default" help:"Output format: default (human-readable) | json."`
 }
@@ -34,15 +35,11 @@ func (c *ArchiveContentsCmd) Run(ctx context.Context) error {
 		defer cancel()
 	}
 
-	var idx index.Index
-	if c.IndexPath != "" {
-		var err error
-		idx, err = openIndex(c.IndexPath, index.BodyCacheCap{})
-		if err != nil {
-			return err
-		}
-		defer func() { _ = idx.Close() }()
+	idx, _, err := openIndex(c.IndexPath, c.NoIndex, index.BodyCacheCap{})
+	if err != nil {
+		return err
 	}
+	defer func() { _ = idx.Close() }()
 
 	result, err := search.WalkArchiveEntries(effectiveCtx, c.Archive, search.ArchiveWalkOptions{
 		Expr:              c.Expr,

--- a/cmd/file-search-on/diff_cmd.go
+++ b/cmd/file-search-on/diff_cmd.go
@@ -25,7 +25,8 @@ type DiffCmd struct {
 	Expr string `name:"expr" help:"Optional CEL expression to scope which files are considered in both trees (e.g. 'size > 1000000' or 'is_image'). Defaults to every file."`
 
 	Workers          int           `short:"w" help:"Parallel workers per tree walk." default:"0"`
-	IndexPath        string        `name:"index-path" help:"Persistent attribute index (bbolt). Caches sha256 hashes alongside other attributes; two warm trees diff in seconds."`
+	IndexPath        string        `name:"index-path" help:"Persistent attribute index (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/. Caches sha256 hashes alongside other attributes; two warm trees diff in seconds."`
+	NoIndex          bool          `name:"no-index" help:"Disable the on-disk index entirely; use only in-memory caching for the process lifetime."`
 	Timeout          time.Duration `name:"timeout" help:"Maximum duration. On expiry, the partial result is still printed and the process exits 124."`
 	Exclude          []string      `name:"exclude" help:"Glob pattern matched against file/dir basenames; matches are pruned from both trees. Repeatable."`
 	RespectGitignore bool          `name:"respect-gitignore" help:"Parse a .gitignore at each tree root and skip matching paths."`
@@ -44,15 +45,11 @@ func (c *DiffCmd) Run(ctx context.Context) error {
 		defer cancel()
 	}
 
-	var idx index.Index
-	if c.IndexPath != "" {
-		var err error
-		idx, err = openIndex(c.IndexPath, index.BodyCacheCap{})
-		if err != nil {
-			return err
-		}
-		defer func() { _ = idx.Close() }()
+	idx, _, err := openIndex(c.IndexPath, c.NoIndex, index.BodyCacheCap{})
+	if err != nil {
+		return err
 	}
+	defer func() { _ = idx.Close() }()
 
 	res, err := search.DiffTrees(effectiveCtx, c.TreeA, c.TreeB, search.DiffOp(c.Op), search.Options{
 		Expr:             c.Expr,

--- a/cmd/file-search-on/duplicates_cmd.go
+++ b/cmd/file-search-on/duplicates_cmd.go
@@ -17,7 +17,8 @@ type DuplicatesCmd struct {
 	Expr             string        `arg:"" help:"Optional CEL expression to scope candidates (e.g. 'is_image' for photo dedup). Defaults to every file." optional:""`
 	Workers          int           `short:"w" help:"Parallel workers." default:"0"`
 	MaxLineBytes     int           `short:"L" name:"max-line-bytes" help:"Per-line scanner cap for text/CSV/HTML (bytes). 0 uses the 1 MiB default." default:"0"`
-	IndexPath        string        `name:"index-path" help:"Persistent attribute index file (bbolt). Caches sha256 hashes alongside other attributes; repeat runs on an unchanged tree don't re-read any bytes."`
+	IndexPath        string        `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/. Caches sha256 hashes alongside other attributes; repeat runs on an unchanged tree don't re-read any bytes."`
+	NoIndex          bool          `name:"no-index" help:"Disable the on-disk index entirely; use only in-memory caching for the process lifetime."`
 	Timeout          time.Duration `name:"timeout" help:"Maximum duration. On expiry, the partial result is still printed and the process exits 124."`
 	Exclude          []string      `name:"exclude" help:"Glob pattern matched against file/dir basenames; matches are skipped. Repeatable."`
 	RespectGitignore bool          `name:"respect-gitignore" help:"Parse a .gitignore at each walk root and skip matching paths."`
@@ -40,15 +41,11 @@ func (d *DuplicatesCmd) Run(ctx context.Context) error {
 		defer cancel()
 	}
 
-	var idx index.Index
-	if d.IndexPath != "" {
-		var err error
-		idx, err = openIndex(d.IndexPath, index.BodyCacheCap{})
-		if err != nil {
-			return err
-		}
-		defer func() { _ = idx.Close() }()
+	idx, _, err := openIndex(d.IndexPath, d.NoIndex, index.BodyCacheCap{})
+	if err != nil {
+		return err
 	}
+	defer func() { _ = idx.Close() }()
 
 	dups, err := search.FindDuplicates(effectiveCtx, search.Options{
 		Roots:            d.Dir,

--- a/cmd/file-search-on/find_matches_cmd.go
+++ b/cmd/file-search-on/find_matches_cmd.go
@@ -26,7 +26,8 @@ type FindMatchesCmd struct {
 	RespectGitignore    bool          `name:"respect-gitignore" help:"Parse a .gitignore at each walk root and skip matching paths."`
 	FollowSymlinks      bool          `name:"follow-symlinks" help:"Descend through symbolic links to directories. Off by default."`
 	PruneArtefacts      bool          `name:"prune-build-artefacts" help:"Pre-walk and prune canonical build-artefact basenames (vendor / node_modules / target / __pycache__ / …)."`
-	IndexPath           string        `name:"index-path" help:"Persistent attribute index file (bbolt). Speeds up the walk-stage content-type detection on unchanged files."`
+	IndexPath           string        `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/. Speeds up the walk-stage content-type detection on unchanged files."`
+	NoIndex             bool          `name:"no-index" help:"Disable the on-disk index entirely; use only in-memory caching for the process lifetime."`
 	Timeout             time.Duration `name:"timeout" help:"Maximum duration (Go duration: 30s, 2m). On expiry, partial results are still printed and the process exits 124."`
 	Output              string        `short:"o" name:"output" enum:"default,json" default:"default" help:"Output format: default (grep-style: path:line:text) | json."`
 }
@@ -51,15 +52,11 @@ func (f *FindMatchesCmd) Run(ctx context.Context) error {
 		defer cancel()
 	}
 
-	var idx index.Index
-	if f.IndexPath != "" {
-		var err error
-		idx, err = openIndex(f.IndexPath, index.BodyCacheCap{})
-		if err != nil {
-			return err
-		}
-		defer func() { _ = idx.Close() }()
+	idx, _, err := openIndex(f.IndexPath, f.NoIndex, index.BodyCacheCap{})
+	if err != nil {
+		return err
 	}
+	defer func() { _ = idx.Close() }()
 
 	res, err := search.FindMatches(effectiveCtx, search.Options{
 		Roots:               f.Dir,

--- a/cmd/file-search-on/index_path.go
+++ b/cmd/file-search-on/index_path.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
 
 	"github.com/richardwooding/file-search-on/internal/index"
 )
@@ -125,7 +125,7 @@ func sanitiseBasename(s string) string {
 // the writer lock" sentinel. Used by openIndex to decide between
 // surfacing the error and silently falling back to in-memory.
 func isBoltLockTimeout(err error) bool {
-	return errors.Is(err, bbolt.ErrTimeout)
+	return errors.Is(err, bolterrors.ErrTimeout)
 }
 
 // resolveIndexBackend picks the right index for the given cwd /

--- a/cmd/file-search-on/index_path.go
+++ b/cmd/file-search-on/index_path.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.etcd.io/bbolt"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+)
+
+// indexSubdir is the per-user cache subdirectory for the default
+// on-disk index files. Mirrors the registrySubdir convention used by
+// internal/monitor/registry.go so all of file-search-on's per-user
+// state lives under one parent.
+const indexSubdir = "file-search-on/indexes"
+
+// maxBasenameLen caps the human-readable filename component to keep
+// the resulting path well under typical filesystem limits even when
+// the cwd basename is unusually long.
+const maxBasenameLen = 50
+
+// IndexBackend records which storage mode an index ended up using and
+// why. The CLI surfaces nothing with this directly, but the MCP server
+// passes it to the monitor.Controller so the dashboard and the
+// monitor_info MCP tool can show "this session is in-memory because
+// another instance holds the index" without scraping logs.
+type IndexBackend struct {
+	// Mode is "persistent" when the bbolt file is open, "in-memory"
+	// when the cache is process-lifetime only.
+	Mode string
+	// Path is the absolute file path when Mode == "persistent", empty
+	// otherwise.
+	Path string
+	// Reason is empty for the happy path. When Mode == "in-memory"
+	// because of a fallback or opt-out, this carries the cause:
+	//   - "no_index_flag"   — caller passed --no-index
+	//   - "lock_contention" — another process holds the writer lock
+	Reason string
+}
+
+// IndexBackend mode constants — keep stringly-typed so they pass
+// cleanly through JSON to the dashboard / monitor_info without
+// per-language enum gymnastics.
+const (
+	BackendPersistent = "persistent"
+	BackendInMemory   = "in-memory"
+
+	ReasonNoIndexFlag   = "no_index_flag"
+	ReasonLockContention = "lock_contention"
+)
+
+// defaultIndexPath returns the per-cwd default index file path,
+// creating the parent directory if needed. cwd is the absolute
+// working directory; pass an empty string to use os.Getwd().
+//
+// Path shape: <UserCacheDir>/file-search-on/indexes/<basename>-<sha1[:6]>.db
+//
+// The basename-shorthash compound keeps the filename readable in `ls`
+// while still being collision-free across projects that share a
+// basename (multiple ~/.../foo/ dirs hash to different short codes).
+// The hash is taken over the absolute path so symlinked variants of
+// the same directory map to one file, but plain renames stay
+// isolated.
+func defaultIndexPath(cwd string) (string, error) {
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("getwd: %w", err)
+		}
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", fmt.Errorf("abs %q: %w", cwd, err)
+	}
+	base, err := os.UserCacheDir()
+	if err != nil {
+		base = os.TempDir()
+	}
+	dir := filepath.Join(base, indexSubdir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	sum := sha1.Sum([]byte(abs))
+	shorthash := hex.EncodeToString(sum[:])[:6]
+	bn := sanitiseBasename(filepath.Base(abs))
+	if bn == "" {
+		bn = "root"
+	}
+	return filepath.Join(dir, bn+"-"+shorthash+".db"), nil
+}
+
+// sanitiseBasename produces a filesystem-safe component from an
+// arbitrary directory name. Allowed characters survive verbatim;
+// anything else becomes an underscore. The result is also length-
+// capped to maxBasenameLen so the final filename stays short.
+func sanitiseBasename(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z',
+			r >= 'a' && r <= 'z',
+			r >= '0' && r <= '9',
+			r == '.' || r == '-' || r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	out := b.String()
+	if len(out) > maxBasenameLen {
+		out = out[:maxBasenameLen]
+	}
+	return out
+}
+
+// isBoltLockTimeout reports whether err is bbolt's "couldn't acquire
+// the writer lock" sentinel. Used by openIndex to decide between
+// surfacing the error and silently falling back to in-memory.
+func isBoltLockTimeout(err error) bool {
+	return errors.Is(err, bbolt.ErrTimeout)
+}
+
+// resolveIndexBackend picks the right index for the given cwd /
+// IndexPath / NoIndex inputs, opens it, and returns diagnostic info
+// describing the selection. On lock-timeout fallback, a single-line
+// warning is logged to stderr so the human (or the MCP client's log
+// pane) sees what happened.
+//
+// The signature deliberately fronts the diagnostic info: every caller
+// that runs a dashboard (mcp, watch) needs it; CLI subcommands that
+// don't can simply discard the second return value.
+func resolveIndexBackend(cwd, path string, noIndex bool, bodyCap index.BodyCacheCap) (index.Index, IndexBackend, error) {
+	// Explicit opt-out wins immediately — no path picking, no disk I/O.
+	if noIndex {
+		return index.NewMemory(), IndexBackend{Mode: BackendInMemory, Reason: ReasonNoIndexFlag}, nil
+	}
+	// No explicit path → pick the per-cwd default.
+	if path == "" {
+		var err error
+		path, err = defaultIndexPath(cwd)
+		if err != nil {
+			// Fall back to in-memory rather than erroring out the
+			// process — if the cache dir is unavailable we still
+			// want the tool to work.
+			fmt.Fprintf(os.Stderr, "file-search-on: could not resolve default index path (%v); using in-memory cache\n", err)
+			return index.NewMemory(), IndexBackend{Mode: BackendInMemory, Reason: ReasonLockContention}, nil
+		}
+	}
+	idx, err := index.OpenWith(path, bodyCap)
+	if err == nil {
+		return idx, IndexBackend{Mode: BackendPersistent, Path: path}, nil
+	}
+	if isBoltLockTimeout(err) {
+		fmt.Fprintf(os.Stderr, "file-search-on: index file %s is held by another instance; this session will use in-memory cache (use --no-index to silence this warning)\n", path)
+		return index.NewMemory(), IndexBackend{Mode: BackendInMemory, Reason: ReasonLockContention}, nil
+	}
+	if errors.Is(err, index.ErrSchemaMismatch) {
+		return nil, IndexBackend{}, fmt.Errorf("index file at %s has an incompatible schema; delete it or pass a new --index-path", path)
+	}
+	return nil, IndexBackend{}, fmt.Errorf("open index: %w", err)
+}

--- a/cmd/file-search-on/index_path_test.go
+++ b/cmd/file-search-on/index_path_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+)
+
+// TestDefaultIndexPath_PerCWD locks in the per-cwd path-keying
+// behaviour: distinct working directories produce distinct filenames,
+// the same working directory produces the same filename
+// (deterministic), and same-basename + different-parent directories
+// don't collide because the hash differs.
+func TestDefaultIndexPath_PerCWD(t *testing.T) {
+	t.Parallel()
+
+	a, err := defaultIndexPath("/Users/example/Code/foo")
+	if err != nil {
+		t.Fatalf("defaultIndexPath A: %v", err)
+	}
+	b, err := defaultIndexPath("/Users/example/Code/bar")
+	if err != nil {
+		t.Fatalf("defaultIndexPath B: %v", err)
+	}
+	if a == b {
+		t.Errorf("distinct cwds produced the same path; got %s for both A and B", a)
+	}
+
+	// Deterministic: same input → same output.
+	again, err := defaultIndexPath("/Users/example/Code/foo")
+	if err != nil {
+		t.Fatalf("defaultIndexPath A (2nd call): %v", err)
+	}
+	if again != a {
+		t.Errorf("non-deterministic path for the same cwd: first %s, second %s", a, again)
+	}
+
+	// Same basename, different parent → different paths (hash should
+	// differentiate). This is the "multiple ~/.../foo/ dirs" scenario.
+	c, err := defaultIndexPath("/Users/other/work/foo")
+	if err != nil {
+		t.Fatalf("defaultIndexPath C: %v", err)
+	}
+	if c == a {
+		t.Errorf("same-basename different-parent dirs collided; both → %s", a)
+	}
+	// Both should still mention the basename "foo".
+	if !strings.Contains(filepath.Base(a), "foo") {
+		t.Errorf("basename of %s does not contain 'foo'", a)
+	}
+	if !strings.Contains(filepath.Base(c), "foo") {
+		t.Errorf("basename of %s does not contain 'foo'", c)
+	}
+
+	// File extension must be .db so `ls *.db` finds them.
+	for _, p := range []string{a, b, c} {
+		if !strings.HasSuffix(p, ".db") {
+			t.Errorf("path %s missing .db suffix", p)
+		}
+	}
+}
+
+// TestSanitiseBasename covers the dir-name → filename component
+// transformation: allowed characters survive, anything else becomes
+// underscore, and length is capped.
+func TestSanitiseBasename(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"file-search-on":  "file-search-on",
+		"Hello World":     "Hello_World",
+		"a/b/c":           "a_b_c", // / shouldn't reach this func, but defensive
+		"weird:name?":     "weird_name_",
+		"normal_dir.v2":   "normal_dir.v2",
+		"":                "",
+	}
+	for in, want := range cases {
+		got := sanitiseBasename(in)
+		if got != want {
+			t.Errorf("sanitiseBasename(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// Length cap.
+	long := strings.Repeat("x", maxBasenameLen+20)
+	got := sanitiseBasename(long)
+	if len(got) != maxBasenameLen {
+		t.Errorf("expected sanitiseBasename to cap at %d chars, got %d", maxBasenameLen, len(got))
+	}
+}
+
+// TestResolveIndexBackend_NoIndex confirms that passing noIndex=true
+// short-circuits to an in-memory index with the expected reason,
+// regardless of the path argument.
+func TestResolveIndexBackend_NoIndex(t *testing.T) {
+	t.Parallel()
+	for _, path := range []string{"", "/tmp/should-be-ignored.db"} {
+		idx, backend, err := resolveIndexBackend("", path, true, index.BodyCacheCap{})
+		if err != nil {
+			t.Fatalf("resolveIndexBackend noIndex with path=%q: %v", path, err)
+		}
+		if idx == nil {
+			t.Fatalf("resolveIndexBackend returned nil index for noIndex=true (path=%q)", path)
+		}
+		if backend.Mode != BackendInMemory {
+			t.Errorf("backend.Mode = %q, want %q", backend.Mode, BackendInMemory)
+		}
+		if backend.Reason != ReasonNoIndexFlag {
+			t.Errorf("backend.Reason = %q, want %q", backend.Reason, ReasonNoIndexFlag)
+		}
+		if backend.Path != "" {
+			t.Errorf("backend.Path = %q, want empty (noIndex skips disk)", backend.Path)
+		}
+		_ = idx.Close()
+	}
+}
+
+// TestResolveIndexBackend_ExplicitPath_HappyPath verifies that
+// passing a fresh path opens a persistent bbolt index and reports
+// it as such.
+func TestResolveIndexBackend_ExplicitPath_HappyPath(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "explicit.db")
+	idx, backend, err := resolveIndexBackend("", path, false, index.BodyCacheCap{})
+	if err != nil {
+		t.Fatalf("resolveIndexBackend explicit path: %v", err)
+	}
+	defer idx.Close()
+	if backend.Mode != BackendPersistent {
+		t.Errorf("backend.Mode = %q, want %q", backend.Mode, BackendPersistent)
+	}
+	if backend.Path != path {
+		t.Errorf("backend.Path = %q, want %q", backend.Path, path)
+	}
+	if backend.Reason != "" {
+		t.Errorf("backend.Reason = %q, want empty for happy-path persistent open", backend.Reason)
+	}
+}
+
+// TestResolveIndexBackend_LockContentionFallback simulates two
+// concurrent processes contending for the same bbolt file: the
+// second open hits bbolt.ErrTimeout and openIndex returns an
+// in-memory fallback with the expected reason.
+//
+// Skipped under -short because it waits for the 5-second bbolt
+// timeout to fire.
+func TestResolveIndexBackend_LockContentionFallback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping 5-second lock-contention test in -short mode")
+	}
+	path := filepath.Join(t.TempDir(), "contended.db")
+
+	// First holder.
+	first, _, err := resolveIndexBackend("", path, false, index.BodyCacheCap{})
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	defer first.Close()
+
+	// Second attempt — should fall back to in-memory once bbolt's
+	// internal 5-second flock timeout elapses.
+	second, backend, err := resolveIndexBackend("", path, false, index.BodyCacheCap{})
+	if err != nil {
+		t.Fatalf("second open should not error (fallback expected), got: %v", err)
+	}
+	defer second.Close()
+	if backend.Mode != BackendInMemory {
+		t.Errorf("backend.Mode = %q, want %q (lock-contention fallback)", backend.Mode, BackendInMemory)
+	}
+	if backend.Reason != ReasonLockContention {
+		t.Errorf("backend.Reason = %q, want %q", backend.Reason, ReasonLockContention)
+	}
+}

--- a/cmd/file-search-on/index_path_test.go
+++ b/cmd/file-search-on/index_path_test.go
@@ -125,7 +125,7 @@ func TestResolveIndexBackend_ExplicitPath_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveIndexBackend explicit path: %v", err)
 	}
-	defer idx.Close()
+	defer func() { _ = idx.Close() }()
 	if backend.Mode != BackendPersistent {
 		t.Errorf("backend.Mode = %q, want %q", backend.Mode, BackendPersistent)
 	}
@@ -155,7 +155,7 @@ func TestResolveIndexBackend_LockContentionFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first open: %v", err)
 	}
-	defer first.Close()
+	defer func() { _ = first.Close() }()
 
 	// Second attempt — should fall back to in-memory once bbolt's
 	// internal 5-second flock timeout elapses.
@@ -163,7 +163,7 @@ func TestResolveIndexBackend_LockContentionFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second open should not error (fallback expected), got: %v", err)
 	}
-	defer second.Close()
+	defer func() { _ = second.Close() }()
 	if backend.Mode != BackendInMemory {
 		t.Errorf("backend.Mode = %q, want %q (lock-contention fallback)", backend.Mode, BackendInMemory)
 	}

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -71,27 +71,25 @@ var CLI struct {
 	Version         kong.VersionFlag   `short:"V" help:"Print version and exit."`
 }
 
-// openIndex returns an index.Index for the given path. Empty path
-// means in-memory only. On schema mismatch it surfaces a helpful
-// "delete or re-point --index-path" message rather than a raw error.
+// openIndex returns an index.Index honouring the new
+// default-on-disk behaviour. With noIndex=false and path=="", the
+// per-cwd default file is used (see defaultIndexPath). With
+// noIndex=true OR a lock-timeout from another running instance, the
+// caller transparently falls back to in-memory.
+//
+// On schema mismatch it surfaces a helpful "delete or re-point" error.
 //
 // bodyCap controls the body-cache total-size cap and opt-out for the
 // bodies_v1 bucket. Zero-value uses defaults (256 MiB cap, body cache
 // enabled). Subcommands that don't expose body-cache flags pass the
-// zero value; SearchCmd threads its --body-cache-max-bytes / --no-body-cache
-// through.
-func openIndex(path string, bodyCap index.BodyCacheCap) (index.Index, error) {
-	if path == "" {
-		return index.NewMemory(), nil
-	}
-	idx, err := index.OpenWith(path, bodyCap)
-	if err != nil {
-		if errors.Is(err, index.ErrSchemaMismatch) {
-			return nil, fmt.Errorf("index file at %s has an incompatible schema; delete it or pass a new --index-path", path)
-		}
-		return nil, fmt.Errorf("open index: %w", err)
-	}
-	return idx, nil
+// zero value.
+//
+// The IndexBackend return carries diagnostic info (which backend was
+// chosen and why) — used by mcp_cmd / watch_cmd to feed the dashboard
+// + monitor_info MCP tool. CLI subcommands without a dashboard can
+// discard it.
+func openIndex(path string, noIndex bool, bodyCap index.BodyCacheCap) (index.Index, IndexBackend, error) {
+	return resolveIndexBackend("", path, noIndex, bodyCap)
 }
 
 func main() {

--- a/cmd/file-search-on/mcp_cmd.go
+++ b/cmd/file-search-on/mcp_cmd.go
@@ -15,7 +15,8 @@ type MCPCmd struct {
 	Transport         string        `name:"transport" enum:"stdio,http,sse" default:"stdio" help:"Transport: stdio (default; for desktop clients), http (Streamable HTTP, MCP 2025-03-26), or sse (DEPRECATED — HTTP+SSE, MCP 2024-11-05)."`
 	Addr              string        `name:"addr" default:":8080" help:"host:port to bind for http or sse transports. Ignored for stdio."`
 	Path              string        `name:"path" default:"/" help:"URL path prefix the handler is mounted at. Ignored for stdio."`
-	IndexPath         string        `name:"index-path" help:"Persistent attribute index file (bbolt). When unset the server uses an in-memory cache that lives for the process lifetime; setting this makes the cache survive restarts. The file is created on first use."`
+	IndexPath         string        `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/<basename>-<sha1[:6]>.db. The file is created on first use."`
+	NoIndex           bool          `name:"no-index" help:"Disable the on-disk index entirely; use only the in-memory cache for the process lifetime. Useful when another file-search-on instance already holds the writer lock on the default index file, or for hermetic CI / one-shot runs."`
 	BodyCacheMaxBytes int           `name:"body-cache-max-bytes" default:"268435456" help:"Total size cap (bytes) for the body cache inside the bbolt index file. Default 256 MiB. FIFO eviction by access time once exceeded. Only relevant when --index-path is set; in-memory indexes have no cap."`
 	NoBodyCache       bool          `name:"no-body-cache" help:"Disable the body cache. LookupBody always misses; PutBody is a no-op. Bodies are re-extracted on every include_body query."`
 	EmbeddingServer   string        `name:"embedding-server" env:"OLLAMA_HOST" default:"http://localhost:11434" help:"Default Ollama base URL for the search_semantic tool. Resolution order: --embedding-server flag > $OLLAMA_HOST env var > http://localhost:11434. Per-call 'embedding_server' input still overrides. Lazy connect — server starts without Ollama running; search_semantic fails clearly on first call if Ollama is unreachable."`
@@ -26,7 +27,7 @@ type MCPCmd struct {
 }
 
 func (m *MCPCmd) Run(ctx context.Context) error {
-	idx, err := openIndex(m.IndexPath, index.BodyCacheCap{MaxBytes: int64(m.BodyCacheMaxBytes), Disable: m.NoBodyCache})
+	idx, backend, err := openIndex(m.IndexPath, m.NoIndex, index.BodyCacheCap{MaxBytes: int64(m.BodyCacheMaxBytes), Disable: m.NoBodyCache})
 	if err != nil {
 		return err
 	}
@@ -53,7 +54,7 @@ func (m *MCPCmd) Run(ctx context.Context) error {
 	// via the monitor_info MCP tool.
 	collector := monitor.NewCollector()
 	bodyCap := int64(0)
-	if m.IndexPath != "" && !m.NoBodyCache {
+	if backend.Mode == BackendPersistent && !m.NoBodyCache {
 		bodyCap = int64(m.BodyCacheMaxBytes)
 	}
 	monAddr := m.MonitorAddr // fixed port wins
@@ -61,14 +62,16 @@ func (m *MCPCmd) Run(ctx context.Context) error {
 		monAddr = ":0" // dynamic, OS-assigned
 	}
 	controller := monitor.NewController(ctx, monitor.Config{
-		Version:      version,
-		Mode:         "mcp-" + m.Transport,
-		Index:        idx,
-		Collector:    collector,
-		EmbedServer:  m.EmbeddingServer,
-		EmbedModel:   m.EmbeddingModel,
-		IndexPath:    m.IndexPath,
-		BodyCacheCap: bodyCap,
+		Version:             version,
+		Mode:                "mcp-" + m.Transport,
+		Index:               idx,
+		Collector:           collector,
+		EmbedServer:         m.EmbeddingServer,
+		EmbedModel:          m.EmbeddingModel,
+		IndexPath:           backend.Path,
+		IndexBackend:        backend.Mode,
+		IndexFallbackReason: backend.Reason,
+		BodyCacheCap:        bodyCap,
 	}, addrOrDynamic(monAddr))
 	// Drain the dashboard (and deregister from the peer registry) before
 	// the index closes. Registered before cancelMonitor so, by LIFO,

--- a/cmd/file-search-on/near_duplicates_cmd.go
+++ b/cmd/file-search-on/near_duplicates_cmd.go
@@ -19,7 +19,8 @@ type NearDuplicatesCmd struct {
 	Workers          int           `short:"w" help:"Parallel workers. 0 = runtime.NumCPU()." default:"0"`
 	MaxLineBytes     int           `short:"L" name:"max-line-bytes" help:"Per-line scanner cap (bytes). 0 uses the 1 MiB default." default:"0"`
 	BodyMaxBytes     int           `name:"body-max-bytes" default:"0" help:"Cap on the body read per file in bytes. 0 uses the 1 MiB default. Files larger than the cap are silently truncated; the prefix still participates in the fingerprint."`
-	IndexPath        string        `name:"index-path" help:"Persistent attribute index file (bbolt). Caches the per-file SimHash fingerprint; repeat runs on an unchanged tree skip the body read AND the SimHash compute."`
+	IndexPath        string        `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/. Caches the per-file SimHash fingerprint; repeat runs on an unchanged tree skip the body read AND the SimHash compute."`
+	NoIndex          bool          `name:"no-index" help:"Disable the on-disk index entirely; use only in-memory caching for the process lifetime."`
 	Timeout          time.Duration `name:"timeout" help:"Maximum duration. On expiry, the partial result is still printed and the process exits 124."`
 	Exclude          []string      `name:"exclude" help:"Glob pattern matched against file/dir basenames; matches are skipped. Repeatable."`
 	RespectGitignore bool          `name:"respect-gitignore" help:"Parse a .gitignore at each walk root and skip matching paths."`
@@ -42,15 +43,11 @@ func (n *NearDuplicatesCmd) Run(ctx context.Context) error {
 		defer cancel()
 	}
 
-	var idx index.Index
-	if n.IndexPath != "" {
-		var err error
-		idx, err = openIndex(n.IndexPath, index.BodyCacheCap{})
-		if err != nil {
-			return err
-		}
-		defer func() { _ = idx.Close() }()
+	idx, _, err := openIndex(n.IndexPath, n.NoIndex, index.BodyCacheCap{})
+	if err != nil {
+		return err
 	}
+	defer func() { _ = idx.Close() }()
 
 	dups, err := search.FindNearDuplicates(effectiveCtx, search.Options{
 		Roots:               n.Dir,

--- a/cmd/file-search-on/organize_cmd.go
+++ b/cmd/file-search-on/organize_cmd.go
@@ -36,7 +36,8 @@ type OrganizeCmd struct {
 	OnConflict string `name:"on-conflict" enum:"skip,overwrite,number" default:"skip" help:"What to do when the target path already exists: skip (leave it, default) | overwrite (replace) | number (append ' (1)', ' (2)', … before the extension)."`
 
 	Workers          int      `short:"w" name:"workers" default:"0" help:"Parallel walker workers. 0 = NumCPU."`
-	IndexPath        string   `name:"index-path" help:"Persistent attribute index (bbolt) — speeds repeat organizes over the same tree."`
+	IndexPath        string   `name:"index-path" help:"Persistent attribute index (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/. Speeds repeat organizes over the same tree."`
+	NoIndex          bool     `name:"no-index" help:"Disable the on-disk index entirely; use only in-memory caching for the process lifetime."`
 	Exclude          []string `name:"exclude" help:"Basename glob to prune from the walk. Repeatable."`
 	RespectGitignore bool     `name:"respect-gitignore" help:"Honour a .gitignore at each walk root."`
 	PruneArtefacts   bool     `name:"prune-build-artefacts" help:"Prune vendor / node_modules / target / __pycache__ etc. for detected project types."`
@@ -56,13 +57,11 @@ func (o *OrganizeCmd) Run(ctx context.Context) error {
 		expr = "true"
 	}
 
-	idx, err := openIndex(o.IndexPath, index.BodyCacheCap{})
+	idx, _, err := openIndex(o.IndexPath, o.NoIndex, index.BodyCacheCap{})
 	if err != nil {
 		return err
 	}
-	if idx != nil {
-		defer func() { _ = idx.Close() }()
-	}
+	defer func() { _ = idx.Close() }()
 
 	opts := search.Options{
 		Roots:               o.Dir,

--- a/cmd/file-search-on/preset_cmd.go
+++ b/cmd/file-search-on/preset_cmd.go
@@ -28,7 +28,8 @@ type PresetCmd struct {
 	Excludes       []string `name:"exclude" help:"Glob patterns pruned from the walk (e.g. node_modules, .git). Repeatable."`
 	RespectGit     bool     `name:"respect-gitignore" help:"Parse a .gitignore at each walk root and skip matching paths."`
 	FollowSymlinks bool     `name:"follow-symlinks" help:"Descend through symbolic links to directories."`
-	IndexPath      string   `name:"index-path" help:"Persistent attribute index file (bbolt). Created on first use; speeds up repeat runs on unchanged trees."`
+	IndexPath      string   `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/. Created on first use; speeds up repeat runs on unchanged trees."`
+	NoIndex        bool     `name:"no-index" help:"Disable the on-disk index entirely; use only in-memory caching for the process lifetime."`
 }
 
 func (p *PresetCmd) Run(ctx context.Context) error {
@@ -67,14 +68,12 @@ func (p *PresetCmd) Run(ctx context.Context) error {
 		walkOpts.Limit = p.Limit
 	}
 
-	if p.IndexPath != "" {
-		idx, err := openIndex(p.IndexPath, index.BodyCacheCap{})
-		if err != nil {
-			return err
-		}
-		defer func() { _ = idx.Close() }()
-		walkOpts.Index = idx
+	idx, _, err := openIndex(p.IndexPath, p.NoIndex, index.BodyCacheCap{})
+	if err != nil {
+		return err
 	}
+	defer func() { _ = idx.Close() }()
+	walkOpts.Index = idx
 
 	results, err := search.Walk(ctx, walkOpts, contentpkg.DefaultRegistry())
 	if err != nil && !isCancellation(err) {

--- a/cmd/file-search-on/search_cmd.go
+++ b/cmd/file-search-on/search_cmd.go
@@ -27,7 +27,8 @@ type SearchCmd struct {
 	Output           string        `short:"o" name:"output" enum:"bare,default,verbose,json" default:"default" help:"Output format: bare | default | verbose | json."`
 	Format           string        `name:"format" help:"Custom Go text/template applied per match (e.g. '{{.Path}}\\t{{.Title}}'). When set, takes precedence over -o."`
 	Unsorted         bool          `name:"unsorted" help:"Stream matches in walk order instead of buffering+sorting. Default and verbose modes still emit the count footer; bare/json/template are streamed and unsorted regardless. Ignored when --sort or --limit is set (those force buffered mode)."`
-	IndexPath        string        `name:"index-path" help:"Persistent attribute index file (bbolt). When set, unchanged files (matched by absolute path + size + mtime) skip the per-file content-type parse, making repeat searches dramatically faster. The file is created on first use; delete it to force a full re-extraction."`
+	IndexPath        string        `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/<basename>-<sha1[:6]>.db. When set, unchanged files (matched by absolute path + size + mtime) skip the per-file content-type parse, making repeat searches dramatically faster. The file is created on first use; delete it to force a full re-extraction."`
+	NoIndex          bool          `name:"no-index" help:"Disable the on-disk index entirely; use only the in-memory cache for the process lifetime. Useful for hermetic CI / one-shot runs, or when another file-search-on instance already holds the writer lock on the default index file."`
 	Timeout          time.Duration `name:"timeout" help:"Maximum walk duration (Go duration string: 30s, 2m, 500ms). Default unset = no timeout. On expiry, results collected so far are still printed and the process exits 124. Ctrl-C exits 130 with whatever was collected."`
 	Sort             string        `name:"sort" help:"Sort matches by attribute. Recognised keys: size, name, path, mod_time, word_count, line_count, page_count, duration, bitrate, sample_rate, video_height, video_width, frame_rate, iso, focal_length, taken_at, sent_at, year, entry_count, uncompressed_size, loc, attachment_count, email_count. Files missing the attribute group at the end. Forces buffered mode."`
 	Order            string        `name:"order" help:"Sort direction: 'asc' (default for --sort) or 'desc'. When --rank is set the default flips to 'desc' (higher score first). Ignored without --sort or --rank."`
@@ -86,19 +87,15 @@ func (s *SearchCmd) Run(ctx context.Context) error {
 		}
 	}
 
-	// CLI is opt-in: nothing is created unless --index-path is set.
-	// One-shot CLI runs without an explicit path don't benefit from a
-	// process-local cache, so we skip the allocation entirely.
-	var idx index.Index
-	if s.IndexPath != "" {
-		var err error
-		idx, err = openIndex(s.IndexPath, index.BodyCacheCap{
-			MaxBytes: int64(s.BodyCacheMaxBytes),
-			Disable:  s.NoBodyCache,
-		})
-		if err != nil {
-			return err
-		}
+	// On-disk index is on by default — picks the per-cwd file under
+	// <UserCacheDir>/file-search-on/indexes/. Override with --index-path
+	// or opt out with --no-index.
+	idx, _, err := openIndex(s.IndexPath, s.NoIndex, index.BodyCacheCap{
+		MaxBytes: int64(s.BodyCacheMaxBytes),
+		Disable:  s.NoBodyCache,
+	})
+	if err != nil {
+		return err
 	}
 
 	// Layer a timeout on top of the signal-bound parent ctx so we can

--- a/cmd/file-search-on/stats_cmd.go
+++ b/cmd/file-search-on/stats_cmd.go
@@ -17,7 +17,8 @@ type StatsCmd struct {
 	Expr             string        `arg:"" help:"Optional CEL expression to scope the stats (e.g. 'is_markdown' for markdown-only counts). Defaults to matching every file." optional:""`
 	Workers          int           `short:"w" help:"Parallel workers." default:"0"`
 	MaxLineBytes     int           `short:"L" name:"max-line-bytes" help:"Per-line scanner cap for text/CSV/HTML (bytes). 0 uses the 1 MiB default." default:"0"`
-	IndexPath        string        `name:"index-path" help:"Persistent attribute index file (bbolt); see search subcommand."`
+	IndexPath        string        `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/; see search subcommand."`
+	NoIndex          bool          `name:"no-index" help:"Disable the on-disk index entirely; use only in-memory caching for the process lifetime."`
 	Timeout          time.Duration `name:"timeout" help:"Maximum walk duration. On expiry, the partial histogram is still printed and the process exits 124."`
 	Exclude          []string      `name:"exclude" help:"Glob pattern matched against file/dir basenames; matches are skipped. Repeatable."`
 	RespectGitignore bool          `name:"respect-gitignore" help:"Parse a .gitignore at the walk root and skip matching paths."`
@@ -40,15 +41,11 @@ func (s *StatsCmd) Run(ctx context.Context) error {
 		defer cancel()
 	}
 
-	var idx index.Index
-	if s.IndexPath != "" {
-		var err error
-		idx, err = openIndex(s.IndexPath, index.BodyCacheCap{})
-		if err != nil {
-			return err
-		}
-		defer func() { _ = idx.Close() }()
+	idx, _, err := openIndex(s.IndexPath, s.NoIndex, index.BodyCacheCap{})
+	if err != nil {
+		return err
 	}
+	defer func() { _ = idx.Close() }()
 
 	start := time.Now()
 	stats, err := search.ComputeStats(effectiveCtx, search.Options{

--- a/cmd/file-search-on/watch_cmd.go
+++ b/cmd/file-search-on/watch_cmd.go
@@ -24,7 +24,8 @@ type WatchCmd struct {
 	Output string   `short:"o" name:"output" enum:"json,bare" default:"json" help:"Output per match: json (NDJSON, one object per line) | bare (path only)."`
 	Format string   `name:"format" help:"Custom Go text/template applied per match (e.g. '{{.Path}}\\t{{.ContentType}}'). Overrides -o."`
 
-	IndexPath        string        `name:"index-path" help:"Persistent attribute index (bbolt) — caches per-file parses + bodies (incl. OCR) across the watch and across runs."`
+	IndexPath        string        `name:"index-path" help:"Persistent attribute index (bbolt) — caches per-file parses + bodies (incl. OCR) across the watch and across runs. Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/<basename>-<sha1[:6]>.db."`
+	NoIndex          bool          `name:"no-index" help:"Disable the on-disk index entirely; use only in-memory caching for the watch. Useful when another file-search-on instance already holds the writer lock on the default index file."`
 	Exclude          []string      `name:"exclude" help:"Basename glob to prune from the watched tree. Repeatable."`
 	RespectGitignore bool          `name:"respect-gitignore" help:"Honour a .gitignore at each watch root when registering directories."`
 	Body             bool          `name:"body" help:"Make file body available as the 'body' CEL variable (needed for body.contains / has_secrets / etc.)."`
@@ -48,13 +49,11 @@ func (c *WatchCmd) Run(ctx context.Context) error {
 		tmpl = t
 	}
 
-	idx, err := openIndex(c.IndexPath, index.BodyCacheCap{})
+	idx, backend, err := openIndex(c.IndexPath, c.NoIndex, index.BodyCacheCap{})
 	if err != nil {
 		return err
 	}
-	if idx != nil {
-		defer func() { _ = idx.Close() }()
-	}
+	defer func() { _ = idx.Close() }()
 
 	opts := search.Options{
 		Roots:                  c.Dir,
@@ -101,10 +100,12 @@ func (c *WatchCmd) Run(ctx context.Context) error {
 	}
 	if monAddr != "" {
 		mon := monitor.NewServer(monitor.Config{
-			Version:   version,
-			Mode:      "watch",
-			Index:     idx,
-			IndexPath: c.IndexPath,
+			Version:             version,
+			Mode:                "watch",
+			Index:               idx,
+			IndexPath:           backend.Path,
+			IndexBackend:        backend.Mode,
+			IndexFallbackReason: backend.Reason,
 		})
 		monDone := make(chan struct{})
 		go func() {

--- a/internal/mcpserver/monitor_info_tool.go
+++ b/internal/mcpserver/monitor_info_tool.go
@@ -27,9 +27,26 @@ type MonitorInfoOutput struct {
 	Enabled bool `json:"enabled"`
 	// URL is this server's dashboard URL (empty when not enabled).
 	URL string `json:"url,omitempty"`
+	// IndexPath is the absolute path of this server's persistent index
+	// file when IndexBackend == "persistent", empty otherwise.
+	IndexPath string `json:"index_path,omitempty"`
+	// IndexBackend is "persistent" when this server is backed by a
+	// bbolt file, "in-memory" when it's running with process-lifetime
+	// cache only (either by --no-index opt-out or by graceful fallback
+	// because another instance held the writer lock).
+	IndexBackend string `json:"index_backend,omitempty"`
+	// IndexFallbackReason explains why IndexBackend is "in-memory" when
+	// the user did not explicitly request that. Values: "" (happy path
+	// — IndexBackend is "persistent"), "no_index_flag" (user passed
+	// --no-index), "lock_contention" (another file-search-on instance
+	// holds the writer lock on the default index file).
+	IndexFallbackReason string `json:"index_fallback_reason,omitempty"`
 	// Peers is every live dashboard instance discovered via the shared
 	// registry, including this one (flagged is_self). Newest-startup
-	// last. Empty when peer discovery is unavailable.
+	// last. Empty when peer discovery is unavailable. Each peer entry
+	// carries the same index_path / index_backend / index_fallback_reason
+	// fields, so an agent can identify which sibling PID holds the
+	// writer lock when this instance is in fallback mode.
 	Peers []monitor.Entry `json:"peers"`
 	// Note carries a human-readable hint when monitoring isn't wired at
 	// all (e.g. the server was built without a controller).
@@ -54,6 +71,7 @@ func (h *handlers) monitorInfoHandler(_ context.Context, _ *mcp.CallToolRequest,
 	url, running := h.monitorCtl.Info()
 	out.Enabled = running
 	out.URL = url
+	out.IndexPath, out.IndexBackend, out.IndexFallbackReason = h.monitorCtl.IndexInfo()
 	out.Peers = monitor.Peers()
 	if out.Peers == nil {
 		out.Peers = []monitor.Entry{}

--- a/internal/monitor/controller.go
+++ b/internal/monitor/controller.go
@@ -67,6 +67,14 @@ func (c *Controller) Info() (url string, running bool) {
 	return c.url, c.started
 }
 
+// IndexInfo reports the index backend chosen at startup. Available
+// before the dashboard is started; the monitor_info MCP tool surfaces
+// this so an agent can see lock-contention / opt-out state without
+// needing to enable the dashboard first.
+func (c *Controller) IndexInfo() (path, backend, fallbackReason string) {
+	return c.cfg.IndexPath, c.cfg.IndexBackend, c.cfg.IndexFallbackReason
+}
+
 // Wait blocks until the dashboard's serve goroutine has fully exited
 // (after serveCtx is cancelled and graceful shutdown + deregistration
 // complete). Returns immediately if the dashboard was never started.

--- a/internal/monitor/registry.go
+++ b/internal/monitor/registry.go
@@ -25,6 +25,19 @@ type Entry struct {
 	StartedAt  time.Time `json:"started_at"`
 	WorkingDir string    `json:"working_dir"`
 	IndexPath  string    `json:"index_path,omitempty"` // "" = in-memory
+	// IndexBackend records which storage layer this instance settled on
+	// after openIndex resolved --index-path / --no-index / default-path
+	// / lock-contention. Values: "persistent" | "in-memory". Older
+	// instances written before this field existed deserialise with the
+	// empty string; callers should treat empty as unknown and fall back
+	// to IndexPath ("" ≈ in-memory).
+	IndexBackend string `json:"index_backend,omitempty"`
+	// IndexFallbackReason is populated only when IndexBackend ==
+	// "in-memory" and the in-memory state wasn't the explicit user
+	// choice. Values: "" (happy path) | "no_index_flag" (--no-index
+	// passed) | "lock_contention" (another instance held the writer
+	// lock). Lets the dashboard peer panel highlight the contending PID.
+	IndexFallbackReason string `json:"index_fallback_reason,omitempty"`
 	// IsSelf is set only on the /api/peers response for the entry that
 	// matches the serving instance; it is never persisted (the registry
 	// files omit it via the zero value).

--- a/internal/monitor/server.go
+++ b/internal/monitor/server.go
@@ -29,14 +29,16 @@ var staticFiles embed.FS
 // tool calls to report). The Embed* / IndexPath / BodyCacheCap fields
 // are informational, surfaced on the overview panel.
 type Config struct {
-	Version      string
-	Mode         string // "mcp-stdio" | "mcp-http" | "mcp-sse" | "watch"
-	Index        index.Index
-	Collector    *Collector
-	EmbedServer  string
-	EmbedModel   string
-	IndexPath    string // "" → in-memory
-	BodyCacheCap int64  // 0 → in-memory / no cap
+	Version             string
+	Mode                string // "mcp-stdio" | "mcp-http" | "mcp-sse" | "watch"
+	Index               index.Index
+	Collector           *Collector
+	EmbedServer         string
+	EmbedModel          string
+	IndexPath           string // "" → in-memory
+	IndexBackend        string // "persistent" | "in-memory"
+	IndexFallbackReason string // "" | "lock_contention" | "no_index_flag"
+	BodyCacheCap        int64  // 0 → in-memory / no cap
 }
 
 // Server is the read-only monitoring HTTP server. Bind with Listen
@@ -120,13 +122,15 @@ func (s *Server) Serve(ctx context.Context) error {
 	}
 
 	deregister, regErr := Register(Entry{
-		PID:        os.Getpid(),
-		URL:        s.url,
-		Mode:       s.cfg.Mode,
-		Version:    s.cfg.Version,
-		StartedAt:  s.startedAt,
-		WorkingDir: workingDir(),
-		IndexPath:  s.cfg.IndexPath,
+		PID:                 os.Getpid(),
+		URL:                 s.url,
+		Mode:                s.cfg.Mode,
+		Version:             s.cfg.Version,
+		StartedAt:           s.startedAt,
+		WorkingDir:          workingDir(),
+		IndexPath:           s.cfg.IndexPath,
+		IndexBackend:        s.cfg.IndexBackend,
+		IndexFallbackReason: s.cfg.IndexFallbackReason,
 	})
 	if regErr != nil {
 		fmt.Fprintln(os.Stderr, "monitor: peer registry unavailable:", regErr)
@@ -218,16 +222,19 @@ func (s *Server) handleOverview(w http.ResponseWriter, _ *http.Request) {
 		indexBacking = s.cfg.IndexPath
 	}
 	writeJSON(w, map[string]any{
-		"version":        s.cfg.Version,
-		"mode":           s.cfg.Mode,
-		"uptime_seconds": time.Since(s.startedAt).Seconds(),
-		"pid":            os.Getpid(),
-		"go_version":     runtime.Version(),
-		"gomaxprocs":     runtime.GOMAXPROCS(0),
-		"num_cpu":        runtime.NumCPU(),
-		"index_backing":  indexBacking,
-		"body_cache_cap": s.cfg.BodyCacheCap,
-		"goroutines":     runtime.NumGoroutine(),
+		"version":               s.cfg.Version,
+		"mode":                  s.cfg.Mode,
+		"uptime_seconds":        time.Since(s.startedAt).Seconds(),
+		"pid":                   os.Getpid(),
+		"go_version":            runtime.Version(),
+		"gomaxprocs":            runtime.GOMAXPROCS(0),
+		"num_cpu":               runtime.NumCPU(),
+		"index_backing":         indexBacking,
+		"index_backend":         s.cfg.IndexBackend,         // "persistent" | "in-memory"
+		"index_path":            s.cfg.IndexPath,            // absolute path when persistent
+		"index_fallback_reason": s.cfg.IndexFallbackReason,  // "" | "no_index_flag" | "lock_contention"
+		"body_cache_cap":        s.cfg.BodyCacheCap,
+		"goroutines":            runtime.NumGoroutine(),
 	})
 }
 

--- a/internal/monitor/static/app.js
+++ b/internal/monitor/static/app.js
@@ -41,6 +41,20 @@ function sparkline(values, w = 200, h = 28) {
 
 function kv(k, v) { return `<div class="kv"><div class="k">${k}</div><div class="v">${v}</div></div>`; }
 
+function indexLabel(o) {
+  if (o.index_backend === "persistent" && o.index_path) {
+    return `<span class="ix-persistent" title="${o.index_path}">🔒 persistent</span>`;
+  }
+  switch (o.index_fallback_reason) {
+    case "lock_contention":
+      return `<span class="ix-memory ix-warn" title="another file-search-on instance holds the writer lock">🧠 in-memory (lock contention)</span>`;
+    case "no_index_flag":
+      return `<span class="ix-memory" title="--no-index passed">🧠 in-memory (--no-index)</span>`;
+    default:
+      return `<span class="ix-memory">🧠 in-memory</span>`;
+  }
+}
+
 function renderOverview(o) {
   $("hdr-version").textContent = o.version || "";
   $("hdr-mode").textContent = o.mode || "";
@@ -48,7 +62,8 @@ function renderOverview(o) {
   $("overview").innerHTML = [
     kv("Mode", o.mode),
     kv("Uptime", dur(o.uptime_seconds || 0)),
-    kv("Index", o.index_backing),
+    kv("Index", indexLabel(o)),
+    kv("Index path", o.index_path || "—"),
     kv("Body cache cap", o.body_cache_cap ? bytes(o.body_cache_cap) : "in-memory"),
     kv("Workers (default)", o.num_cpu),
     kv("GOMAXPROCS", o.gomaxprocs),
@@ -160,13 +175,20 @@ function shortDir(d) {
   return (parts.length > 2 ? "…/" : "/") + parts.slice(-2).join("/");
 }
 
+function peerBadge(p) {
+  if (p.index_backend === "persistent") return "🔒 ";
+  if (p.index_backend === "in-memory") return "🧠 ";
+  return ""; // pre-#242 peer or unknown — no badge rather than wrong badge
+}
+
 function renderPeers(d) {
   const peers = (d && d.peers) || [];
   const el = $("peers");
   // A lone instance (just us) doesn't need a switcher.
   if (peers.length <= 1) { el.innerHTML = ""; return; }
   const opts = peers.map((p) => {
-    const label = `${p.mode} ${shortDir(p.working_dir)} :${(p.url.match(/:(\d+)\//) || [])[1] || "?"}${p.is_self ? " (you)" : ""}`;
+    const port = (p.url.match(/:(\d+)\//) || [])[1] || "?";
+    const label = `${peerBadge(p)}${p.mode} ${shortDir(p.working_dir)} :${port}${p.is_self ? " (you)" : ""}`;
     return `<option value="${p.url}" ${p.is_self ? "selected" : ""}>${label}</option>`;
   }).join("");
   el.innerHTML = `<label class="peers-label">${peers.length} instances</label>

--- a/internal/monitor/static/style.css
+++ b/internal/monitor/static/style.css
@@ -73,4 +73,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 .caps-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
 .chip { display: inline-block; background: var(--card); border-radius: 4px; padding: 2px 8px; margin: 2px; font-size: 12px; }
 .empty { color: var(--muted); font-style: italic; padding: 8px 0; }
+.ix-persistent { color: var(--ok); }
+.ix-memory { color: var(--muted); }
+.ix-memory.ix-warn { color: var(--warn); }
 @media (max-width: 760px) { main, .caps-grid { grid-template-columns: 1fr; } }


### PR DESCRIPTION
Closes #242.

## Summary

On-disk attribute index now **on by default** at \`<UserCacheDir>/file-search-on/indexes/<basename>-<sha1[:6]>.db\` — per-cwd path keying so multiple stdio agents across different projects never collide on the same bbolt file. New \`--no-index\` flag opts out (hermetic CI, one-shot runs). Existing \`--index-path\` continues to override.

Same-cwd contention (two stdio agents in one repo) is handled gracefully: first wins bbolt's 5-second flock, second logs a single stderr warning and falls back transparently to in-memory. Both instances keep working; only the cache layer differs.

## Why

stdio MCP servers spawned per Claude Code session previously started cold every time. Content-type detection, attribute extraction, OCR, perceptual hashes, sha256, and Ollama embeddings all re-ran from scratch. With this change, every session benefits from a warm cache keyed to the working directory. End-to-end smoke on this repo: **3914 hits / 308 misses** on the second run.

## Surface area

**CLI** — all 11 subcommands with \`--index-path\` gain a sibling \`--no-index\` flag (search, mcp, watch, preset, stats, duplicates, near-duplicates, find-matches, archive-contents, organize, diff). \`cmd/file-search-on/index_path.go\` houses the path picker, basename sanitiser, lock-timeout detector, and the \`IndexBackend\` diagnostic struct.

**Monitor dashboard** —
- \`/api/overview\` JSON gains \`index_backend\` / \`index_path\` / \`index_fallback_reason\` (legacy \`index_backing\` kept for back-compat).
- Overview panel renders 🔒 persistent / 🧠 in-memory with the reason inline.
- Peer-switcher entries get 🔒 / 🧠 badges using each peer's \`Entry.IndexBackend\`.
- \`monitor.Entry\` gains \`IndexBackend\` + \`IndexFallbackReason\` (omitempty — old registry files deserialise cleanly).

**MCP server** — \`monitor_info\` tool gains top-level \`index_path\` / \`index_backend\` / \`index_fallback_reason\` AND the same fields on each peer entry. Available even before the dashboard is enabled, via a new \`Controller.IndexInfo()\` accessor. \`monitor.Config\` extended to carry the backend info from CLI through to the dashboard.

## Tests

\`cmd/file-search-on/index_path_test.go\` covers:
- \`TestDefaultIndexPath_PerCWD\` — distinct cwds → distinct files; same cwd is deterministic; same-basename / different-parent dirs don't collide.
- \`TestSanitiseBasename\` — character whitelist + length cap.
- \`TestResolveIndexBackend_NoIndex\` — \`--no-index\` short-circuits to in-memory with the expected reason regardless of path arg.
- \`TestResolveIndexBackend_ExplicitPath_HappyPath\` — explicit path reports backend="persistent".
- \`TestResolveIndexBackend_LockContentionFallback\` — two opens of the same file: first wins, second falls back transparently. Skipped under \`-short\` (waits for the 5s bbolt flock timeout to fire).

CI sweep: \`go test -race -short ./...\` clean; \`go vet ./...\` clean; \`go fix ./...\` idempotent.

## Verification

End-to-end smoke (run by me before opening this PR):

\`\`\`sh
rm -rf ~/Library/Caches/file-search-on/indexes/
file-search-on search -d . 'is_source && language == "go"' --limit 3
# → creates file-search-on-<6hex>.db; walk completes normally

file-search-on search -d . 'is_source && language == "go"' --limit 3
# → footer reports thousands of hits

file-search-on search -d . --no-index ...
# → no new file under ~/Library/Caches/file-search-on/indexes/

file-search-on search -d . --index-path /tmp/explicit.db ...
# → /tmp/explicit.db created, default-path file untouched
\`\`\`

Dashboard JSON during a normal run:

\`\`\`json
{
  "index_backend": "persistent",
  "index_path": "~/Library/Caches/file-search-on/indexes/file-search-on-bf200b.db",
  "index_fallback_reason": ""
}
\`\`\`

## Test plan
- [ ] Two stdio servers in the same cwd: second logs the fallback warning; both serve queries normally
- [ ] Two stdio servers in different cwds: both write to their own files; no warnings
- [ ] \`--no-index\` everywhere: no on-disk file touched (verify via \`lsof\` or default-file mtime)
- [ ] Dashboard \`/api/overview\` shows the right backend label across all three reasons (delete file / lock with sibling / pass \`--no-index\`)
- [ ] \`monitor_info\` MCP tool returns the same fields without enabling the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)