### PR TITLE
feat(attrs): use the on-disk index and reach parity with read_attributes MCP tool

### DIFF
--- a/cmd/file-search-on/attrs_cmd.go
+++ b/cmd/file-search-on/attrs_cmd.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/richardwooding/file-search-on/internal/celexpr"
 	contentpkg "github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/hashset"
+	"github.com/richardwooding/file-search-on/internal/index"
 	"github.com/richardwooding/file-search-on/internal/search"
 )
 
@@ -15,6 +17,14 @@ type AttrsCmd struct {
 	Path   string `arg:"" help:"File to inspect."`
 	Output string `short:"o" name:"output" enum:"default,verbose,json" default:"verbose" help:"Output format: default | verbose | json."`
 	Format string `name:"format" help:"Custom Go text/template applied to the record (e.g. '{{.Path}}\\t{{.Title}}'). When set, takes precedence over -o."`
+
+	IndexPath      string `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/<basename>-<sha1[:6]>.db. Repeated attrs calls on the same file are returned from the cache after the first parse."`
+	NoIndex        bool   `name:"no-index" help:"Disable the on-disk index entirely; re-parse the file from scratch every call. Useful for hermetic CI or when another file-search-on instance holds the writer lock."`
+	WithHashes     bool   `name:"with-hashes" help:"Compute md5 / sha1 / sha256 of the file in a single io.MultiWriter pass and surface them as attributes. Hashes cache in the index alongside (size, mtime), so subsequent runs are free on unchanged files. Off by default — hashing reads the file in full."`
+	CheckDisguised bool   `name:"check-disguised" help:"Run both the name-based and magic-byte detection passes, populating magic_content_type / extension_content_type / is_disguised. is_disguised fires when the bytes disagree with the extension. One extra 512-byte file read (cached)."`
+	WithXattrs     bool   `name:"with-xattrs" help:"Read macOS extended attributes and surface them as CEL variables: xattr_keys, xattr_count, is_xattr_rich, is_quarantined, quarantine_agent / event_id / source_url / referrer_url / download_date / user_approved, finder_tags, finder_color, has_finder_comment. Darwin-only; non-Darwin builds silently leave these empty."`
+	HashAllowlist  string `name:"hash-allowlist" help:"Path to a hash allowlist (newline-separated md5/sha1/sha256 hex, mixed algorithms auto-detected by length, # comments allowed) OR a pre-built bbolt hashset file. Populates is_known_good. Forces --with-hashes on. NSRL / corp-allowlist / threat-intel-allowlist interop."`
+	HashDenylist   string `name:"hash-denylist" help:"Path to a hash denylist (same format as --hash-allowlist). Populates is_known_bad. Threat-intel-feed / IOC-list interop."`
 }
 
 func (a *AttrsCmd) Run(ctx context.Context) error {
@@ -33,7 +43,44 @@ func (a *AttrsCmd) Run(ctx context.Context) error {
 	dir := filepath.Dir(abs)
 	base := filepath.Base(abs)
 
-	attrs, err := celexpr.BuildAttributes(ctx, os.DirFS(dir), base, abs, contentpkg.DefaultRegistry())
+	idx, _, err := openIndex(a.IndexPath, a.NoIndex, index.BodyCacheCap{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = idx.Close() }()
+
+	// Hash allow/denylists mirror the read_attributes MCP tool — both
+	// force --with-hashes on so the resulting is_known_good /
+	// is_known_bad predicates have something to test against.
+	computeHashes := a.WithHashes
+	var allowlist, denylist hashset.Set
+	if a.HashAllowlist != "" {
+		al, alErr := hashset.Open(a.HashAllowlist)
+		if alErr != nil {
+			return fmt.Errorf("load --hash-allowlist: %w", alErr)
+		}
+		allowlist = al
+		defer func() { _ = al.Close() }()
+		computeHashes = true
+	}
+	if a.HashDenylist != "" {
+		dl, dlErr := hashset.Open(a.HashDenylist)
+		if dlErr != nil {
+			return fmt.Errorf("load --hash-denylist: %w", dlErr)
+		}
+		denylist = dl
+		defer func() { _ = dl.Close() }()
+		computeHashes = true
+	}
+
+	attrs, err := celexpr.BuildAttributesWith(ctx, os.DirFS(dir), base, abs, contentpkg.DefaultRegistry(), celexpr.BuildOptions{
+		Index:                  idx,
+		ComputeHashes:          computeHashes,
+		CheckDisguised:         a.CheckDisguised,
+		ReadExtendedAttributes: a.WithXattrs,
+		Allowlist:              allowlist,
+		Denylist:               denylist,
+	})
 	if err != nil {
 		return fmt.Errorf("read attributes: %w", err)
 	}

--- a/cmd/file-search-on/attrs_test.go
+++ b/cmd/file-search-on/attrs_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+)
+
+// captureStdout swaps os.Stdout for a pipe for the duration of fn,
+// returning what was written. Used to assert printJSON output from
+// AttrsCmd.Run without needing to mock the formatter.
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	runErr := fn()
+	_ = w.Close()
+	<-done
+	return buf.String(), runErr
+}
+
+// TestAttrsCmd_PopulatesIndex confirms the long-standing gap is
+// closed: running `attrs` on a file with an explicit --index-path
+// stores the attribute entry, so a subsequent walking subcommand
+// would see a cache hit on that path.
+func TestAttrsCmd_PopulatesIndex(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "fixture.md")
+	if err := os.WriteFile(target, []byte("# title\n\nbody\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	dbPath := filepath.Join(tmp, "attrs.db")
+
+	cmd := &AttrsCmd{Path: target, Output: "json", IndexPath: dbPath}
+	if _, err := captureStdout(t, func() error { return cmd.Run(t.Context()) }); err != nil {
+		t.Fatalf("attrs run: %v", err)
+	}
+
+	// Re-open the index and confirm the file's entry made it in.
+	idx, err := index.Open(dbPath)
+	if err != nil {
+		t.Fatalf("re-open index: %v", err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat fixture: %v", err)
+	}
+	if _, ok := idx.Lookup(target, info.Size(), info.ModTime()); !ok {
+		t.Fatalf("attrs did not populate the index for %s (expected cache hit on lookup)", target)
+	}
+}
+
+// TestAttrsCmd_NoIndex_LeavesNoFile confirms --no-index skips the
+// disk entirely — no bbolt file appears at the explicit path.
+func TestAttrsCmd_NoIndex_LeavesNoFile(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "fixture.md")
+	if err := os.WriteFile(target, []byte("# title\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	dbPath := filepath.Join(tmp, "should-not-be-created.db")
+
+	cmd := &AttrsCmd{Path: target, Output: "json", IndexPath: dbPath, NoIndex: true}
+	if _, err := captureStdout(t, func() error { return cmd.Run(t.Context()) }); err != nil {
+		t.Fatalf("attrs run: %v", err)
+	}
+
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Errorf("--no-index should not create %s (stat err = %v)", dbPath, err)
+	}
+}
+
+// TestAttrsCmd_WithHashes confirms md5 / sha1 / sha256 land on the
+// JSON output when --with-hashes is set, matching the read_attributes
+// MCP tool's compute_hashes=true behaviour.
+func TestAttrsCmd_WithHashes(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "fixture.txt")
+	// Single known string → deterministic hashes (sha256 of "hello\n"
+	// is well-known, so the test could even pin the digest, but
+	// presence-only is enough to confirm the wire-through).
+	if err := os.WriteFile(target, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cmd := &AttrsCmd{
+		Path:       target,
+		Output:     "json",
+		NoIndex:    true, // hermetic — no disk side effect from the cache
+		WithHashes: true,
+	}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("attrs run: %v", err)
+	}
+
+	// attrs emits a single JSON object (not an array — one file = one
+	// record). Decode straight into a map.
+	var r map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&r); err != nil {
+		t.Fatalf("decode JSON output: %v\nraw: %q", err, out)
+	}
+	for _, k := range []string{"md5", "sha1", "sha256"} {
+		v, ok := r[k]
+		if !ok {
+			t.Errorf("missing %s in --with-hashes output", k)
+			continue
+		}
+		s, _ := v.(string)
+		if s == "" {
+			t.Errorf("%s is empty; expected lowercase hex digest", k)
+		}
+	}
+	// sha256 of "hello\n" is a well-known constant — pin it as a
+	// regression guard.
+	const wantSHA256 = "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
+	if got, _ := r["sha256"].(string); got != wantSHA256 {
+		t.Errorf("sha256 = %q, want %q", got, wantSHA256)
+	}
+}


### PR DESCRIPTION
The CLI \`attrs\` subcommand bypassed the on-disk index entirely while its sibling on the agent surface — the \`read_attributes\` MCP tool — already used it. PR #243 made the index on-by-default for every **walking** subcommand, but \`attrs\` (which doesn't walk) was missed. This closes the gap and brings the CLI surface to full parity with the MCP tool.

## What's new on \`attrs\`

| Flag | Effect |
| --- | --- |
| \`--index-path\` | Override the new per-cwd default index file |
| \`--no-index\` | Disable on-disk caching for this call (hermetic / CI / lock-contention bypass) |
| \`--with-hashes\` | Compute and emit \`md5\` / \`sha1\` / \`sha256\` (cached) |
| \`--check-disguised\` | Emit \`magic_content_type\` / \`extension_content_type\` / \`is_disguised\` |
| \`--with-xattrs\` | Emit the macOS xattr family (quarantine, finder tags, …) |
| \`--hash-allowlist\` / \`--hash-denylist\` | NSRL-style lists → emit \`is_known_good\` / \`is_known_bad\`. Forces \`--with-hashes\` on. |

Help-text wording is reused verbatim from \`search_cmd.go\` so the same flags read identically across subcommands.

## Why it matters

A repeated \`attrs <photo.jpg>\` against a 10 MB JPEG previously re-ran \`imagemeta.Decode\` + \`image.DecodeConfig\` every call (~15–60 ms cold). Now the second call is a \`(size, mtime)\`-validated cache hit assembled from stored attributes in microseconds. Scripted / monitoring workflows that repeatedly inspect the same path see the biggest gain.

## Implementation

One file changed: \`cmd/file-search-on/attrs_cmd.go\`. Swaps \`celexpr.BuildAttributes(...)\` (zero options, no index) for \`celexpr.BuildAttributesWith(..., BuildOptions{Index: idx, ...})\`, mirroring the construction in \`internal/mcpserver/read_attributes_tool.go\` line-for-line so the two surfaces stay in sync.

## Tests

New \`cmd/file-search-on/attrs_test.go\`:

- **\`TestAttrsCmd_PopulatesIndex\`** — runs \`attrs\` with explicit \`--index-path\`, then re-opens the bbolt file directly and asserts the entry is queryable via \`idx.Lookup(path, size, mtime)\`.
- **\`TestAttrsCmd_NoIndex_LeavesNoFile\`** — \`--no-index\` skips disk entirely; the explicit path is never created.
- **\`TestAttrsCmd_WithHashes\`** — \`--with-hashes\` populates md5 / sha1 / sha256; sha256 of \`"hello\n"\` pinned as a regression guard.

CI sweep: \`go test -race -short ./...\` ✓, \`go vet ./...\` ✓, \`golangci-lint run\` ✓ (0 issues), \`go fix ./...\` idempotent.

## Test plan
- [ ] \`rm -rf ~/Library/Caches/file-search-on/indexes/ && file-search-on attrs go.mod && file-search-on attrs go.mod\` — second call shorter / cached
- [ ] \`file-search-on attrs --no-index go.mod\` — no bbolt file created
- [ ] \`file-search-on attrs --with-hashes --output json some.jpg\` — output contains md5 / sha1 / sha256
- [ ] \`file-search-on attrs --check-disguised --output json some.txt\` — output contains is_disguised
- [ ] \`file-search-on attrs --with-xattrs --output json ~/Downloads/something\` (macOS) — output contains quarantine_source_url etc.
- [ ] \`file-search-on attrs --hash-allowlist /tmp/list.txt --output json some.bin\` — output contains is_known_good
- [ ] Spot-check that \`attrs\` output is unchanged when no new flags are passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)