### PR TITLE
docs: sync README + examples to current behaviour (v0.64.0 + v0.65.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Built in the open — issues, PRs, and feature requests warmly welcomed. See [Co
 - **CEL expressions** — the full Common Expression Language: comparisons, `&&`/`||`, string functions, list membership, timestamp arithmetic. Composes naturally with structural attributes.
 - **Fuzzy, phonetic, and geographic matching** — built-in `levenshtein`, `soundex`, `ngrams`, `ngram_similarity`, and `point_in_polygon` (for GPS bboxes / city outlines) let you write typo-tolerant and "sounds-like" queries against any string attribute. EXIF camera make in `Nikkon` instead of `Nikon`? Artist tag mistyped as `Radiohad`? Same query catches all of them. See [examples/fuzzy-search.md](./examples/fuzzy-search.md).
 - **Multiple output formats** — `bare` (paths only), `default`, `verbose` (multi-line), `json` (NDJSON), or a Go `text/template` via `--format`.
-- **MCP server mode** — same binary doubles as a [Model Context Protocol](https://modelcontextprotocol.io) server (stdio, HTTP, or SSE). Fourteen tools exposed: `search`, `read_attributes`, `read_lines`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `list_archive_contents`, `read_file_in_archive`, `detect_project`, `find_projects`, `resolve_project_for_path`, `list_attributes`, `index_stats`.
+- **MCP server mode** — same binary doubles as a [Model Context Protocol](https://modelcontextprotocol.io) server (stdio, HTTP, or SSE). Twenty tools exposed: `search`, `search_semantic`, `read_attributes`, `read_lines`, `stats`, `find_duplicates`, `find_near_duplicates`, `diff_trees`, `find_matches`, `watch_search`, `list_archive_contents`, `read_file_in_archive`, `detect_project`, `find_projects`, `resolve_project_for_path`, `list_attributes`, `list_presets`, `query_preset`, `index_stats`, `monitor_info`.
 - **Pure Go, no CGO** — cross-compiles cleanly to all six release targets. No image/audio/video decoder dependencies.
 - **Parallel walking** — files are evaluated across a worker pool (defaults to `NumCPU`).
 
@@ -240,7 +240,17 @@ Fingerprints cache via `--index-path` alongside the exact hash; repeat runs skip
 
 ### Common flags
 
-`-d <dir>` (repeatable for multi-root walks), `--exclude <glob>` (basename, repeatable), `--respect-gitignore`, `--timeout 30s` (partial results returned on expiry), `--workers N`, `--index-path <file.db>` (persistent attribute cache — see [examples/indexing.md](./examples/indexing.md)).
+`-d <dir>` (repeatable for multi-root walks), `--exclude <glob>` (basename, repeatable), `--respect-gitignore`, `--timeout 30s` (partial results returned on expiry), `--workers N`, `--index-path <file.db>` (override the per-cwd default index — see [examples/indexing.md](./examples/indexing.md)), `--no-index` (opt out of on-disk caching for hermetic runs).
+
+### Pointing at a non-default Ollama
+
+For semantic search and `search_semantic` (MCP), the embedding HTTP endpoint resolves in this order:
+
+1. `--embedding-server <url>` flag (CLI or `mcp` subcommand)
+2. `$OLLAMA_HOST` environment variable
+3. `http://localhost:11434` (built-in default)
+
+So a remote Ollama box on the LAN works without a per-invocation flag: `export OLLAMA_HOST=http://gpu-box:11434`. See [examples/semantic-search.md](./examples/semantic-search.md) for the full setup.
 
 ## Recipes
 
@@ -399,32 +409,67 @@ file-search-on mcp --timeout 90s                         # raise the per-call de
 
 For HTTP and SSE, `--addr` (default `:8080`) is the bind address and `--path` (default `/`) is the URL prefix. `--timeout` (default `60s`) sets the per-tool-call deadline; per-call `timeout_seconds` on the `search` tool input overrides it.
 
-Eleven tools are exposed:
+Twenty tools are exposed, grouped by family:
+
+**Search & inspect**
 
 | Tool | What it does |
 | --- | --- |
-| `search` | CEL expression over a directory tree. Supports `sort_by` / `limit` (top-K), `include_body` (full body filter), `include_snippet` (preview), `resolve_projects` (`project_type` per match), `prune_build_artefacts`, `fields` (project response to a subset of attributes; path / content_type / size always-on). Returns matches with the full attribute set + partial-result fields. |
-| `read_attributes` | Attributes for a single path — same shape as one `search` match. Accepts `fields` for the same token-saving projection. |
+| `search` | CEL expression over a directory tree. Supports `sort_by` / `limit` (top-K), `rank` (custom CEL sort key), `include_body` (full body filter), `include_snippet` (preview), `ocr_images` (run OCR before evaluating), `with_phash` (perceptual hash + `image_similar_to` function), `compute_hashes`, `check_disguised`, `with_xattrs`, `resolve_projects`, `prune_build_artefacts`, `fields` (token-saving projection — path / content_type / size always-on). Returns matches with the full attribute set + partial-result fields. |
+| `search_semantic` | Natural-language similarity search via local Ollama embeddings. Pre-prunes with an optional `expr`, embeds the query, ranks files by cosine similarity, applies a `threshold` cap. Embeddings cache per file. |
+| `read_attributes` | Attributes for a single path — same shape as one `search` match. Accepts `fields` for token-saving projection. |
 | `read_lines` | A specific line range of a file — pairs with `search` for context around matches. |
-| `stats` | Histogram + totals for a directory tree, bucketed by `group_by` (default `content_type`; full set documented in [Usage § Stats](#stats-and-reconnaissance)). |
+
+**Aggregate**
+
+| Tool | What it does |
+| --- | --- |
+| `stats` | Histogram + totals for a directory tree, bucketed by `group_by` (default `content_type`; recognised: `ext`, `dir`, `language`, `camera_make`, `camera_model`, `lens`, `artist`, `album`, `genre`, time buckets like `taken_at_month`, …). |
+
+**Dedup & diff**
+
+| Tool | What it does |
+| --- | --- |
 | `find_duplicates` | Byte-identical files keyed by sha256 — two-pass (size-bucket then hash). Sorted by `wasted_bytes` desc. |
 | `find_near_duplicates` | Similar files by SimHash fingerprint of extracted body. Catches typo edits, regenerated headers, template copies. Configurable similarity threshold (default 0.85). |
+| `diff_trees` | Cross-tree set operations by sha256 content hash — `a-minus-b`, `b-minus-a`, `intersect`, `union`, `mismatch` (same relative path, different content). Read-only; never mutates either tree. |
+
+**Archive**
+
+| Tool | What it does |
+| --- | --- |
 | `list_archive_contents` | Per-entry CEL filtering inside ZIP / TAR / TAR.GZ / GZIP without extracting. Same vocabulary as top-level search; cache-aware. |
 | `read_file_in_archive` | Read one named entry's bytes out of an archive. Returns content + content_type + attributes. |
+
+**Pattern + watch**
+
+| Tool | What it does |
+| --- | --- |
 | `find_matches` | Line-level regex (RE2) hits across a tree with `context_before` / `context_after` windows. CEL pre-prune (e.g. `is_source && language == "go"`) keeps the regex pass narrow. Replaces the search-then-`read_lines` dance with one call. |
+| `watch_search` | Bounded "tell me when X appears" subscription — block up to `duration_seconds` (default 30, capped at 600), return every new / changed file that matches the CEL filter. |
+
+**Project + introspection + monitoring**
+
+| Tool | What it does |
+| --- | --- |
 | `detect_project` | Project type(s) of one directory. |
 | `find_projects` | Walk a tree, list every project subdirectory. |
 | `resolve_project_for_path` | Walk UP from a file/dir path to the nearest enclosing project root. Useful when an agent has a stray path and needs to know the project context. |
 | `list_attributes` | The full canonical schema (`common`, `type_specific`, `frontmatter`, `functions`) plus registered content types. |
-| `index_stats` | Cache counters for the running server (hits, misses, puts, stales, errors). |
+| `list_presets` | Discover the eight built-in named search recipes (`recent_changes`, `recent_photos`, `old_drafts`, `large_files`, `large_binaries`, `suspicious_files`, `failed_tests`, `system_metadata`). |
+| `query_preset` | Run a named preset; per-call overrides for `dir`, `limit`, `excludes`, etc. |
+| `index_stats` | Cache counters for the running server (hits, misses, puts, stales, errors; same for body + embedding caches). |
+| `monitor_info` | This server's monitoring-dashboard URL + the registry of sibling instances. Pass `enable: true` to start the dashboard on demand if it isn't already running. |
 
-Every walking tool (`search`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `find_projects`) honours the same partial-result contract: on timeout the call returns `cancelled=true` with the results gathered so far, never an error. Agents inspect the flag rather than catching exceptions.
+Every walking tool (`search`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `find_projects`, `diff_trees`) honours the same partial-result contract: on timeout the call returns `cancelled=true` with the results gathered so far, never an error. Agents inspect the flag rather than catching exceptions.
 
-The MCP server keeps an attribute cache for its process lifetime — repeated `search` / `read_attributes` calls against the same files skip the parse step on the second and later invocations. Pass `--index-path` to persist the cache across restarts:
+Since v0.64.0 the on-disk index is **on by default**. The MCP server (like every other long-running subcommand) auto-creates a per-cwd bbolt cache at `<UserCacheDir>/file-search-on/indexes/<basename>-<sha1[:6]>.db` — repeated `search` / `read_attributes` calls against unchanged files skip parsing entirely. The default path is per-cwd so concurrent agents in different projects never collide; same-cwd contention falls back gracefully to in-memory (logged on stderr, surfaced on the dashboard as `index_fallback_reason: "lock_contention"`). Override with `--index-path`; opt out with `--no-index` for hermetic CI runs:
 
 ```sh
-file-search-on mcp --index-path ~/.cache/fso/agent.db                    # stdio + persistent cache
-file-search-on mcp --transport http --addr :8080 --index-path /var/lib/fso.db
+file-search-on mcp                                                       # default: per-cwd persistent cache
+file-search-on mcp --index-path /var/lib/fso.db                          # explicit path (e.g. shared across cwd)
+file-search-on mcp --no-index                                            # in-memory only (process lifetime)
+file-search-on mcp --transport http --addr :8080
 ```
 
 Example Claude Desktop entry in `claude_desktop_config.json` (stdio):
@@ -446,20 +491,22 @@ Built on [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcont
 
 ## Monitoring dashboard
 
-Both long-running modes (`mcp` and `watch`) can expose a read-only monitoring dashboard. It's off by default, binds **127.0.0.1 only** (the host part of any address is ignored — only the port is used), needs no auth, and adds no dependencies — the UI is a single embedded page that polls a small JSON API.
+Both long-running modes (`mcp` and `watch`) expose a read-only monitoring dashboard. Since v0.65.0 it's **on by default** on a dynamic OS-assigned localhost port — many concurrent stdio agents each get their own dashboard without colliding. The server binds **127.0.0.1 only** (the host part of any address is ignored — only the port is used), needs no auth, and adds no dependencies — the UI is a single embedded page that polls a small JSON API.
 
 ```sh
-file-search-on mcp --monitor                                  # dynamic OS-assigned port (no collisions)
-file-search-on mcp --monitor-addr :9090                       # pin a fixed port
-file-search-on mcp --transport http --addr :8080 --monitor
-file-search-on watch 'is_image' -d ~/Screenshots --monitor
+file-search-on mcp                                            # default: dashboard on dynamic port
+file-search-on mcp --monitor-addr :9090                       # pin a fixed port instead
+file-search-on mcp --no-monitor                               # opt out (hermetic CI / sandboxed runs)
+file-search-on mcp --transport http --addr :8080              # dashboard still auto-starts
+file-search-on watch 'is_image' -d ~/Screenshots              # default: dashboard auto-starts
+file-search-on monitors                                       # list active dashboards across all instances
 ```
 
-`--monitor` picks a free localhost port (so **many concurrent stdio agents** each get their own dashboard without colliding); `--monitor-addr :PORT` pins a fixed one. Find the URL in the stderr log line, or — for an `mcp` server — ask it via the **`monitor_info` MCP tool**, which also reports sibling instances.
+Find the URL in the stderr log line (`monitor dashboard: http://127.0.0.1:<port>/`), via the `monitors` subcommand, or — for an `mcp` server — by calling the **`monitor_info` MCP tool**, which also reports sibling instances. The legacy `--monitor` bool is kept as a no-op for back-compat (same effect as no flag).
 
 Open the URL. Five panels:
 
-- **Overview** — version, uptime, run mode, PID / Go version / GOMAXPROCS, default worker count, index backing (path or in-memory), body-cache cap.
+- **Overview** — version, uptime, run mode, PID / Go version / GOMAXPROCS, default worker count, **index backend** (🔒 persistent path / 🧠 in-memory with reason — `--no-index` opt-out or lock-contention fallback), body-cache cap.
 - **Cache** — the attribute / body / embedding cache counters as live cards with derived **hit-rate %** and sparklines; body evictions / oversize rejects / embed model-mismatches flagged.
 - **Activity** — live MCP tool-call feed (tool, elapsed, outcome, result count), per-tool call / error / cancel counts and p50 / p95 / max latency, and an in-flight gauge. (Watch mode has no MCP calls, so this panel shows a notice.)
 - **Capabilities** — registered content types grouped by family, project types, OCR provider availability, embedder model / server + a reachability check.

--- a/examples/bytecode.md
+++ b/examples/bytecode.md
@@ -175,7 +175,7 @@ The same applies to `.pyc` files inside Python wheel (`.whl`) archives and `.was
 
 ## Caveats
 
-- **`.NET` PE assemblies** detect as `binary/pe`, not `bytecode/*`. They're PE files on disk with CLR metadata in a specific PE section — separate code path. Tracked as a follow-up to issue #139.
+- **`.NET` PE assemblies** detect as `binary/pe`, not `bytecode/*`. They're PE files on disk with CLR metadata in a specific PE section — separate code path. Left for a future follow-up; no issue currently tracking.
 - **JAR / WAR / EAR / AAR** detect as `archive/zip` (the existing alias list). Use `archive-contents` to walk the inner `.class` entries.
 - **Python magic numbers go out of date**. Each CPython release picks a new magic; the table covers 3.7-3.14. Unknown magics return empty `runtime_version` but still detect as `bytecode/python`.
 - **`.class` constant-pool walking caps at 65535 entries** (the JVMS hard limit). Larger files are truncated rather than reading unboundedly.

--- a/examples/indexing.md
+++ b/examples/indexing.md
@@ -2,22 +2,31 @@
 
 `file-search-on` parses every matching candidate file on every walk: PDF metadata, EXIF blocks, audio tags, markdown front-matter, ZIP headers, binary architectures. For trees that change rarely (a code repo, a Music library, an archive) this is wasted work — the *expression* changes between runs, but the underlying *attributes* don't.
 
-`--index-path` plugs in an on-disk cache (a single bbolt file). Each entry is keyed by absolute path and validated against the file's `(size, mtime)` pair. Modify a file and only that entry is invalidated. Different CEL expressions reuse the same cache — the index stores attributes, not search results.
+Since v0.64.0 the on-disk index is **on by default**. Every subcommand that walks a tree (`search`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `diff`, `archive-contents`, `organize`, `near-duplicates`, `preset`, `attrs`, `watch`, `mcp`) auto-creates a per-cwd bbolt cache the first time it runs. Each entry is keyed by absolute path and validated against the file's `(size, mtime)` pair. Modify a file and only that entry is invalidated. Different CEL expressions reuse the same cache — the index stores attributes, not search results.
+
+## Default path scheme
+
+```
+<UserCacheDir>/file-search-on/indexes/<basename(cwd)>-<sha1(abs(cwd))[:6]>.db
+```
+
+- **macOS**:   `~/Library/Caches/file-search-on/indexes/file-search-on-3a7b2c.db`
+- **Linux**:   `$XDG_CACHE_HOME/file-search-on/indexes/...` (or `~/.cache/...`)
+- **Windows**: `%LOCALAPPDATA%/file-search-on/indexes/...`
+
+The `<basename>-<shorthash>` form is readable in `ls` and collision-free across projects that share a basename. Different cwds get different files; the same cwd is deterministic. Per-cwd keying means multiple concurrent stdio agents across different projects never fight for the same bbolt file.
 
 ## CLI: cold + warm
 
 ```sh
-# Cold: parses every file, stores the attribute payload in the bbolt file.
-file-search-on 'is_markdown && word_count > 500' \
-    -d ~/notes \
-    --index-path ~/.cache/fso/notes.db
+# Cold: parses every file, stores the attribute payload in the default
+# per-cwd bbolt file. No flag needed.
+file-search-on 'is_markdown && word_count > 500' -d ~/notes
 
-# Warm: same dir, different CEL expression, same cache. The PDF metadata,
+# Warm: same dir, different CEL expression, same cache. PDF metadata,
 # markdown frontmatter, image EXIF — all already cached. The walk still
 # stats every file (mtime/size validation) but skips the per-file parse.
-file-search-on 'is_pdf && page_count > 20' \
-    -d ~/notes \
-    --index-path ~/.cache/fso/notes.db
+file-search-on 'is_pdf && page_count > 20' -d ~/notes
 ```
 
 After each run, the CLI prints a stderr footer:
@@ -32,63 +41,95 @@ index: 1234 hits, 56 misses, 56 stored, 0 stale, 0 errors
 - **stale** — entry existed but `(size, mtime)` mismatched; entry was discarded and the file was re-parsed.
 - **errors** — encoding failures, oversized payloads, write-channel back-pressure. Cache misses are always recoverable; errors are diagnostic.
 
+## Override the default path
+
+`--index-path <file.db>` overrides the per-cwd default. Useful when you want to share a single cache across multiple cwds, or pin the location for backup / shared-CI scenarios:
+
+```sh
+file-search-on 'is_image' -d ~/Pictures --index-path /Volumes/Backup/photos.db
+```
+
+## Opt out: `--no-index`
+
+`--no-index` disables the on-disk index entirely for that run; the tool falls back to a process-lifetime in-memory cache. Useful for:
+
+- **Hermetic CI** — tests / scripts that should leave no disk side effects.
+- **One-shot runs** — a single grep-like invocation where the cache file is overhead.
+- **Lock-contention bypass** — see below.
+
+```sh
+file-search-on 'is_source' -d ./project --no-index
+```
+
+## Multi-instance: lock contention falls back gracefully
+
+bbolt is a single-writer database. When two stdio agents share the same cwd:
+
+1. The first wins the file lock.
+2. The second's `Open` blocks 5 s, then transparently falls back to in-memory caching for the rest of its session. A one-line stderr warning surfaces the fact:
+
+```
+file-search-on: index file <path>.db is held by another file-search-on instance;
+this session will use in-memory cache (use --no-index to silence this warning)
+```
+
+Both agents keep working; only the cache layer differs for the loser. The first agent's writes accumulate normally; the second restarts cold next time. The monitor dashboard's Overview panel shows the backend state with a badge: 🔒 persistent / 🧠 in-memory + reason (`lock_contention` or `no_index_flag`).
+
+Projects with **different cwds** → different bbolt files → zero contention. This is the common case (multiple Claude Code sessions across several repos at once).
+
 ## CLI: forcing a refresh
 
 The cache is invalidated automatically when a file's mtime or size changes. To force a full refresh of everything (e.g. after upgrading the binary across an attribute schema bump), delete the file:
 
 ```sh
-rm ~/.cache/fso/notes.db
-file-search-on 'is_markdown' -d ~/notes --index-path ~/.cache/fso/notes.db   # rebuilds
+rm ~/Library/Caches/file-search-on/indexes/file-search-on-3a7b2c.db
+file-search-on 'is_markdown' -d ~/notes   # rebuilds
 ```
 
 The tool will refuse to open an index file from an incompatible schema version with a message like:
 
 ```
-Error: index file at ~/.cache/fso/notes.db has an incompatible schema; delete it or pass a new --index-path
+Error: index file at <path>.db has an incompatible schema; delete it or pass a new --index-path
 ```
 
 We never auto-delete user files, even cache files — explicit `rm` is the recovery step.
 
-## MCP: cache lives for the server lifetime
+## MCP server: same default-on behaviour
 
-In MCP server mode the cache is **on by default** with no flag. It uses an in-memory implementation that lives for the server process. Agents that explore a tree iteratively get progressively faster `search` and `read_attributes` calls:
+`file-search-on mcp` inherits the same per-cwd default + same `--index-path` / `--no-index` overrides. Agents that explore a tree iteratively get progressively faster `search` and `read_attributes` calls; the cache survives MCP server restarts because it's on disk by default:
 
 ```sh
-file-search-on mcp                                         # in-memory cache, lost on restart
-file-search-on mcp --index-path ~/.cache/fso/agent.db      # bbolt-backed, survives restart
+file-search-on mcp                                    # default per-cwd index
+file-search-on mcp --index-path /var/lib/fso.db       # explicit shared path
+file-search-on mcp --no-monitor --no-index            # hermetic / no side effects
 ```
 
-Hit/miss counters are exposed via the new `index_stats` tool (no input, returns `hits/misses/puts/stales/errors`):
+Hit/miss counters are exposed via the `index_stats` MCP tool (no input, returns `hits/misses/puts/stales/errors` for attributes + body + embedding caches) and live on the monitor dashboard's Cache panel.
 
 ```json
-{
-  "name": "index_stats",
-  "arguments": {}
-}
+{ "name": "index_stats", "arguments": {} }
 ```
 
 ## When NOT to use it
 
-- **One-shot scripts**, e.g. a `find`-like invocation in a CI pipeline that walks a fresh checkout. The cache file would be cold every time and add disk I/O for no benefit.
-- **Trees that change every run**, like a build directory whose mtimes get bumped on every compile — every file is stale, every entry is invalidated, the cache is overhead.
+- **One-shot scripts** in a hermetic CI where any disk side effect is unwanted — pass `--no-index`.
+- **Trees that change every run**, like a build directory whose mtimes get bumped on every compile — every file is stale, every entry is invalidated, the cache is overhead. Either ignore that subtree via `--exclude` / `--prune-build-artefacts` or pass `--no-index`.
 - **Hostile inputs**, e.g. arbitrary user uploads. The encoder has a 256 KiB per-entry soft cap to defend against pathological frontmatter, but you still don't want to point the cache at content you don't trust.
 
 ## CI / cron / large libraries
 
-For larger trees that you scan periodically (e.g. weekly photo backup, monthly archive triage), put the index file under `~/.cache/`:
+For trees that you scan periodically (e.g. weekly photo backup, monthly archive triage), the per-cwd default works out of the box — running `file-search-on` from the same cwd each time hits the same cache file:
 
 ```sh
 # Photo library — full sweep monthly, then cheap delta queries during the month
-mkdir -p ~/.cache/fso
-file-search-on 'is_image && taken_at > timestamp("2024-01-01T00:00:00Z")' \
-    -d ~/Pictures \
-    --index-path ~/.cache/fso/photos.db
+cd ~/Pictures
+file-search-on 'is_image && taken_at > timestamp("2024-01-01T00:00:00Z")'
 ```
 
 Subsequent queries against `~/Pictures` for *any* attribute (camera_model, GPS bounding box, ISO range) hit the cache. Only files that were added, edited, or moved since the last walk re-parse.
 
-Bbolt is a single file, so it backs up trivially (`cp ~/.cache/fso/photos.db ~/backups/`). It's also safe to copy across machines as long as the absolute paths line up — the validator only checks `(size, mtime)`, not host or filesystem identity.
+Bbolt is a single file, so it backs up trivially (`cp ~/Library/Caches/file-search-on/indexes/<file>.db ~/backups/`). It's also safe to copy across machines as long as the absolute paths line up — the validator only checks `(size, mtime)`, not host or filesystem identity.
 
 ## Inspecting the cache
 
-There is no built-in `index` subcommand for stats / vacuum / dump (yet). The MCP `index_stats` tool is the canonical observability surface; the CLI footer line is the equivalent for one-shot use. If your index file grows unwieldy after months of file churn, the simplest reset is to delete it.
+There is no built-in `index` subcommand for stats / vacuum / dump (yet). The MCP `index_stats` tool is the canonical observability surface; the CLI footer line is the equivalent for one-shot use. The monitor dashboard surfaces the same counters live with sparklines. If your index file grows unwieldy after months of file churn, the simplest reset is to delete it.

--- a/examples/monitoring.md
+++ b/examples/monitoring.md
@@ -1,30 +1,33 @@
 # Monitoring dashboard
 
-The long-running modes — the `mcp` server and the `watch` command — can serve a small **read-only** monitoring dashboard so you can watch file-search-on's internal state while it runs: is the cache working, what is the agent doing right now, is OCR / embedding available.
+The long-running modes — the `mcp` server and the `watch` command — serve a small **read-only** monitoring dashboard so you can watch file-search-on's internal state while it runs: is the cache working, what is the agent doing right now, is OCR / embedding available.
 
-It's **off by default**, binds **127.0.0.1 only** (the host part of any address is ignored — only the port matters), has **no auth**, and adds **no dependencies** (the UI is a single embedded page polling a JSON API).
+Since v0.65.0 it's **on by default** on a dynamic OS-assigned localhost port — many concurrent stdio agents each get their own dashboard without colliding. The server binds **127.0.0.1 only** (the host part of any address is ignored — only the port matters), has **no auth**, and adds **no dependencies** (the UI is a single embedded page polling a JSON API).
 
 ```sh
-# stdio MCP server + dashboard on a dynamic (OS-assigned) port
-file-search-on mcp --monitor
+# stdio MCP server — dashboard auto-starts on a dynamic port
+file-search-on mcp
 
-# pin a fixed port instead
+# pin a fixed port instead of a dynamic one
 file-search-on mcp --monitor-addr :9090
 
-# HTTP MCP server + dashboard
-file-search-on mcp --transport http --addr :8080 --monitor
+# opt out for hermetic / sandboxed runs
+file-search-on mcp --no-monitor
+
+# HTTP MCP server + dashboard (auto-starts, same as stdio)
+file-search-on mcp --transport http --addr :8080
 
 # watch mode + dashboard
-file-search-on watch 'is_image && body.contains("error")' --ocr -d ~/Desktop --monitor
+file-search-on watch 'is_image && body.contains("error")' --ocr -d ~/Desktop
 ```
 
-`--monitor` picks a free localhost port; `--monitor-addr :PORT` pins one. The chosen URL is printed to stderr (`monitor dashboard: http://127.0.0.1:<port>/`) — or, for an `mcp` server, ask it via the `monitor_info` tool. Then open that URL.
+The chosen URL is printed to stderr (`monitor dashboard: http://127.0.0.1:<port>/`) — or, for an `mcp` server, ask it via the `monitor_info` tool. For a one-shot view of every active dashboard across concurrent instances, `file-search-on monitors` lists the live registry. The legacy `--monitor` bool is kept as a documented no-op for back-compat (same effect as no flag).
 
 ## Panels
 
 | Panel | Shows |
 | --- | --- |
-| **Overview** | version, uptime, run mode (`mcp-stdio` / `mcp-http` / `watch`), PID, Go version, GOMAXPROCS, default worker count, index backing (path or in-memory), body-cache cap, goroutines |
+| **Overview** | version, uptime, run mode (`mcp-stdio` / `mcp-http` / `watch`), PID, Go version, GOMAXPROCS, default worker count, **index backend** (🔒 persistent path / 🧠 in-memory with reason — `--no-index` opt-out or `lock_contention` fallback), body-cache cap, goroutines |
 | **Cache** | attribute / body / embedding cache counters with derived **hit-rate %** + sparklines; body evictions / oversize rejects and embed model-mismatches highlighted |
 | **Activity** | live MCP tool-call feed (tool, elapsed, outcome, result count), per-tool call/error/cancel counts + p50/p95/max latency, in-flight gauge |
 | **Capabilities** | registered content types grouped by family, project types, OCR provider availability, embedder model/server + reachability |


### PR DESCRIPTION
Three feature PRs (#243 default on-disk index, #245 default-on monitor, #240 OLLAMA_HOST env var) plus older drift had left user-facing docs behind the code. **Pure doc sync, no functional changes.**

## What was wrong

| Site | Was | Now |
| --- | --- | --- |
| README.md:70 | "Fourteen tools exposed" + 14 names | "Twenty tools exposed" + 20 names |
| README.md:402 | "Eleven tools are exposed" + 13 rows | "Twenty tools are exposed" + family-grouped table mirroring the file-search-on-mcp skill |
| README.md:423 | "MCP keeps an attribute cache for process lifetime. Pass --index-path to persist." | Index is on-by-default at per-cwd path; --no-index opts out; --index-path overrides. Multi-instance-safe. |
| README.md:482 | "Monitoring dashboard … off by default … --monitor to enable" | "On by default since v0.65.0 … --no-monitor opts out … --monitor kept as back-compat no-op" |
| README.md (new) | (no env-var doc) | New subsection: "Pointing at a non-default Ollama" — documents --embedding-server > $OLLAMA_HOST > localhost:11434 |
| examples/indexing.md | "--index-path plugs in an on-disk cache" (opt-in framing) | Rewritten end-to-end — leads with the per-cwd default path scheme, covers --no-index, lock-contention fallback |
| examples/monitoring.md | "off by default", every example passes --monitor | "on by default", examples show plain `mcp`/`watch`; --no-monitor opts out |
| examples/bytecode.md:178 | "Tracked as a follow-up to issue #139" (which is closed) | "Left for a future follow-up; no issue currently tracking" |

## Audit results

All 15 cited issue numbers in `examples/*.md` were audited against `gh issue view`: every one is closed/merged. Most citations are correct historical attributions (gives credit for shipped work — leave alone). The only genuinely stale tracking-ref was the bytecode.md one above, since #139 closed without the .NET PE follow-up being re-tracked.

## Verification

\`\`\`sh
$ grep -nE '(Fourteen|Eleven) (tools|MCP)' README.md
# (no hits — clean)

$ grep -c 'mcp.AddTool' internal/mcpserver/server.go
20  # matches README's claimed count
\`\`\`

`go fix ./...` idempotent — doc-only change.

## Test plan
- [ ] Render \`README.md\` (e.g. \`gh repo view --web\`) and confirm the 20-tool table renders cleanly across families
- [ ] Spot-check the inline 20-tool list at L70 — every name should exist as a registered MCP tool
- [ ] Read the new "Pointing at a non-default Ollama" subsection in context; confirm wording is consistent with examples/semantic-search.md (the existing canonical doc for OLLAMA_HOST)
- [ ] Read \`examples/indexing.md\` end-to-end — every command should work as written (cold/warm pattern, --no-index, multi-instance fallback)
- [ ] Read \`examples/monitoring.md\` — every command should work; verify the panels table reflects current dashboard UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)