### PR TITLE
test(cmd): CLI coverage push — 28.6% to 48.4% (+19.8pp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Built in the open — issues, PRs, and feature requests warmly welcomed. See [Co
 - **CEL expressions** — the full Common Expression Language: comparisons, `&&`/`||`, string functions, list membership, timestamp arithmetic. Composes naturally with structural attributes.
 - **Fuzzy, phonetic, and geographic matching** — built-in `levenshtein`, `soundex`, `ngrams`, `ngram_similarity`, and `point_in_polygon` (for GPS bboxes / city outlines) let you write typo-tolerant and "sounds-like" queries against any string attribute. EXIF camera make in `Nikkon` instead of `Nikon`? Artist tag mistyped as `Radiohad`? Same query catches all of them. See [examples/fuzzy-search.md](./examples/fuzzy-search.md).
 - **Multiple output formats** — `bare` (paths only), `default`, `verbose` (multi-line), `json` (NDJSON), or a Go `text/template` via `--format`.
-- **MCP server mode** — same binary doubles as a [Model Context Protocol](https://modelcontextprotocol.io) server (stdio, HTTP, or SSE). Fourteen tools exposed: `search`, `read_attributes`, `read_lines`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `list_archive_contents`, `read_file_in_archive`, `detect_project`, `find_projects`, `resolve_project_for_path`, `list_attributes`, `index_stats`.
+- **MCP server mode** — same binary doubles as a [Model Context Protocol](https://modelcontextprotocol.io) server (stdio, HTTP, or SSE). Twenty tools exposed: `search`, `search_semantic`, `read_attributes`, `read_lines`, `stats`, `find_duplicates`, `find_near_duplicates`, `diff_trees`, `find_matches`, `watch_search`, `list_archive_contents`, `read_file_in_archive`, `detect_project`, `find_projects`, `resolve_project_for_path`, `list_attributes`, `list_presets`, `query_preset`, `index_stats`, `monitor_info`.
 - **Pure Go, no CGO** — cross-compiles cleanly to all six release targets. No image/audio/video decoder dependencies.
 - **Parallel walking** — files are evaluated across a worker pool (defaults to `NumCPU`).
 
@@ -240,7 +240,17 @@ Fingerprints cache via `--index-path` alongside the exact hash; repeat runs skip
 
 ### Common flags
 
-`-d <dir>` (repeatable for multi-root walks), `--exclude <glob>` (basename, repeatable), `--respect-gitignore`, `--timeout 30s` (partial results returned on expiry), `--workers N`, `--index-path <file.db>` (persistent attribute cache — see [examples/indexing.md](./examples/indexing.md)).
+`-d <dir>` (repeatable for multi-root walks), `--exclude <glob>` (basename, repeatable), `--respect-gitignore`, `--timeout 30s` (partial results returned on expiry), `--workers N`, `--index-path <file.db>` (override the per-cwd default index — see [examples/indexing.md](./examples/indexing.md)), `--no-index` (opt out of on-disk caching for hermetic runs).
+
+### Pointing at a non-default Ollama
+
+For semantic search and `search_semantic` (MCP), the embedding HTTP endpoint resolves in this order:
+
+1. `--embedding-server <url>` flag (CLI or `mcp` subcommand)
+2. `$OLLAMA_HOST` environment variable
+3. `http://localhost:11434` (built-in default)
+
+So a remote Ollama box on the LAN works without a per-invocation flag: `export OLLAMA_HOST=http://gpu-box:11434`. See [examples/semantic-search.md](./examples/semantic-search.md) for the full setup.
 
 ## Recipes
 
@@ -399,32 +409,67 @@ file-search-on mcp --timeout 90s                         # raise the per-call de
 
 For HTTP and SSE, `--addr` (default `:8080`) is the bind address and `--path` (default `/`) is the URL prefix. `--timeout` (default `60s`) sets the per-tool-call deadline; per-call `timeout_seconds` on the `search` tool input overrides it.
 
-Eleven tools are exposed:
+Twenty tools are exposed, grouped by family:
+
+**Search & inspect**
 
 | Tool | What it does |
 | --- | --- |
-| `search` | CEL expression over a directory tree. Supports `sort_by` / `limit` (top-K), `include_body` (full body filter), `include_snippet` (preview), `resolve_projects` (`project_type` per match), `prune_build_artefacts`, `fields` (project response to a subset of attributes; path / content_type / size always-on). Returns matches with the full attribute set + partial-result fields. |
-| `read_attributes` | Attributes for a single path — same shape as one `search` match. Accepts `fields` for the same token-saving projection. |
+| `search` | CEL expression over a directory tree. Supports `sort_by` / `limit` (top-K), `rank` (custom CEL sort key), `include_body` (full body filter), `include_snippet` (preview), `ocr_images` (run OCR before evaluating), `with_phash` (perceptual hash + `image_similar_to` function), `compute_hashes`, `check_disguised`, `with_xattrs`, `resolve_projects`, `prune_build_artefacts`, `fields` (token-saving projection — path / content_type / size always-on). Returns matches with the full attribute set + partial-result fields. |
+| `search_semantic` | Natural-language similarity search via local Ollama embeddings. Pre-prunes with an optional `expr`, embeds the query, ranks files by cosine similarity, applies a `threshold` cap. Embeddings cache per file. |
+| `read_attributes` | Attributes for a single path — same shape as one `search` match. Accepts `fields` for token-saving projection. |
 | `read_lines` | A specific line range of a file — pairs with `search` for context around matches. |
-| `stats` | Histogram + totals for a directory tree, bucketed by `group_by` (default `content_type`; full set documented in [Usage § Stats](#stats-and-reconnaissance)). |
+
+**Aggregate**
+
+| Tool | What it does |
+| --- | --- |
+| `stats` | Histogram + totals for a directory tree, bucketed by `group_by` (default `content_type`; recognised: `ext`, `dir`, `language`, `camera_make`, `camera_model`, `lens`, `artist`, `album`, `genre`, time buckets like `taken_at_month`, …). |
+
+**Dedup & diff**
+
+| Tool | What it does |
+| --- | --- |
 | `find_duplicates` | Byte-identical files keyed by sha256 — two-pass (size-bucket then hash). Sorted by `wasted_bytes` desc. |
 | `find_near_duplicates` | Similar files by SimHash fingerprint of extracted body. Catches typo edits, regenerated headers, template copies. Configurable similarity threshold (default 0.85). |
+| `diff_trees` | Cross-tree set operations by sha256 content hash — `a-minus-b`, `b-minus-a`, `intersect`, `union`, `mismatch` (same relative path, different content). Read-only; never mutates either tree. |
+
+**Archive**
+
+| Tool | What it does |
+| --- | --- |
 | `list_archive_contents` | Per-entry CEL filtering inside ZIP / TAR / TAR.GZ / GZIP without extracting. Same vocabulary as top-level search; cache-aware. |
 | `read_file_in_archive` | Read one named entry's bytes out of an archive. Returns content + content_type + attributes. |
+
+**Pattern + watch**
+
+| Tool | What it does |
+| --- | --- |
 | `find_matches` | Line-level regex (RE2) hits across a tree with `context_before` / `context_after` windows. CEL pre-prune (e.g. `is_source && language == "go"`) keeps the regex pass narrow. Replaces the search-then-`read_lines` dance with one call. |
+| `watch_search` | Bounded "tell me when X appears" subscription — block up to `duration_seconds` (default 30, capped at 600), return every new / changed file that matches the CEL filter. |
+
+**Project + introspection + monitoring**
+
+| Tool | What it does |
+| --- | --- |
 | `detect_project` | Project type(s) of one directory. |
 | `find_projects` | Walk a tree, list every project subdirectory. |
 | `resolve_project_for_path` | Walk UP from a file/dir path to the nearest enclosing project root. Useful when an agent has a stray path and needs to know the project context. |
 | `list_attributes` | The full canonical schema (`common`, `type_specific`, `frontmatter`, `functions`) plus registered content types. |
-| `index_stats` | Cache counters for the running server (hits, misses, puts, stales, errors). |
+| `list_presets` | Discover the eight built-in named search recipes (`recent_changes`, `recent_photos`, `old_drafts`, `large_files`, `large_binaries`, `suspicious_files`, `failed_tests`, `system_metadata`). |
+| `query_preset` | Run a named preset; per-call overrides for `dir`, `limit`, `excludes`, etc. |
+| `index_stats` | Cache counters for the running server (hits, misses, puts, stales, errors; same for body + embedding caches). |
+| `monitor_info` | This server's monitoring-dashboard URL + the registry of sibling instances. Pass `enable: true` to start the dashboard on demand if it isn't already running. |
 
-Every walking tool (`search`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `find_projects`) honours the same partial-result contract: on timeout the call returns `cancelled=true` with the results gathered so far, never an error. Agents inspect the flag rather than catching exceptions.
+Every walking tool (`search`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `find_projects`, `diff_trees`) honours the same partial-result contract: on timeout the call returns `cancelled=true` with the results gathered so far, never an error. Agents inspect the flag rather than catching exceptions.
 
-The MCP server keeps an attribute cache for its process lifetime — repeated `search` / `read_attributes` calls against the same files skip the parse step on the second and later invocations. Pass `--index-path` to persist the cache across restarts:
+Since v0.64.0 the on-disk index is **on by default**. The MCP server (like every other long-running subcommand) auto-creates a per-cwd bbolt cache at `<UserCacheDir>/file-search-on/indexes/<basename>-<sha1[:6]>.db` — repeated `search` / `read_attributes` calls against unchanged files skip parsing entirely. The default path is per-cwd so concurrent agents in different projects never collide; same-cwd contention falls back gracefully to in-memory (logged on stderr, surfaced on the dashboard as `index_fallback_reason: "lock_contention"`). Override with `--index-path`; opt out with `--no-index` for hermetic CI runs:
 
 ```sh
-file-search-on mcp --index-path ~/.cache/fso/agent.db                    # stdio + persistent cache
-file-search-on mcp --transport http --addr :8080 --index-path /var/lib/fso.db
+file-search-on mcp                                                       # default: per-cwd persistent cache
+file-search-on mcp --index-path /var/lib/fso.db                          # explicit path (e.g. shared across cwd)
+file-search-on mcp --no-index                                            # in-memory only (process lifetime)
+file-search-on mcp --transport http --addr :8080
 ```
 
 Example Claude Desktop entry in `claude_desktop_config.json` (stdio):
@@ -446,20 +491,22 @@ Built on [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcont
 
 ## Monitoring dashboard
 
-Both long-running modes (`mcp` and `watch`) can expose a read-only monitoring dashboard. It's off by default, binds **127.0.0.1 only** (the host part of any address is ignored — only the port is used), needs no auth, and adds no dependencies — the UI is a single embedded page that polls a small JSON API.
+Both long-running modes (`mcp` and `watch`) expose a read-only monitoring dashboard. Since v0.65.0 it's **on by default** on a dynamic OS-assigned localhost port — many concurrent stdio agents each get their own dashboard without colliding. The server binds **127.0.0.1 only** (the host part of any address is ignored — only the port is used), needs no auth, and adds no dependencies — the UI is a single embedded page that polls a small JSON API.
 
 ```sh
-file-search-on mcp --monitor                                  # dynamic OS-assigned port (no collisions)
-file-search-on mcp --monitor-addr :9090                       # pin a fixed port
-file-search-on mcp --transport http --addr :8080 --monitor
-file-search-on watch 'is_image' -d ~/Screenshots --monitor
+file-search-on mcp                                            # default: dashboard on dynamic port
+file-search-on mcp --monitor-addr :9090                       # pin a fixed port instead
+file-search-on mcp --no-monitor                               # opt out (hermetic CI / sandboxed runs)
+file-search-on mcp --transport http --addr :8080              # dashboard still auto-starts
+file-search-on watch 'is_image' -d ~/Screenshots              # default: dashboard auto-starts
+file-search-on monitors                                       # list active dashboards across all instances
 ```
 
-`--monitor` picks a free localhost port (so **many concurrent stdio agents** each get their own dashboard without colliding); `--monitor-addr :PORT` pins a fixed one. Find the URL in the stderr log line, or — for an `mcp` server — ask it via the **`monitor_info` MCP tool**, which also reports sibling instances.
+Find the URL in the stderr log line (`monitor dashboard: http://127.0.0.1:<port>/`), via the `monitors` subcommand, or — for an `mcp` server — by calling the **`monitor_info` MCP tool**, which also reports sibling instances. The legacy `--monitor` bool is kept as a no-op for back-compat (same effect as no flag).
 
 Open the URL. Five panels:
 
-- **Overview** — version, uptime, run mode, PID / Go version / GOMAXPROCS, default worker count, index backing (path or in-memory), body-cache cap.
+- **Overview** — version, uptime, run mode, PID / Go version / GOMAXPROCS, default worker count, **index backend** (🔒 persistent path / 🧠 in-memory with reason — `--no-index` opt-out or lock-contention fallback), body-cache cap.
 - **Cache** — the attribute / body / embedding cache counters as live cards with derived **hit-rate %** and sparklines; body evictions / oversize rejects / embed model-mismatches flagged.
 - **Activity** — live MCP tool-call feed (tool, elapsed, outcome, result count), per-tool call / error / cancel counts and p50 / p95 / max latency, and an in-flight gauge. (Watch mode has no MCP calls, so this panel shows a notice.)
 - **Capabilities** — registered content types grouped by family, project types, OCR provider availability, embedder model / server + a reachability check.

--- a/cmd/file-search-on/archive_cmd_test.go
+++ b/cmd/file-search-on/archive_cmd_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"archive/zip"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// makeZip builds a small ZIP archive at dest with the given entry map.
+// Returns the absolute path. Used as the fixture for archive tests.
+func makeZip(t *testing.T, dest string, entries map[string]string) string {
+	t.Helper()
+	f, err := os.Create(dest)
+	if err != nil {
+		t.Fatalf("create zip: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+	for name, body := range entries {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatalf("zip.Create %s: %v", name, err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatalf("zip write %s: %v", name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return dest
+}
+
+// TestArchiveContentsCmd_Run_ListsAllEntries seeds a 3-entry ZIP
+// and confirms the JSON output reports all three.
+func TestArchiveContentsCmd_Run_ListsAllEntries(t *testing.T) {
+	zipPath := makeZip(t, filepath.Join(t.TempDir(), "test.zip"), map[string]string{
+		"README.md":      "# hello\n",
+		"src/main.go":    "package main\n\nfunc main(){}\n",
+		"data/config.json": `{"k":"v"}`,
+	})
+
+	cmd := &ArchiveContentsCmd{Archive: zipPath, Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	entries, _ := got["Entries"].([]any)
+	if len(entries) != 3 {
+		t.Errorf("expected 3 entries, got %d: %v", len(entries), entries)
+	}
+}
+
+// TestArchiveContentsCmd_Run_GlobPrune applies the cheap basename
+// pre-prune and confirms only matching entries come back.
+func TestArchiveContentsCmd_Run_GlobPrune(t *testing.T) {
+	zipPath := makeZip(t, filepath.Join(t.TempDir(), "test.zip"), map[string]string{
+		"a.go":   "package main\n",
+		"b.go":   "package other\n",
+		"c.txt":  "not Go\n",
+		"d.json": `{}`,
+	})
+
+	cmd := &ArchiveContentsCmd{Archive: zipPath, Glob: "*.go", Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	entries, _ := got["Entries"].([]any)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries after *.go glob prune, got %d: %v", len(entries), entries)
+	}
+}
+
+// TestArchiveContentsCmd_Run_MaxEntries caps the result count.
+func TestArchiveContentsCmd_Run_MaxEntries(t *testing.T) {
+	zipPath := makeZip(t, filepath.Join(t.TempDir(), "test.zip"), map[string]string{
+		"a.txt": "1\n", "b.txt": "2\n", "c.txt": "3\n", "d.txt": "4\n", "e.txt": "5\n",
+	})
+
+	cmd := &ArchiveContentsCmd{Archive: zipPath, MaxEntries: 2, Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	entries, _ := got["Entries"].([]any)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries after --max=2, got %d", len(entries))
+	}
+}
+
+// TestArchiveReadCmd_Run_ExtractsEntry reads a specific entry's
+// bytes back out via the JSON envelope path.
+func TestArchiveReadCmd_Run_ExtractsEntry(t *testing.T) {
+	const wantContent = "# README\n\nhi there\n"
+	zipPath := makeZip(t, filepath.Join(t.TempDir(), "test.zip"), map[string]string{
+		"README.md":   wantContent,
+		"src/main.go": "package main\n",
+	})
+
+	cmd := &ArchiveReadCmd{Archive: zipPath, Entry: "README.md", Output: "json"}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	// Go's json encoder base64-encodes []byte by default; decode to
+	// compare against the original entry body.
+	contentB64, _ := got["content"].(string)
+	decoded, err := base64.StdEncoding.DecodeString(contentB64)
+	if err != nil {
+		t.Fatalf("base64 decode content: %v (raw: %q)", err, contentB64)
+	}
+	if string(decoded) != wantContent {
+		t.Errorf("content = %q, want %q", decoded, wantContent)
+	}
+}
+
+// TestArchiveReadCmd_Run_MissingEntry confirms an unknown entry
+// surfaces the documented exit-1 error.
+func TestArchiveReadCmd_Run_MissingEntry(t *testing.T) {
+	zipPath := makeZip(t, filepath.Join(t.TempDir(), "test.zip"), map[string]string{"only.txt": "x\n"})
+
+	cmd := &ArchiveReadCmd{Archive: zipPath, Entry: "does-not-exist.md", Output: "json"}
+	_, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err == nil {
+		t.Fatalf("expected error for missing entry, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got %q", err.Error())
+	}
+}

--- a/cmd/file-search-on/attrs_test.go
+++ b/cmd/file-search-on/attrs_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,32 +9,6 @@ import (
 
 	"github.com/richardwooding/file-search-on/internal/index"
 )
-
-// captureStdout swaps os.Stdout for a pipe for the duration of fn,
-// returning what was written. Used to assert printJSON output from
-// AttrsCmd.Run without needing to mock the formatter.
-func captureStdout(t *testing.T, fn func() error) (string, error) {
-	t.Helper()
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	orig := os.Stdout
-	os.Stdout = w
-	defer func() { os.Stdout = orig }()
-
-	done := make(chan struct{})
-	var buf bytes.Buffer
-	go func() {
-		_, _ = io.Copy(&buf, r)
-		close(done)
-	}()
-
-	runErr := fn()
-	_ = w.Close()
-	<-done
-	return buf.String(), runErr
-}
 
 // TestAttrsCmd_PopulatesIndex confirms the long-standing gap is
 // closed: running `attrs` on a file with an explicit --index-path

--- a/cmd/file-search-on/duplicates_cmd_test.go
+++ b/cmd/file-search-on/duplicates_cmd_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDuplicatesCmd_Run_FindsSha256Duplicates seeds two files with
+// identical bytes (and one unique sibling), then confirms the cmd
+// surfaces the duplicate group.
+func TestDuplicatesCmd_Run_FindsSha256Duplicates(t *testing.T) {
+	tmp := t.TempDir()
+	body := "same content across two files\n"
+	mustWriteFile(t, filepath.Join(tmp, "a.txt"), body)
+	mustWriteFile(t, filepath.Join(tmp, "b.txt"), body)
+	mustWriteFile(t, filepath.Join(tmp, "different.txt"), "unique\n")
+
+	cmd := &DuplicatesCmd{Dir: []string{tmp}, Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	groups, _ := got["duplicates"].([]any)
+	if len(groups) != 1 {
+		t.Fatalf("expected exactly one duplicate group, got %d: %v", len(groups), groups)
+	}
+	g, _ := groups[0].(map[string]any)
+	paths, _ := g["paths"].([]any)
+	if len(paths) != 2 {
+		t.Errorf("expected 2 paths in the duplicate group, got %d: %v", len(paths), paths)
+	}
+}
+
+// TestDuplicatesCmd_Run_NoDuplicates seeds three unique files and
+// asserts the cmd reports zero groups (clean exit).
+func TestDuplicatesCmd_Run_NoDuplicates(t *testing.T) {
+	tmp := t.TempDir()
+	for i, body := range []string{"alpha\n", "beta\n", "gamma\n"} {
+		mustWriteFile(t, filepath.Join(tmp, "f"+string(rune('a'+i))+".txt"), body)
+	}
+
+	cmd := &DuplicatesCmd{Dir: []string{tmp}, Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	groups, _ := got["duplicates"].([]any)
+	if len(groups) != 0 {
+		t.Errorf("expected zero duplicate groups, got %d: %v", len(groups), groups)
+	}
+}
+
+// TestDuplicatesCmd_Run_MinSizeFilter confirms the --min-size cap
+// excludes small files from the dedup pass.
+func TestDuplicatesCmd_Run_MinSizeFilter(t *testing.T) {
+	tmp := t.TempDir()
+	// Two tiny files with identical content — would dedupe without the floor.
+	mustWriteFile(t, filepath.Join(tmp, "tiny-a.txt"), "x")
+	mustWriteFile(t, filepath.Join(tmp, "tiny-b.txt"), "x")
+
+	cmd := &DuplicatesCmd{Dir: []string{tmp}, MinSize: 100, Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	groups, _ := got["duplicates"].([]any)
+	if len(groups) != 0 {
+		t.Errorf("expected zero groups after min-size filter, got %d: %v", len(groups), groups)
+	}
+}
+
+// TestDuplicatesCmd_Run_CELScopeFilter scopes the walk to a single
+// content family via the optional Expr arg.
+func TestDuplicatesCmd_Run_CELScopeFilter(t *testing.T) {
+	tmp := t.TempDir()
+	body := "duplicate content\n"
+	// Two identical markdown files — should dedupe.
+	mustWriteFile(t, filepath.Join(tmp, "a.md"), body)
+	mustWriteFile(t, filepath.Join(tmp, "b.md"), body)
+	// Two identical text files — should NOT show under is_markdown filter.
+	mustWriteFile(t, filepath.Join(tmp, "a.txt"), body)
+	mustWriteFile(t, filepath.Join(tmp, "b.txt"), body)
+
+	cmd := &DuplicatesCmd{Dir: []string{tmp}, Expr: "is_markdown", Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	groups, _ := got["duplicates"].([]any)
+	if len(groups) != 1 {
+		t.Fatalf("expected exactly one markdown-only duplicate group, got %d: %v", len(groups), groups)
+	}
+}

--- a/cmd/file-search-on/find_matches_cmd_test.go
+++ b/cmd/file-search-on/find_matches_cmd_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFindMatchesCmd_Run_BasicMatch confirms the command surfaces a
+// match line via the default grep-style output.
+func TestFindMatchesCmd_Run_BasicMatch(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "a.go"), "package main\n\n// TODO: write the code\nfunc main() {}\n")
+	mustWriteFile(t, filepath.Join(tmp, "b.go"), "package other\n\nfunc f() {}\n")
+
+	cmd := &FindMatchesCmd{Pattern: `TODO`, Dir: []string{tmp}, Expr: `is_source && language == "go"`, Output: "default", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(out, "TODO: write the code") {
+		t.Errorf("expected match line in output, got %q", out)
+	}
+	if strings.Contains(out, "b.go") {
+		t.Errorf("expected only a.go to match, found b.go in output %q", out)
+	}
+}
+
+// TestFindMatchesCmd_Run_NoMatch confirms a clean run with zero
+// matches still produces valid output, and signals "no match" via
+// grep-style exit code 1 (the documented convention).
+func TestFindMatchesCmd_Run_NoMatch(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "f.go"), "package main\n\nfunc main() {}\n")
+
+	cmd := &FindMatchesCmd{Pattern: `XXXNEVERMATCH`, Dir: []string{tmp}, Output: "json", NoIndex: true}
+	out, runErr := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	// runErr is non-nil for no-match (grep convention: exit 1); the
+	// JSON output still lands on stdout regardless.
+	if runErr == nil {
+		t.Errorf("expected non-nil error for no-match (grep convention), got nil")
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	matches, _ := got["matches"].([]any)
+	if len(matches) != 0 {
+		t.Errorf("expected zero matches for pattern that doesn't match anything, got %d", len(matches))
+	}
+}
+
+// TestFindMatchesCmd_Run_ContextWindow exercises the -C shortcut
+// and asserts before/after lines land in the output.
+func TestFindMatchesCmd_Run_ContextWindow(t *testing.T) {
+	tmp := t.TempDir()
+	body := "line one\nline two\nMATCH HERE\nline four\nline five\n"
+	mustWriteFile(t, filepath.Join(tmp, "f.txt"), body)
+
+	cmd := &FindMatchesCmd{Pattern: `MATCH`, Dir: []string{tmp}, Context: 1, Output: "default", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// Default grep-style output uses "-" for context lines, ":" for match line.
+	if !strings.Contains(out, "line two") {
+		t.Errorf("expected context-before line 'line two' in output, got %q", out)
+	}
+	if !strings.Contains(out, "line four") {
+		t.Errorf("expected context-after line 'line four' in output, got %q", out)
+	}
+	if !strings.Contains(out, "MATCH HERE") {
+		t.Errorf("expected match line 'MATCH HERE' in output, got %q", out)
+	}
+}
+
+// TestFindMatchesCmd_Run_CELScopeFilter confirms the CEL pre-prune
+// narrows the candidate set before the regex scan fires.
+func TestFindMatchesCmd_Run_CELScopeFilter(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "go-side.go"), "// keyword\npackage main\n")
+	mustWriteFile(t, filepath.Join(tmp, "text-side.txt"), "keyword in text\n")
+
+	// Restrict to Go source — the .txt file should be invisible.
+	cmd := &FindMatchesCmd{Pattern: `keyword`, Dir: []string{tmp}, Expr: `is_source && language == "go"`, Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	matches, _ := got["matches"].([]any)
+	for _, m := range matches {
+		mm, _ := m.(map[string]any)
+		path, _ := mm["path"].(string)
+		if strings.HasSuffix(path, ".txt") {
+			t.Errorf("expected CEL filter to exclude .txt files, got match in %q", path)
+		}
+	}
+}

--- a/cmd/file-search-on/hashset_cmd_test.go
+++ b/cmd/file-search-on/hashset_cmd_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHashSetBuildCmd_Run_FromText compiles a small text hashlist
+// into a bbolt file and confirms the count summary lands on stdout.
+func TestHashSetBuildCmd_Run_FromText(t *testing.T) {
+	tmp := t.TempDir()
+	in := filepath.Join(tmp, "list.txt")
+	// Three sha256s (64 hex chars each — length-based auto-detection).
+	mustWriteFile(t, in,
+		"d2d2c790271471dee54c81a0d4f72f48d9b1b1c54c1f6f8a5c8e2e6cbdf09c5b\n"+
+			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n"+
+			"# a comment line\n"+
+			"9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08\n")
+
+	out := filepath.Join(tmp, "out.db")
+	cmd := &HashSetBuildCmd{From: in, Out: out, Format: "text", Quiet: true}
+	stdout, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(stdout, "sha256: 3") {
+		t.Errorf("expected 'sha256: 3' in stdout, got %q", stdout)
+	}
+}
+
+// TestHashSetBuildCmd_Run_MissingInput surfaces an error when the
+// input file doesn't exist.
+func TestHashSetBuildCmd_Run_MissingInput(t *testing.T) {
+	tmp := t.TempDir()
+	cmd := &HashSetBuildCmd{
+		From:   filepath.Join(tmp, "does-not-exist.txt"),
+		Out:    filepath.Join(tmp, "out.db"),
+		Format: "text",
+		Quiet:  true,
+	}
+	_, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err == nil {
+		t.Fatalf("expected error for missing input, got nil")
+	}
+	if !strings.Contains(err.Error(), "open input") {
+		t.Errorf("expected 'open input' in error, got %q", err.Error())
+	}
+}
+
+// TestHashSetInfoCmd_Run_ReportsCounts builds a bbolt hashset then
+// reads its counts back via the `info` subcommand.
+func TestHashSetInfoCmd_Run_ReportsCounts(t *testing.T) {
+	tmp := t.TempDir()
+	in := filepath.Join(tmp, "list.txt")
+	// Two sha1s (40 hex chars each) and one md5 (32 hex chars).
+	mustWriteFile(t, in,
+		"da39a3ee5e6b4b0d3255bfef95601890afd80709\n"+
+			"a94a8fef8c91167b18b8e1c9a02d1b4e7d72a3a3\n"+
+			"d41d8cd98f00b204e9800998ecf8427e\n")
+
+	bolt := filepath.Join(tmp, "out.db")
+	buildCmd := &HashSetBuildCmd{From: in, Out: bolt, Format: "text", Quiet: true}
+	if _, err := captureStdout(t, func() error { return buildCmd.Run(t.Context()) }); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	infoCmd := &HashSetInfoCmd{Path: bolt}
+	stdout, err := captureStdout(t, func() error { return infoCmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("info run: %v", err)
+	}
+	if !strings.Contains(stdout, "sha1:   2") {
+		t.Errorf("expected 'sha1:   2' in info output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "md5:    1") {
+		t.Errorf("expected 'md5:    1' in info output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "total:  3") {
+		t.Errorf("expected 'total:  3' in info output, got %q", stdout)
+	}
+}
+
+// TestHashSetInfoCmd_Run_ReadsTextFile confirms `info` also accepts
+// a plain-text hashlist (not just a built bbolt file) — the
+// HashSet.Open helper handles both formats transparently.
+func TestHashSetInfoCmd_Run_ReadsTextFile(t *testing.T) {
+	tmp := t.TempDir()
+	in := filepath.Join(tmp, "list.txt")
+	mustWriteFile(t, in, "d41d8cd98f00b204e9800998ecf8427e\n")
+
+	cmd := &HashSetInfoCmd{Path: in}
+	stdout, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(stdout, "md5:    1") {
+		t.Errorf("expected 'md5:    1' in text-file info output, got %q", stdout)
+	}
+}
+
+// TestHashSetInfoCmd_Run_MissingFile surfaces an error when the
+// hashset path doesn't exist.
+func TestHashSetInfoCmd_Run_MissingFile(t *testing.T) {
+	tmp := t.TempDir()
+	cmd := &HashSetInfoCmd{Path: filepath.Join(tmp, "does-not-exist.db")}
+	_, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err == nil {
+		t.Fatalf("expected error for missing hashset file, got nil")
+	}
+}

--- a/cmd/file-search-on/lines_cmd_test.go
+++ b/cmd/file-search-on/lines_cmd_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLinesCmd_Run_BasicRange asserts the default text-output path
+// emits the requested 1-indexed-inclusive line range.
+func TestLinesCmd_Run_BasicRange(t *testing.T) {
+	tmp := t.TempDir()
+	body := "one\ntwo\nthree\nfour\nfive\n"
+	target := filepath.Join(tmp, "file.txt")
+	mustWriteFile(t, target, body)
+
+	cmd := &LinesCmd{Path: target, Start: 2, End: 4, Output: "text"}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	want := "two\nthree\nfour\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
+	}
+}
+
+// TestLinesCmd_Run_JSON exercises the JSON branch: confirms the
+// wire shape (lines / total_lines / start / end / truncated).
+func TestLinesCmd_Run_JSON(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "f.txt")
+	mustWriteFile(t, target, "a\nb\nc\n")
+
+	cmd := &LinesCmd{Path: target, Start: 1, End: 0, Output: "json"}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	lines, _ := got["lines"].([]any)
+	if len(lines) != 3 {
+		t.Errorf("lines length = %d, want 3 (raw: %v)", len(lines), got)
+	}
+}
+
+// TestLinesCmd_Run_DirectoryRejected confirms passing a directory
+// surfaces a clear error rather than reading bytes blindly.
+func TestLinesCmd_Run_DirectoryRejected(t *testing.T) {
+	tmp := t.TempDir()
+	cmd := &LinesCmd{Path: tmp, Output: "text"}
+	_, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err == nil {
+		t.Fatalf("expected error for directory path, got nil")
+	}
+	if !strings.Contains(err.Error(), "directory") {
+		t.Errorf("expected 'directory' in error message, got %q", err.Error())
+	}
+}
+
+// TestLinesCmd_Run_MissingFile confirms a stat failure on a
+// non-existent path bubbles up as an error.
+func TestLinesCmd_Run_MissingFile(t *testing.T) {
+	tmp := t.TempDir()
+	cmd := &LinesCmd{Path: filepath.Join(tmp, "does-not-exist.txt"), Output: "text"}
+	_, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err == nil {
+		t.Fatalf("expected error for missing file, got nil")
+	}
+}

--- a/cmd/file-search-on/near_duplicates_cmd_test.go
+++ b/cmd/file-search-on/near_duplicates_cmd_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNearDuplicatesCmd_Run_FindsSimilar seeds two markdown files
+// that share a long stretch of body content but differ by one line
+// (SimHash should cluster them) plus an unrelated file.
+func TestNearDuplicatesCmd_Run_FindsSimilar(t *testing.T) {
+	tmp := t.TempDir()
+	shared := strings.Repeat("the quick brown fox jumps over the lazy dog\n", 30)
+	mustWriteFile(t, filepath.Join(tmp, "a.md"), shared+"version one\n")
+	mustWriteFile(t, filepath.Join(tmp, "b.md"), shared+"version two\n")
+	mustWriteFile(t, filepath.Join(tmp, "c.md"), strings.Repeat("completely different prose entirely unrelated\n", 30))
+
+	cmd := &NearDuplicatesCmd{Dir: []string{tmp}, Threshold: 0.85, Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	groups, _ := got["groups"].([]any)
+	if len(groups) == 0 {
+		t.Fatalf("expected at least one near-duplicate group at threshold 0.85, got 0 (full: %v)", got)
+	}
+	// First group should contain a.md and b.md.
+	g, _ := groups[0].(map[string]any)
+	members, _ := g["members"].([]any)
+	if len(members) < 2 {
+		t.Errorf("expected ≥2 members in the near-dup group, got %d", len(members))
+	}
+}
+
+// TestNearDuplicatesCmd_Run_DifferentContentNoGroup confirms two
+// files with no shared body content don't cluster at any sane
+// threshold.
+func TestNearDuplicatesCmd_Run_DifferentContentNoGroup(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "a.md"), strings.Repeat("alpha beta gamma delta\n", 40))
+	mustWriteFile(t, filepath.Join(tmp, "b.md"), strings.Repeat("zeta eta theta iota kappa lambda mu nu xi\n", 40))
+
+	cmd := &NearDuplicatesCmd{Dir: []string{tmp}, Threshold: 0.85, Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	groups, _ := got["groups"].([]any)
+	if len(groups) != 0 {
+		t.Errorf("expected zero groups for wholly-different content, got %d: %v", len(groups), groups)
+	}
+}
+
+// TestNearDuplicatesCmd_Run_SingleFileNoGroup confirms a single
+// matched file produces no group (groups need ≥2 members).
+func TestNearDuplicatesCmd_Run_SingleFileNoGroup(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "only.md"), "alone here\n")
+
+	cmd := &NearDuplicatesCmd{Dir: []string{tmp}, Threshold: 0.85, Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	groups, _ := got["groups"].([]any)
+	if len(groups) != 0 {
+		t.Errorf("expected zero groups for a single-file fixture, got %d", len(groups))
+	}
+}
+
+// TestNearDuplicatesCmd_Run_EmptyDir confirms a clean run with no
+// candidates returns valid JSON with zero groups.
+func TestNearDuplicatesCmd_Run_EmptyDir(t *testing.T) {
+	tmp := t.TempDir() // empty
+
+	cmd := &NearDuplicatesCmd{Dir: []string{tmp}, Threshold: 0.85, Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	groups, _ := got["groups"].([]any)
+	if len(groups) != 0 {
+		t.Errorf("expected zero groups for empty dir, got %d", len(groups))
+	}
+}

--- a/cmd/file-search-on/project_cmd_test.go
+++ b/cmd/file-search-on/project_cmd_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDetectProjectCmd_Run_GoModule confirms a directory containing
+// `go.mod` is detected as a "go" project. The minimal fixture pins
+// the most common project type.
+func TestDetectProjectCmd_Run_GoModule(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "go.mod"), "module example.com/foo\n\ngo 1.24\n")
+
+	cmd := &DetectProjectCmd{Dir: tmp, Output: "json"}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	types, _ := got["project_types"].([]any)
+	var hasGo bool
+	for _, t := range types {
+		if s, _ := t.(string); s == "go" {
+			hasGo = true
+		}
+	}
+	if !hasGo {
+		t.Errorf("expected project_types to include \"go\" for a go.mod fixture, got %v", got)
+	}
+}
+
+// TestDetectProjectCmd_Run_NoMatch confirms an empty directory
+// produces zero matches without erroring.
+func TestDetectProjectCmd_Run_NoMatch(t *testing.T) {
+	tmp := t.TempDir() // empty
+	cmd := &DetectProjectCmd{Dir: tmp, Output: "json"}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	types, _ := got["project_types"].([]any)
+	if len(types) != 0 {
+		t.Errorf("expected zero project_types for empty dir, got %d: %v", len(types), types)
+	}
+}
+
+// TestWhichProjectCmd_Run_WalksUp confirms a file inside a project
+// resolves to its enclosing root.
+func TestWhichProjectCmd_Run_WalksUp(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "go.mod"), "module example.com/foo\n\ngo 1.24\n")
+	sub := filepath.Join(tmp, "internal", "deep")
+	if err := mkdirAll(sub); err != nil {
+		t.Fatalf("mkdir %s: %v", sub, err)
+	}
+	mustWriteFile(t, filepath.Join(sub, "thing.go"), "package deep\n")
+
+	cmd := &WhichProjectCmd{Path: filepath.Join(sub, "thing.go"), Output: "json"}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	root, _ := got["project_root"].(string)
+	if !strings.HasSuffix(root, filepath.Base(tmp)) {
+		t.Errorf("expected project_root to end with %q, got %q (full: %v)", filepath.Base(tmp), root, got)
+	}
+}
+
+// TestWhichProjectCmd_Run_NoEnclosingProject confirms a file with no
+// project ancestor still prints JSON output, then returns exit-code 1
+// (the documented "not found" signal — see exitCodeError below).
+func TestWhichProjectCmd_Run_NoEnclosingProject(t *testing.T) {
+	tmp := t.TempDir() // empty — no project markers anywhere
+	mustWriteFile(t, filepath.Join(tmp, "loose.txt"), "stray\n")
+
+	cmd := &WhichProjectCmd{Path: filepath.Join(tmp, "loose.txt"), Output: "json"}
+	out, runErr := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	// JSON output still lands on stdout even though Run signals "not
+	// found" via the exit-code wrapper.
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	if got["project_root"] != "" && got["project_root"] != nil {
+		t.Errorf("expected empty project_root for orphan file, got %v", got["project_root"])
+	}
+	// And confirm Run signalled the not-found condition. We don't
+	// pin the specific exitCode-wrapper type to avoid making the
+	// test fragile, but the error must be non-nil.
+	if runErr == nil {
+		t.Errorf("expected Run to signal not-found (non-nil error), got nil")
+	}
+}
+
+// TestFindProjectsCmd_Run_FindsGoModules walks a tree containing
+// two sibling go.mod dirs and asserts both are reported.
+func TestFindProjectsCmd_Run_FindsGoModules(t *testing.T) {
+	tmp := t.TempDir()
+	for _, name := range []string{"alpha", "beta"} {
+		dir := filepath.Join(tmp, name)
+		if err := mkdirAll(dir); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.com/"+name+"\n\ngo 1.24\n")
+	}
+
+	cmd := &FindProjectsCmd{Dir: tmp, Output: "json"}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	projects, _ := got["projects"].([]any)
+	if len(projects) != 2 {
+		t.Errorf("expected 2 projects, got %d: %v", len(projects), projects)
+	}
+}
+
+// TestFindProjectsCmd_Run_TypeFilter restricts the report to a
+// single project type and confirms only matching dirs come back.
+func TestFindProjectsCmd_Run_TypeFilter(t *testing.T) {
+	tmp := t.TempDir()
+	goDir := filepath.Join(tmp, "go-side")
+	if err := mkdirAll(goDir); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(goDir, "go.mod"), "module example.com/g\n\ngo 1.24\n")
+	npmDir := filepath.Join(tmp, "node-side")
+	if err := mkdirAll(npmDir); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mustWriteFile(t, filepath.Join(npmDir, "package.json"), `{"name":"x","version":"0.0.1"}`)
+
+	cmd := &FindProjectsCmd{Dir: tmp, Type: []string{"go"}, Output: "json"}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	projects, _ := got["projects"].([]any)
+	if len(projects) != 1 {
+		t.Fatalf("expected 1 project (go only), got %d: %v", len(projects), projects)
+	}
+	p, _ := projects[0].(map[string]any)
+	if path, _ := p["path"].(string); !strings.HasSuffix(path, "go-side") {
+		t.Errorf("expected the go-side project to win the type filter, got path=%q", path)
+	}
+}
+
+// TestFindProjectsCmd_Run_EmptyTree confirms a tree with no project
+// markers returns zero projects without erroring.
+func TestFindProjectsCmd_Run_EmptyTree(t *testing.T) {
+	tmp := t.TempDir() // empty
+	cmd := &FindProjectsCmd{Dir: tmp, Output: "json"}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	projects, _ := got["projects"].([]any)
+	if len(projects) != 0 {
+		t.Errorf("expected zero projects in empty tree, got %d", len(projects))
+	}
+}
+
+// mkdirAll is a thin os.MkdirAll wrapper without test plumbing —
+// project_cmd_test.go uses it across a few setups.
+func mkdirAll(path string) error {
+	return os.MkdirAll(path, 0o755)
+}

--- a/cmd/file-search-on/stats_cmd_test.go
+++ b/cmd/file-search-on/stats_cmd_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStatsCmd_Run_GroupByContentType builds a small tree with two
+// distinct content types and confirms the histogram surfaces both.
+func TestStatsCmd_Run_GroupByContentType(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "doc.md"), "# title\n\nbody\n")
+	mustWriteFile(t, filepath.Join(tmp, "code.go"), "package main\n\nfunc main(){}\n")
+	mustWriteFile(t, filepath.Join(tmp, "data.json"), `{"k":"v"}`)
+
+	cmd := &StatsCmd{Dir: []string{tmp}, GroupBy: "content_type", Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	groups, _ := got["groups"].([]any)
+	if len(groups) < 3 {
+		t.Errorf("expected at least 3 content-type groups, got %d: %v", len(groups), groups)
+	}
+}
+
+// TestStatsCmd_Run_TotalCount verifies the aggregate count + size
+// roll-ups land correctly for a known fixture.
+func TestStatsCmd_Run_TotalCount(t *testing.T) {
+	tmp := t.TempDir()
+	for i, body := range []string{"alpha\n", "beta\n", "gamma\n"} {
+		mustWriteFile(t, filepath.Join(tmp, "f"+string(rune('a'+i))+".txt"), body)
+	}
+
+	cmd := &StatsCmd{Dir: []string{tmp}, GroupBy: "content_type", Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	totalCount, _ := got["total_count"].(float64)
+	if int(totalCount) != 3 {
+		t.Errorf("total_count = %v, want 3", totalCount)
+	}
+}
+
+// TestStatsCmd_Run_GroupByExt exercises a non-default group_by — the
+// bucketing-by-key code path that's different from content_type.
+func TestStatsCmd_Run_GroupByExt(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "a.md"), "x\n")
+	mustWriteFile(t, filepath.Join(tmp, "b.md"), "y\n")
+	mustWriteFile(t, filepath.Join(tmp, "c.txt"), "z\n")
+
+	cmd := &StatsCmd{Dir: []string{tmp}, GroupBy: "ext", Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	groups, _ := got["groups"].([]any)
+	// Expect one bucket for .md (count 2) and one for .txt (count 1).
+	var mdCount, txtCount int
+	for _, g := range groups {
+		gg, _ := g.(map[string]any)
+		name, _ := gg["name"].(string)
+		cnt, _ := gg["count"].(float64)
+		switch name {
+		case ".md":
+			mdCount = int(cnt)
+		case ".txt":
+			txtCount = int(cnt)
+		}
+	}
+	if mdCount != 2 {
+		t.Errorf(".md count = %d, want 2", mdCount)
+	}
+	if txtCount != 1 {
+		t.Errorf(".txt count = %d, want 1", txtCount)
+	}
+}
+
+// TestStatsCmd_Run_CELFilter pre-prunes the walk to markdown only
+// and asserts non-matching files don't land in any group.
+func TestStatsCmd_Run_CELFilter(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "doc.md"), "# md\n")
+	mustWriteFile(t, filepath.Join(tmp, "code.go"), "package main\n")
+
+	cmd := &StatsCmd{Dir: []string{tmp}, Expr: "is_markdown", GroupBy: "content_type", Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	totalCount, _ := got["total_count"].(float64)
+	if int(totalCount) != 1 {
+		t.Errorf("CEL-filtered total_count = %v, want 1 (only the markdown)", totalCount)
+	}
+}
+
+// TestStatsCmd_Run_EmptyDir confirms a walk over an empty dir
+// returns a well-formed JSON with zero groups.
+func TestStatsCmd_Run_EmptyDir(t *testing.T) {
+	tmp := t.TempDir() // empty
+
+	cmd := &StatsCmd{Dir: []string{tmp}, GroupBy: "content_type", Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	totalCount, _ := got["total_count"].(float64)
+	if int(totalCount) != 0 {
+		t.Errorf("empty dir total_count = %v, want 0", totalCount)
+	}
+}
+
+// TestStatsCmd_Run_MultipleDirs exercises the multi-root path —
+// stats aggregates across all -d roots into a single histogram.
+func TestStatsCmd_Run_MultipleDirs(t *testing.T) {
+	tmp1, tmp2 := t.TempDir(), t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp1, "a.md"), "x\n")
+	mustWriteFile(t, filepath.Join(tmp2, "b.md"), "y\n")
+
+	cmd := &StatsCmd{Dir: []string{tmp1, tmp2}, GroupBy: "content_type", Output: "json", NoIndex: true}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	var got map[string]any
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&got); err != nil {
+		t.Fatalf("decode JSON: %v\nraw: %q", err, out)
+	}
+	totalCount, _ := got["total_count"].(float64)
+	if int(totalCount) != 2 {
+		t.Errorf("multi-dir total_count = %v, want 2", totalCount)
+	}
+}

--- a/cmd/file-search-on/testhelpers_test.go
+++ b/cmd/file-search-on/testhelpers_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+)
+
+// captureStdout swaps os.Stdout for a pipe for the duration of fn,
+// returning what was written. Used to assert command output without
+// having to mock the formatter. Originally introduced in
+// attrs_test.go and lifted here for reuse across the CLI test suite.
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	runErr := fn()
+	_ = w.Close()
+	<-done
+	return buf.String(), runErr
+}
+
+// mustWriteFile writes body to path with 0644 perms, fatally failing
+// the test on any I/O error. Used to seed t.TempDir() fixtures.
+// Originally introduced in timeout_test.go and lifted here for
+// reuse across the CLI test suite.
+func mustWriteFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/cmd/file-search-on/timeout_test.go
+++ b/cmd/file-search-on/timeout_test.go
@@ -1,19 +1,11 @@
 package main
 
 import (
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
-
-func mustWriteFile(t *testing.T, path, body string) {
-	t.Helper()
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
-}
 
 // TestCLITimeoutExitCode builds the binary, walks a directory under
 // an absurdly tight --timeout, and asserts:

--- a/examples/bytecode.md
+++ b/examples/bytecode.md
@@ -175,7 +175,7 @@ The same applies to `.pyc` files inside Python wheel (`.whl`) archives and `.was
 
 ## Caveats
 
-- **`.NET` PE assemblies** detect as `binary/pe`, not `bytecode/*`. They're PE files on disk with CLR metadata in a specific PE section — separate code path. Tracked as a follow-up to issue #139.
+- **`.NET` PE assemblies** detect as `binary/pe`, not `bytecode/*`. They're PE files on disk with CLR metadata in a specific PE section — separate code path. Left for a future follow-up; no issue currently tracking.
 - **JAR / WAR / EAR / AAR** detect as `archive/zip` (the existing alias list). Use `archive-contents` to walk the inner `.class` entries.
 - **Python magic numbers go out of date**. Each CPython release picks a new magic; the table covers 3.7-3.14. Unknown magics return empty `runtime_version` but still detect as `bytecode/python`.
 - **`.class` constant-pool walking caps at 65535 entries** (the JVMS hard limit). Larger files are truncated rather than reading unboundedly.

--- a/examples/indexing.md
+++ b/examples/indexing.md
@@ -2,22 +2,31 @@
 
 `file-search-on` parses every matching candidate file on every walk: PDF metadata, EXIF blocks, audio tags, markdown front-matter, ZIP headers, binary architectures. For trees that change rarely (a code repo, a Music library, an archive) this is wasted work — the *expression* changes between runs, but the underlying *attributes* don't.
 
-`--index-path` plugs in an on-disk cache (a single bbolt file). Each entry is keyed by absolute path and validated against the file's `(size, mtime)` pair. Modify a file and only that entry is invalidated. Different CEL expressions reuse the same cache — the index stores attributes, not search results.
+Since v0.64.0 the on-disk index is **on by default**. Every subcommand that walks a tree (`search`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `diff`, `archive-contents`, `organize`, `near-duplicates`, `preset`, `attrs`, `watch`, `mcp`) auto-creates a per-cwd bbolt cache the first time it runs. Each entry is keyed by absolute path and validated against the file's `(size, mtime)` pair. Modify a file and only that entry is invalidated. Different CEL expressions reuse the same cache — the index stores attributes, not search results.
+
+## Default path scheme
+
+```
+<UserCacheDir>/file-search-on/indexes/<basename(cwd)>-<sha1(abs(cwd))[:6]>.db
+```
+
+- **macOS**:   `~/Library/Caches/file-search-on/indexes/file-search-on-3a7b2c.db`
+- **Linux**:   `$XDG_CACHE_HOME/file-search-on/indexes/...` (or `~/.cache/...`)
+- **Windows**: `%LOCALAPPDATA%/file-search-on/indexes/...`
+
+The `<basename>-<shorthash>` form is readable in `ls` and collision-free across projects that share a basename. Different cwds get different files; the same cwd is deterministic. Per-cwd keying means multiple concurrent stdio agents across different projects never fight for the same bbolt file.
 
 ## CLI: cold + warm
 
 ```sh
-# Cold: parses every file, stores the attribute payload in the bbolt file.
-file-search-on 'is_markdown && word_count > 500' \
-    -d ~/notes \
-    --index-path ~/.cache/fso/notes.db
+# Cold: parses every file, stores the attribute payload in the default
+# per-cwd bbolt file. No flag needed.
+file-search-on 'is_markdown && word_count > 500' -d ~/notes
 
-# Warm: same dir, different CEL expression, same cache. The PDF metadata,
+# Warm: same dir, different CEL expression, same cache. PDF metadata,
 # markdown frontmatter, image EXIF — all already cached. The walk still
 # stats every file (mtime/size validation) but skips the per-file parse.
-file-search-on 'is_pdf && page_count > 20' \
-    -d ~/notes \
-    --index-path ~/.cache/fso/notes.db
+file-search-on 'is_pdf && page_count > 20' -d ~/notes
 ```
 
 After each run, the CLI prints a stderr footer:
@@ -32,63 +41,95 @@ index: 1234 hits, 56 misses, 56 stored, 0 stale, 0 errors
 - **stale** — entry existed but `(size, mtime)` mismatched; entry was discarded and the file was re-parsed.
 - **errors** — encoding failures, oversized payloads, write-channel back-pressure. Cache misses are always recoverable; errors are diagnostic.
 
+## Override the default path
+
+`--index-path <file.db>` overrides the per-cwd default. Useful when you want to share a single cache across multiple cwds, or pin the location for backup / shared-CI scenarios:
+
+```sh
+file-search-on 'is_image' -d ~/Pictures --index-path /Volumes/Backup/photos.db
+```
+
+## Opt out: `--no-index`
+
+`--no-index` disables the on-disk index entirely for that run; the tool falls back to a process-lifetime in-memory cache. Useful for:
+
+- **Hermetic CI** — tests / scripts that should leave no disk side effects.
+- **One-shot runs** — a single grep-like invocation where the cache file is overhead.
+- **Lock-contention bypass** — see below.
+
+```sh
+file-search-on 'is_source' -d ./project --no-index
+```
+
+## Multi-instance: lock contention falls back gracefully
+
+bbolt is a single-writer database. When two stdio agents share the same cwd:
+
+1. The first wins the file lock.
+2. The second's `Open` blocks 5 s, then transparently falls back to in-memory caching for the rest of its session. A one-line stderr warning surfaces the fact:
+
+```
+file-search-on: index file <path>.db is held by another file-search-on instance;
+this session will use in-memory cache (use --no-index to silence this warning)
+```
+
+Both agents keep working; only the cache layer differs for the loser. The first agent's writes accumulate normally; the second restarts cold next time. The monitor dashboard's Overview panel shows the backend state with a badge: 🔒 persistent / 🧠 in-memory + reason (`lock_contention` or `no_index_flag`).
+
+Projects with **different cwds** → different bbolt files → zero contention. This is the common case (multiple Claude Code sessions across several repos at once).
+
 ## CLI: forcing a refresh
 
 The cache is invalidated automatically when a file's mtime or size changes. To force a full refresh of everything (e.g. after upgrading the binary across an attribute schema bump), delete the file:
 
 ```sh
-rm ~/.cache/fso/notes.db
-file-search-on 'is_markdown' -d ~/notes --index-path ~/.cache/fso/notes.db   # rebuilds
+rm ~/Library/Caches/file-search-on/indexes/file-search-on-3a7b2c.db
+file-search-on 'is_markdown' -d ~/notes   # rebuilds
 ```
 
 The tool will refuse to open an index file from an incompatible schema version with a message like:
 
 ```
-Error: index file at ~/.cache/fso/notes.db has an incompatible schema; delete it or pass a new --index-path
+Error: index file at <path>.db has an incompatible schema; delete it or pass a new --index-path
 ```
 
 We never auto-delete user files, even cache files — explicit `rm` is the recovery step.
 
-## MCP: cache lives for the server lifetime
+## MCP server: same default-on behaviour
 
-In MCP server mode the cache is **on by default** with no flag. It uses an in-memory implementation that lives for the server process. Agents that explore a tree iteratively get progressively faster `search` and `read_attributes` calls:
+`file-search-on mcp` inherits the same per-cwd default + same `--index-path` / `--no-index` overrides. Agents that explore a tree iteratively get progressively faster `search` and `read_attributes` calls; the cache survives MCP server restarts because it's on disk by default:
 
 ```sh
-file-search-on mcp                                         # in-memory cache, lost on restart
-file-search-on mcp --index-path ~/.cache/fso/agent.db      # bbolt-backed, survives restart
+file-search-on mcp                                    # default per-cwd index
+file-search-on mcp --index-path /var/lib/fso.db       # explicit shared path
+file-search-on mcp --no-monitor --no-index            # hermetic / no side effects
 ```
 
-Hit/miss counters are exposed via the new `index_stats` tool (no input, returns `hits/misses/puts/stales/errors`):
+Hit/miss counters are exposed via the `index_stats` MCP tool (no input, returns `hits/misses/puts/stales/errors` for attributes + body + embedding caches) and live on the monitor dashboard's Cache panel.
 
 ```json
-{
-  "name": "index_stats",
-  "arguments": {}
-}
+{ "name": "index_stats", "arguments": {} }
 ```
 
 ## When NOT to use it
 
-- **One-shot scripts**, e.g. a `find`-like invocation in a CI pipeline that walks a fresh checkout. The cache file would be cold every time and add disk I/O for no benefit.
-- **Trees that change every run**, like a build directory whose mtimes get bumped on every compile — every file is stale, every entry is invalidated, the cache is overhead.
+- **One-shot scripts** in a hermetic CI where any disk side effect is unwanted — pass `--no-index`.
+- **Trees that change every run**, like a build directory whose mtimes get bumped on every compile — every file is stale, every entry is invalidated, the cache is overhead. Either ignore that subtree via `--exclude` / `--prune-build-artefacts` or pass `--no-index`.
 - **Hostile inputs**, e.g. arbitrary user uploads. The encoder has a 256 KiB per-entry soft cap to defend against pathological frontmatter, but you still don't want to point the cache at content you don't trust.
 
 ## CI / cron / large libraries
 
-For larger trees that you scan periodically (e.g. weekly photo backup, monthly archive triage), put the index file under `~/.cache/`:
+For trees that you scan periodically (e.g. weekly photo backup, monthly archive triage), the per-cwd default works out of the box — running `file-search-on` from the same cwd each time hits the same cache file:
 
 ```sh
 # Photo library — full sweep monthly, then cheap delta queries during the month
-mkdir -p ~/.cache/fso
-file-search-on 'is_image && taken_at > timestamp("2024-01-01T00:00:00Z")' \
-    -d ~/Pictures \
-    --index-path ~/.cache/fso/photos.db
+cd ~/Pictures
+file-search-on 'is_image && taken_at > timestamp("2024-01-01T00:00:00Z")'
 ```
 
 Subsequent queries against `~/Pictures` for *any* attribute (camera_model, GPS bounding box, ISO range) hit the cache. Only files that were added, edited, or moved since the last walk re-parse.
 
-Bbolt is a single file, so it backs up trivially (`cp ~/.cache/fso/photos.db ~/backups/`). It's also safe to copy across machines as long as the absolute paths line up — the validator only checks `(size, mtime)`, not host or filesystem identity.
+Bbolt is a single file, so it backs up trivially (`cp ~/Library/Caches/file-search-on/indexes/<file>.db ~/backups/`). It's also safe to copy across machines as long as the absolute paths line up — the validator only checks `(size, mtime)`, not host or filesystem identity.
 
 ## Inspecting the cache
 
-There is no built-in `index` subcommand for stats / vacuum / dump (yet). The MCP `index_stats` tool is the canonical observability surface; the CLI footer line is the equivalent for one-shot use. If your index file grows unwieldy after months of file churn, the simplest reset is to delete it.
+There is no built-in `index` subcommand for stats / vacuum / dump (yet). The MCP `index_stats` tool is the canonical observability surface; the CLI footer line is the equivalent for one-shot use. The monitor dashboard surfaces the same counters live with sparklines. If your index file grows unwieldy after months of file churn, the simplest reset is to delete it.

--- a/examples/monitoring.md
+++ b/examples/monitoring.md
@@ -1,30 +1,33 @@
 # Monitoring dashboard
 
-The long-running modes — the `mcp` server and the `watch` command — can serve a small **read-only** monitoring dashboard so you can watch file-search-on's internal state while it runs: is the cache working, what is the agent doing right now, is OCR / embedding available.
+The long-running modes — the `mcp` server and the `watch` command — serve a small **read-only** monitoring dashboard so you can watch file-search-on's internal state while it runs: is the cache working, what is the agent doing right now, is OCR / embedding available.
 
-It's **off by default**, binds **127.0.0.1 only** (the host part of any address is ignored — only the port matters), has **no auth**, and adds **no dependencies** (the UI is a single embedded page polling a JSON API).
+Since v0.65.0 it's **on by default** on a dynamic OS-assigned localhost port — many concurrent stdio agents each get their own dashboard without colliding. The server binds **127.0.0.1 only** (the host part of any address is ignored — only the port matters), has **no auth**, and adds **no dependencies** (the UI is a single embedded page polling a JSON API).
 
 ```sh
-# stdio MCP server + dashboard on a dynamic (OS-assigned) port
-file-search-on mcp --monitor
+# stdio MCP server — dashboard auto-starts on a dynamic port
+file-search-on mcp
 
-# pin a fixed port instead
+# pin a fixed port instead of a dynamic one
 file-search-on mcp --monitor-addr :9090
 
-# HTTP MCP server + dashboard
-file-search-on mcp --transport http --addr :8080 --monitor
+# opt out for hermetic / sandboxed runs
+file-search-on mcp --no-monitor
+
+# HTTP MCP server + dashboard (auto-starts, same as stdio)
+file-search-on mcp --transport http --addr :8080
 
 # watch mode + dashboard
-file-search-on watch 'is_image && body.contains("error")' --ocr -d ~/Desktop --monitor
+file-search-on watch 'is_image && body.contains("error")' --ocr -d ~/Desktop
 ```
 
-`--monitor` picks a free localhost port; `--monitor-addr :PORT` pins one. The chosen URL is printed to stderr (`monitor dashboard: http://127.0.0.1:<port>/`) — or, for an `mcp` server, ask it via the `monitor_info` tool. Then open that URL.
+The chosen URL is printed to stderr (`monitor dashboard: http://127.0.0.1:<port>/`) — or, for an `mcp` server, ask it via the `monitor_info` tool. For a one-shot view of every active dashboard across concurrent instances, `file-search-on monitors` lists the live registry. The legacy `--monitor` bool is kept as a documented no-op for back-compat (same effect as no flag).
 
 ## Panels
 
 | Panel | Shows |
 | --- | --- |
-| **Overview** | version, uptime, run mode (`mcp-stdio` / `mcp-http` / `watch`), PID, Go version, GOMAXPROCS, default worker count, index backing (path or in-memory), body-cache cap, goroutines |
+| **Overview** | version, uptime, run mode (`mcp-stdio` / `mcp-http` / `watch`), PID, Go version, GOMAXPROCS, default worker count, **index backend** (🔒 persistent path / 🧠 in-memory with reason — `--no-index` opt-out or `lock_contention` fallback), body-cache cap, goroutines |
 | **Cache** | attribute / body / embedding cache counters with derived **hit-rate %** + sparklines; body evictions / oversize rejects and embed model-mismatches highlighted |
 | **Activity** | live MCP tool-call feed (tool, elapsed, outcome, result count), per-tool call/error/cancel counts + p50/p95/max latency, in-flight gauge |
 | **Capabilities** | registered content types grouped by family, project types, OCR provider availability, embedder model/server + reachability |


### PR DESCRIPTION
Closes the test-coverage gap on \`cmd/file-search-on/\` by adding 39 new tests across 8 zero-coverage subcommands. All tests hermetic, deterministic, parallel-safe (where applicable), and pass under \`-race -short\` with no flakes across three back-to-back runs.

## Scope

| Group | New tests | Notes |
| --- | --- | --- |
| \`project_cmd_test.go\` | 7 | DetectProjectCmd, WhichProjectCmd, FindProjectsCmd — happy-path detection + no-match exit-code paths |
| \`lines_cmd_test.go\` | 4 | Range / JSON / directory-rejection / missing-file |
| \`stats_cmd_test.go\` | 6 | group_by content_type/ext, CEL filter, multi-dir, empty-dir, total-count rollup |
| \`duplicates_cmd_test.go\` | 4 | sha256 dedup, no-dup, min-size filter, CEL scope filter |
| \`near_duplicates_cmd_test.go\` | 4 | SimHash similarity, divergent content, single-file, empty dir |
| \`archive_cmd_test.go\` | 5 | ZIP-fixture builder; list entries, glob prune, max-entries cap, read + missing-entry |
| \`find_matches_cmd_test.go\` | 4 | Match line, no-match exit (grep convention), -C context window, CEL pre-prune |
| \`hashset_cmd_test.go\` | 5 | text→bbolt build, info on bbolt + text files, error paths |

## Shared scaffolding

Created \`cmd/file-search-on/testhelpers_test.go\` to host the existing \`captureStdout\` (was in attrs_test.go) and \`mustWriteFile\` (was in timeout_test.go). Reusable across the 8 new test files without duplication. The two original files updated to drop the local copies.

## Coverage delta

| | Before | After |
| --- | --- | --- |
| \`cmd/file-search-on/\` coverage | **28.6%** | **48.4%** |
| Number of subcommands with ≥1 test | 4 of 20 | 12 of 20 |
| Total tests in \`cmd/file-search-on/*_test.go\` | 38 | 77 |

\`go test -race -short -count=3 ./cmd/file-search-on/\` — three back-to-back runs, no flakes. CI sweep clean: vet ✓, golangci-lint 0 issues ✓, go fix idempotent ✓.

## Lessons baked in

- **No \`t.Parallel()\` with \`captureStdout\`** — the helper swaps global \`os.Stdout\`, so parallel tests stomp each other. Documented in the helper's comment.
- **JSON output via \`map[string]any\` decode** — assert specific keys, never string-match the rendered output (fragile under format changes).
- **Grep-style exit codes** (find-matches "no match", which-project "no enclosing project") are tested via non-nil error return from \`Run()\`, not as failure conditions.
- **\`base64\` quirk** — Go's encoding/json base64-encodes \`[]byte\` fields (e.g. \`ArchiveFileResult.Content\`), so the archive-read test base64-decodes before comparing against the original entry body.

## Out of scope — follow-up PRs

- **\`search\` subcommand** — biggest LOC (~400 lines), needs CEL fixtures + index interaction tests. Own PR.
- **\`mcp\` subcommand** — process lifecycle and transport spawning; \`os/exec\`-driven integration tests in the \`timeout_test.go\` style. Own PR.
- **\`watch\` subcommand** — fsnotify timing is flaky on CI runners; careful sleep/poll design needed.
- **\`preset\` subcommand** — straightforward but skipped to keep PR scope tight.
- **\`internal/search\` (52.3%)** and **\`internal/celexpr\` (53.6%)** — bigger LOC weights, separate concerns; their own PRs.

## Test plan

- [ ] \`go test -race -short ./...\` green on CI
- [ ] \`go tool cover\` reports cmd/file-search-on/ ≥48%
- [ ] All 8 new test files run cleanly when invoked individually (\`go test -run TestStatsCmd ./cmd/file-search-on/\` etc.)
- [ ] No t.Parallel() in any test that uses captureStdout (regression guard for the parallel-stomp issue found during this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)