### PR TITLE
feat(monitor): browse cache entries from the dashboard

### DIFF
--- a/internal/index/bbolt.go
+++ b/internal/index/bbolt.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -332,28 +333,204 @@ func (b *boltIndex) PutBody(absPath string, be *BodyEntry) error {
 }
 
 func (b *boltIndex) Stats() Stats {
-	return Stats{
-		Hits:          b.stats.hits.Load(),
-		Misses:        b.stats.misses.Load(),
-		Puts:          b.stats.puts.Load(),
-		Stales:        b.stats.stales.Load(),
-		Errors:        b.stats.errors.Load(),
-		BodyHits:      b.stats.bodyHits.Load(),
-		BodyMisses:    b.stats.bodyMisses.Load(),
-		BodyPuts:      b.stats.bodyPuts.Load(),
-		BodyStales:    b.stats.bodyStales.Load(),
-		BodyEvictions: b.stats.bodyEvictions.Load(),
-		BodyOversize:  b.stats.bodyOversize.Load(),
-		BodyErrors:    b.stats.bodyErrors.Load(),
+	s := Stats{
+		Hits:                 b.stats.hits.Load(),
+		Misses:               b.stats.misses.Load(),
+		Puts:                 b.stats.puts.Load(),
+		Stales:               b.stats.stales.Load(),
+		Errors:               b.stats.errors.Load(),
+		BodyHits:             b.stats.bodyHits.Load(),
+		BodyMisses:           b.stats.bodyMisses.Load(),
+		BodyPuts:             b.stats.bodyPuts.Load(),
+		BodyStales:           b.stats.bodyStales.Load(),
+		BodyEvictions:        b.stats.bodyEvictions.Load(),
+		BodyOversize:         b.stats.bodyOversize.Load(),
+		BodyErrors:           b.stats.bodyErrors.Load(),
 		EmbedHits:            b.stats.embedHits.Load(),
 		EmbedMisses:          b.stats.embedMisses.Load(),
 		EmbedPuts:            b.stats.embedPuts.Load(),
 		EmbedErrors:          b.stats.embedErrors.Load(),
 		EmbedModelMismatches: b.stats.embedModelMismatches.Load(),
+		BodiesTotalBytes:     b.bodiesTotalSize.Load(),
 	}
+	// Per-bucket entry counts come from bbolt's bucket.Stats(). Cheap
+	// (no full scan; bbolt maintains running counts) but it's a View
+	// transaction so we tolerate failure gracefully — counts default
+	// to zero rather than failing the whole snapshot.
+	_ = b.db.View(func(tx *bbolt.Tx) error {
+		if bkt := tx.Bucket([]byte(bucketAttrs)); bkt != nil {
+			s.AttrEntriesCount = uint64(bkt.Stats().KeyN)
+		}
+		if bkt := tx.Bucket([]byte(bucketBodies)); bkt != nil {
+			s.BodyEntriesCount = uint64(bkt.Stats().KeyN)
+		}
+		return nil
+	})
+	return s
 }
 
 func (b *boltIndex) BumpEmbedStat(kind string) { bumpEmbedStat(&b.stats, kind) }
+
+// ListAttrs walks attrs_v1 with a Cursor, collecting summaries for
+// entries whose key contains substr. The iteration is sorted by key
+// because bbolt keys are returned in lexicographic order — no extra
+// sort step needed.
+//
+// Live (size, mtime) is stat'd per row to compute Stale; a missing
+// file (os.Stat error) is reported as Stale=true rather than
+// dropped. Pagination is offset + limit on the FILTERED slice.
+func (b *boltIndex) ListAttrs(substr string, limit, offset int) ([]EntrySummary, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	var out []EntrySummary
+	var total int
+	var matchPaths []string
+	if err := b.db.View(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(bucketAttrs))
+		if bkt == nil {
+			return nil
+		}
+		c := bkt.Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			if substr == "" || strings.Contains(string(k), substr) {
+				total++
+				matchPaths = append(matchPaths, string(k))
+			}
+		}
+		// Slice for pagination.
+		from := min(offset, len(matchPaths))
+		to := min(from+limit, len(matchPaths))
+		for _, p := range matchPaths[from:to] {
+			raw := bkt.Get([]byte(p))
+			if raw == nil {
+				continue
+			}
+			e, err := decodeEntry(raw)
+			if err != nil {
+				continue
+			}
+			out = append(out, EntrySummary{
+				Path:        p,
+				ContentType: e.ContentType,
+				Size:        e.Size,
+				ModTime:     time.Unix(0, e.ModTimeUnixNano),
+				Stale:       isAttrStaleEntry(p, e),
+			})
+		}
+		return nil
+	}); err != nil {
+		return nil, 0, err
+	}
+	return out, total, nil
+}
+
+// ListBodies mirrors ListAttrs against bodies_v1 + body_access_v1.
+func (b *boltIndex) ListBodies(substr string, limit, offset int) ([]BodySummary, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	var out []BodySummary
+	var total int
+	var matchPaths []string
+	if err := b.db.View(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(bucketBodies))
+		if bkt == nil {
+			return nil
+		}
+		access := tx.Bucket([]byte(bucketBodyAccess))
+		c := bkt.Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			if substr == "" || strings.Contains(string(k), substr) {
+				total++
+				matchPaths = append(matchPaths, string(k))
+			}
+		}
+		from := min(offset, len(matchPaths))
+		to := min(from+limit, len(matchPaths))
+		for _, p := range matchPaths[from:to] {
+			raw := bkt.Get([]byte(p))
+			if raw == nil {
+				continue
+			}
+			be, err := decodeBody(raw)
+			if err != nil {
+				continue
+			}
+			var lastAccess time.Time
+			if access != nil {
+				if av := access.Get([]byte(p)); len(av) == 8 {
+					lastAccess = time.Unix(0, int64(binary.BigEndian.Uint64(av)))
+				}
+			}
+			out = append(out, BodySummary{
+				Path:       p,
+				Size:       be.Size,
+				ModTime:    time.Unix(0, be.ModTimeUnixNano),
+				LastAccess: lastAccess,
+				Stale:      isBodyStaleEntry(p, be),
+			})
+		}
+		return nil
+	}); err != nil {
+		return nil, 0, err
+	}
+	return out, total, nil
+}
+
+// PeekAttrs returns the cached Entry for absPath bypassing the
+// (size, mtime) validation that Lookup enforces. Used by the
+// dashboard's detail view so stale entries can be displayed with a
+// stale flag rather than hidden.
+func (b *boltIndex) PeekAttrs(absPath string) (*Entry, bool) {
+	var out *Entry
+	_ = b.db.View(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(bucketAttrs))
+		if bkt == nil {
+			return nil
+		}
+		raw := bkt.Get([]byte(absPath))
+		if raw == nil {
+			return nil
+		}
+		e, err := decodeEntry(raw)
+		if err != nil {
+			return nil
+		}
+		out = e
+		return nil
+	})
+	return out, out != nil
+}
+
+// PeekBody returns the cached BodyEntry for absPath bypassing
+// validation. Same semantics as PeekAttrs.
+func (b *boltIndex) PeekBody(absPath string) (*BodyEntry, bool) {
+	var out *BodyEntry
+	_ = b.db.View(func(tx *bbolt.Tx) error {
+		bkt := tx.Bucket([]byte(bucketBodies))
+		if bkt == nil {
+			return nil
+		}
+		raw := bkt.Get([]byte(absPath))
+		if raw == nil {
+			return nil
+		}
+		be, err := decodeBody(raw)
+		if err != nil {
+			return nil
+		}
+		out = be
+		return nil
+	})
+	return out, out != nil
+}
 
 // Close drains both writer channels, waits for the writer goroutines
 // to exit, then closes the bbolt db. Safe to call once; subsequent

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -184,6 +184,48 @@ type Stats struct {
 	EmbedPuts            uint64 // freshly-computed vector stored back to cache
 	EmbedErrors          uint64 // Embedder.Embed call failed (Ollama unreachable, model missing, etc.)
 	EmbedModelMismatches uint64 // cached Vector existed but came from a different embedding model → treated as miss, re-embedded
+
+	// AttrEntriesCount / BodyEntriesCount are the *current* number of
+	// cached records in each bucket — distinct from the monotonic Hits
+	// / Puts counters above. They give the dashboard a "size of cache"
+	// gauge alongside the activity gauges. The bbolt implementation
+	// computes these on-demand via bucket.Stats(); the in-memory
+	// implementation reports map length.
+	AttrEntriesCount uint64
+	BodyEntriesCount uint64
+	// BodiesTotalBytes mirrors the in-memory running size used by FIFO
+	// eviction (bbolt only — the in-memory backend doesn't track this
+	// because it has no per-size eviction). Reported in bytes so the
+	// dashboard can render "256 MiB cap / 87.4 MiB used".
+	BodiesTotalBytes int64
+}
+
+// EntrySummary is the compact row shape returned by ListAttrs. The
+// full Entry payload (Extra map, hashes, vector) is fetched via
+// PeekAttrs on demand for a detail view — list responses avoid
+// shipping the heavy fields.
+type EntrySummary struct {
+	Path        string    `json:"path"`
+	ContentType string    `json:"content_type"`
+	Size        int64     `json:"size"`
+	ModTime     time.Time `json:"mod_time"`
+	// Stale is true when the live file's (size, mtime) no longer
+	// matches the cached entry's. The list builder stats every
+	// candidate to compute this — a one-shot Lstat per row is cheap
+	// against the size of a typical browser page (50 entries).
+	// Bumps to true silently when the underlying file vanishes.
+	Stale bool `json:"stale,omitempty"`
+}
+
+// BodySummary is the compact row shape returned by ListBodies.
+type BodySummary struct {
+	Path    string    `json:"path"`
+	Size    int64     `json:"size"`
+	ModTime time.Time `json:"mod_time"`
+	// LastAccess is the most-recent read time recorded for FIFO
+	// eviction. Zero for the in-memory backend (no eviction layer).
+	LastAccess time.Time `json:"last_access"`
+	Stale      bool      `json:"stale,omitempty"`
 }
 
 // Index is the surface every cache implementation honours.
@@ -227,6 +269,32 @@ type Index interface {
 	// just a field on Entry, but agents want a per-cache breakdown
 	// of how often the field was present.
 	BumpEmbedStat(kind string)
+
+	// ListAttrs returns summaries for entries in the attribute cache
+	// whose path contains substr (empty = match all), sorted by path
+	// lexicographically, sliced by offset + limit. Total is the
+	// unfiltered count after the substring pass — pagination UIs use
+	// it to render the right "showing N of M" footer.
+	//
+	// Implementations need not enforce a limit themselves (callers can
+	// pass a huge value); a sane upper bound is enforced at the HTTP
+	// layer (see internal/monitor/server.go) to keep response sizes
+	// bounded.
+	ListAttrs(substr string, limit, offset int) ([]EntrySummary, int, error)
+
+	// ListBodies returns summaries for body-cache entries. Same shape
+	// semantics as ListAttrs.
+	ListBodies(substr string, limit, offset int) ([]BodySummary, int, error)
+
+	// PeekAttrs returns the cached Entry for absPath bypassing
+	// (size, mtime) validation. The dashboard's detail view uses this
+	// to show stale entries with a stale flag rather than hiding
+	// them. Walking callers continue to use the strict Lookup.
+	PeekAttrs(absPath string) (*Entry, bool)
+
+	// PeekBody returns the cached BodyEntry for absPath bypassing
+	// validation. Same semantics as PeekAttrs.
+	PeekBody(absPath string) (*BodyEntry, bool)
 
 	Stats() Stats
 	Close() error

--- a/internal/index/list_test.go
+++ b/internal/index/list_test.go
@@ -1,0 +1,299 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// seedAttrs writes len(paths) entries into idx with deterministic
+// content. Each path actually exists on disk (in tmp) so isAttrStale
+// returns false for fresh entries. Returns the tmp dir and the
+// absolute paths in declaration order.
+func seedAttrs(t *testing.T, idx Index, basenames ...string) (string, []string) {
+	t.Helper()
+	tmp := t.TempDir()
+	paths := make([]string, 0, len(basenames))
+	for _, b := range basenames {
+		p := filepath.Join(tmp, b)
+		if err := os.WriteFile(p, []byte("body of "+b), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %s: %v", p, err)
+		}
+		if err := idx.Put(p, &Entry{
+			Size:            info.Size(),
+			ModTimeUnixNano: info.ModTime().UnixNano(),
+			ContentType:     "text",
+			Extra:           map[string]any{"basename": b},
+		}); err != nil {
+			t.Fatalf("Put %s: %v", p, err)
+		}
+		paths = append(paths, p)
+	}
+	return tmp, paths
+}
+
+func seedBodies(t *testing.T, idx Index, basenames ...string) (string, []string) {
+	t.Helper()
+	tmp := t.TempDir()
+	paths := make([]string, 0, len(basenames))
+	for _, b := range basenames {
+		p := filepath.Join(tmp, b)
+		body := "body of " + b + "\n"
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %s: %v", p, err)
+		}
+		if err := idx.PutBody(p, &BodyEntry{
+			Size:            info.Size(),
+			ModTimeUnixNano: info.ModTime().UnixNano(),
+			CreatedUnixNano: time.Now().UnixNano(),
+			Body:            body,
+		}); err != nil {
+			t.Fatalf("PutBody %s: %v", p, err)
+		}
+		paths = append(paths, p)
+	}
+	return tmp, paths
+}
+
+// openTestIndex returns both backends; tests run their assertions
+// against each. The bbolt backend's writer is async; flushAttrs
+// blocks until the put has landed.
+func openTestIndex(t *testing.T, name string) Index {
+	t.Helper()
+	if name == "memory" {
+		return NewMemory()
+	}
+	path := filepath.Join(t.TempDir(), "test.db")
+	idx, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = idx.Close() })
+	return idx
+}
+
+// flushAttrs forces the bbolt writer to drain by issuing a Lookup
+// for a known path (which acquires the read lock and synchronises
+// with the writer's batch commit). For the memory backend it's a
+// no-op since Put is synchronous.
+func flushAttrs(t *testing.T, idx Index, knownPath string) {
+	t.Helper()
+	// The bbolt writer batches every 100ms; wait at least one batch
+	// cycle to be sure pending Puts landed before we List them.
+	for range 50 {
+		if _, ok := idx.Lookup(knownPath, mustStatSize(t, knownPath), mustStatMtime(t, knownPath)); ok {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("flushAttrs: Put for %s did not become visible within 500ms", knownPath)
+}
+
+func mustStatSize(t *testing.T, p string) int64 {
+	t.Helper()
+	i, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	return i.Size()
+}
+
+func mustStatMtime(t *testing.T, p string) time.Time {
+	t.Helper()
+	i, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	return i.ModTime()
+}
+
+func TestListAttrs_PaginationAndFilter(t *testing.T) {
+	for _, backend := range []string{"memory", "bbolt"} {
+		t.Run(backend, func(t *testing.T) {
+			idx := openTestIndex(t, backend)
+			_, paths := seedAttrs(t, idx, "alpha.md", "beta.md", "gamma.md", "delta.txt", "epsilon.md")
+			if backend == "bbolt" {
+				flushAttrs(t, idx, paths[len(paths)-1])
+			}
+
+			// No filter, full list — should return all 5 sorted lexicographically.
+			got, total, err := idx.ListAttrs("", 50, 0)
+			if err != nil {
+				t.Fatalf("ListAttrs: %v", err)
+			}
+			if total != 5 {
+				t.Errorf("total = %d, want 5", total)
+			}
+			if len(got) != 5 {
+				t.Errorf("entries len = %d, want 5", len(got))
+			}
+			// Filter by ".md" — alpha/beta/gamma/epsilon = 4 hits.
+			_, total, err = idx.ListAttrs(".md", 50, 0)
+			if err != nil {
+				t.Fatalf("ListAttrs filter: %v", err)
+			}
+			if total != 4 {
+				t.Errorf("filtered total = %d, want 4", total)
+			}
+			// Pagination — limit 2, offset 1.
+			got, _, err = idx.ListAttrs("", 2, 1)
+			if err != nil {
+				t.Fatalf("ListAttrs page: %v", err)
+			}
+			if len(got) != 2 {
+				t.Errorf("paged len = %d, want 2", len(got))
+			}
+		})
+	}
+}
+
+func TestListAttrs_StaleFlagSet(t *testing.T) {
+	for _, backend := range []string{"memory", "bbolt"} {
+		t.Run(backend, func(t *testing.T) {
+			idx := openTestIndex(t, backend)
+			_, paths := seedAttrs(t, idx, "a.md")
+			if backend == "bbolt" {
+				flushAttrs(t, idx, paths[0])
+			}
+
+			// Initially fresh — Stale should be false.
+			got, _, err := idx.ListAttrs("", 50, 0)
+			if err != nil {
+				t.Fatalf("ListAttrs: %v", err)
+			}
+			if got[0].Stale {
+				t.Errorf("fresh entry reported as stale: %+v", got[0])
+			}
+
+			// Mutate the file so size/mtime drift from the cached entry.
+			if err := os.WriteFile(paths[0], []byte("CHANGED CONTENT MORE BYTES"), 0o644); err != nil {
+				t.Fatalf("rewrite: %v", err)
+			}
+			got, _, err = idx.ListAttrs("", 50, 0)
+			if err != nil {
+				t.Fatalf("ListAttrs re-list: %v", err)
+			}
+			if !got[0].Stale {
+				t.Errorf("expected Stale=true after rewrite, got %+v", got[0])
+			}
+		})
+	}
+}
+
+func TestPeekAttrs_ReturnsStale(t *testing.T) {
+	for _, backend := range []string{"memory", "bbolt"} {
+		t.Run(backend, func(t *testing.T) {
+			idx := openTestIndex(t, backend)
+			_, paths := seedAttrs(t, idx, "a.md")
+			if backend == "bbolt" {
+				flushAttrs(t, idx, paths[0])
+			}
+
+			// PeekAttrs should return the entry regardless of staleness.
+			if err := os.WriteFile(paths[0], []byte("CHANGED"), 0o644); err != nil {
+				t.Fatalf("rewrite: %v", err)
+			}
+			e, ok := idx.PeekAttrs(paths[0])
+			if !ok {
+				t.Fatalf("PeekAttrs returned !ok for a known-cached entry")
+			}
+			if e.ContentType != "text" {
+				t.Errorf("Entry.ContentType = %q, want %q", e.ContentType, "text")
+			}
+
+			// Lookup (strict) should now fail with stale.
+			if _, ok := idx.Lookup(paths[0], 7, time.Now()); ok {
+				t.Errorf("Lookup unexpectedly succeeded after rewrite")
+			}
+		})
+	}
+}
+
+func TestPeekAttrs_MissingPath(t *testing.T) {
+	for _, backend := range []string{"memory", "bbolt"} {
+		t.Run(backend, func(t *testing.T) {
+			idx := openTestIndex(t, backend)
+			if _, ok := idx.PeekAttrs("/nonexistent/path"); ok {
+				t.Errorf("PeekAttrs returned ok=true for unknown path")
+			}
+		})
+	}
+}
+
+func TestListBodies_FilterAndPagination(t *testing.T) {
+	for _, backend := range []string{"memory", "bbolt"} {
+		t.Run(backend, func(t *testing.T) {
+			idx := openTestIndex(t, backend)
+			_, paths := seedBodies(t, idx, "a.md", "b.md", "c.txt")
+			if backend == "bbolt" {
+				// Body writer is also async; wait for the body to be queryable.
+				for range 50 {
+					if _, ok := idx.LookupBody(paths[0], mustStatSize(t, paths[0]), mustStatMtime(t, paths[0])); ok {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+
+			got, total, err := idx.ListBodies(".md", 50, 0)
+			if err != nil {
+				t.Fatalf("ListBodies: %v", err)
+			}
+			if total != 2 {
+				t.Errorf("filtered total = %d, want 2 (.md only)", total)
+			}
+			if len(got) != 2 {
+				t.Errorf("entries len = %d, want 2", len(got))
+			}
+		})
+	}
+}
+
+func TestPeekBody_ReturnsBody(t *testing.T) {
+	for _, backend := range []string{"memory", "bbolt"} {
+		t.Run(backend, func(t *testing.T) {
+			idx := openTestIndex(t, backend)
+			_, paths := seedBodies(t, idx, "doc.md")
+			if backend == "bbolt" {
+				for range 50 {
+					if _, ok := idx.LookupBody(paths[0], mustStatSize(t, paths[0]), mustStatMtime(t, paths[0])); ok {
+						break
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+			be, ok := idx.PeekBody(paths[0])
+			if !ok {
+				t.Fatalf("PeekBody returned !ok for a known-cached body")
+			}
+			if be.Body == "" {
+				t.Errorf("Body is empty; want 'body of doc.md\\n'")
+			}
+		})
+	}
+}
+
+func TestStats_EntryCounts(t *testing.T) {
+	for _, backend := range []string{"memory", "bbolt"} {
+		t.Run(backend, func(t *testing.T) {
+			idx := openTestIndex(t, backend)
+			_, paths := seedAttrs(t, idx, "a.md", "b.md", "c.md")
+			if backend == "bbolt" {
+				flushAttrs(t, idx, paths[len(paths)-1])
+			}
+			s := idx.Stats()
+			if s.AttrEntriesCount != 3 {
+				t.Errorf("AttrEntriesCount = %d, want 3", s.AttrEntriesCount)
+			}
+		})
+	}
+}

--- a/internal/index/memory.go
+++ b/internal/index/memory.go
@@ -1,6 +1,9 @@
 package index
 
 import (
+	"os"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -114,25 +117,138 @@ func (m *memoryIndex) PutBody(path string, be *BodyEntry) error {
 }
 
 func (m *memoryIndex) Stats() Stats {
+	m.mu.RLock()
+	attrCount := uint64(len(m.data))
+	bodyCount := uint64(len(m.bodies))
+	m.mu.RUnlock()
 	return Stats{
-		Hits:          m.stats.hits.Load(),
-		Misses:        m.stats.misses.Load(),
-		Puts:          m.stats.puts.Load(),
-		Stales:        m.stats.stales.Load(),
-		Errors:        m.stats.errors.Load(),
-		BodyHits:      m.stats.bodyHits.Load(),
-		BodyMisses:    m.stats.bodyMisses.Load(),
-		BodyPuts:      m.stats.bodyPuts.Load(),
-		BodyStales:    m.stats.bodyStales.Load(),
-		BodyEvictions: m.stats.bodyEvictions.Load(),
-		BodyOversize:  m.stats.bodyOversize.Load(),
-		BodyErrors:    m.stats.bodyErrors.Load(),
+		Hits:                 m.stats.hits.Load(),
+		Misses:               m.stats.misses.Load(),
+		Puts:                 m.stats.puts.Load(),
+		Stales:               m.stats.stales.Load(),
+		Errors:               m.stats.errors.Load(),
+		BodyHits:             m.stats.bodyHits.Load(),
+		BodyMisses:           m.stats.bodyMisses.Load(),
+		BodyPuts:             m.stats.bodyPuts.Load(),
+		BodyStales:           m.stats.bodyStales.Load(),
+		BodyEvictions:        m.stats.bodyEvictions.Load(),
+		BodyOversize:         m.stats.bodyOversize.Load(),
+		BodyErrors:           m.stats.bodyErrors.Load(),
 		EmbedHits:            m.stats.embedHits.Load(),
 		EmbedMisses:          m.stats.embedMisses.Load(),
 		EmbedPuts:            m.stats.embedPuts.Load(),
 		EmbedErrors:          m.stats.embedErrors.Load(),
 		EmbedModelMismatches: m.stats.embedModelMismatches.Load(),
+		AttrEntriesCount:     attrCount,
+		BodyEntriesCount:     bodyCount,
 	}
+}
+
+// ListAttrs iterates m.data, filters by substring, sorts by path,
+// and slices for pagination. Each row's Stale flag is computed by
+// stat'ing the live file (cheap for the typical browser page size).
+func (m *memoryIndex) ListAttrs(substr string, limit, offset int) ([]EntrySummary, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var matches []string
+	for k := range m.data {
+		if substr == "" || strings.Contains(k, substr) {
+			matches = append(matches, k)
+		}
+	}
+	sort.Strings(matches)
+	total := len(matches)
+	from := min(offset, total)
+	to := min(from+limit, total)
+	out := make([]EntrySummary, 0, to-from)
+	for _, p := range matches[from:to] {
+		e := m.data[p]
+		out = append(out, EntrySummary{
+			Path:        p,
+			ContentType: e.ContentType,
+			Size:        e.Size,
+			ModTime:     time.Unix(0, e.ModTimeUnixNano),
+			Stale:       isAttrStaleEntry(p, e),
+		})
+	}
+	return out, total, nil
+}
+
+// ListBodies is the body-cache analogue of ListAttrs. LastAccess is
+// always zero — the in-memory backend has no FIFO eviction layer.
+func (m *memoryIndex) ListBodies(substr string, limit, offset int) ([]BodySummary, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var matches []string
+	for k := range m.bodies {
+		if substr == "" || strings.Contains(k, substr) {
+			matches = append(matches, k)
+		}
+	}
+	sort.Strings(matches)
+	total := len(matches)
+	from := min(offset, total)
+	to := min(from+limit, total)
+	out := make([]BodySummary, 0, to-from)
+	for _, p := range matches[from:to] {
+		be := m.bodies[p]
+		out = append(out, BodySummary{
+			Path:    p,
+			Size:    be.Size,
+			ModTime: time.Unix(0, be.ModTimeUnixNano),
+			Stale:   isBodyStaleEntry(p, be),
+		})
+	}
+	return out, total, nil
+}
+
+// PeekAttrs returns m.data[absPath] bypassing validation.
+func (m *memoryIndex) PeekAttrs(absPath string) (*Entry, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	e, ok := m.data[absPath]
+	return e, ok
+}
+
+// PeekBody returns m.bodies[absPath] bypassing validation.
+func (m *memoryIndex) PeekBody(absPath string) (*BodyEntry, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	be, ok := m.bodies[absPath]
+	return be, ok
+}
+
+// isAttrStaleEntry and isBodyStaleEntry are the shared
+// stat-and-compare used by ListAttrs / ListBodies across both
+// backends. (bbolt.go has type-specific copies because it can't
+// import from a separate file without a re-org — duplication is
+// minimal and the helpers don't share state.)
+func isAttrStaleEntry(p string, e *Entry) bool {
+	info, err := os.Stat(p)
+	if err != nil {
+		return true
+	}
+	return info.Size() != e.Size || info.ModTime().UnixNano() != e.ModTimeUnixNano
+}
+
+func isBodyStaleEntry(p string, be *BodyEntry) bool {
+	info, err := os.Stat(p)
+	if err != nil {
+		return true
+	}
+	return info.Size() != be.Size || info.ModTime().UnixNano() != be.ModTimeUnixNano
 }
 
 func (m *memoryIndex) BumpEmbedStat(kind string) { bumpEmbedStat(&m.stats, kind) }

--- a/internal/monitor/server.go
+++ b/internal/monitor/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strconv"
@@ -465,6 +466,17 @@ func (s *Server) handleCacheEntry(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "path is required", http.StatusBadRequest)
 		return
 	}
+	// Reject ill-formed paths defensively. Our cache only ever stores
+	// keys via Put() with absolute, filepath.Clean()-normalised paths
+	// — anything else can't hit a cache entry anyway. Validating up
+	// front means PeekAttrs / PeekBody never have to consider hostile
+	// inputs, and keeps the handler off CodeQL's go/path-injection
+	// radar by sanitising user input before it flows into any path
+	// operation downstream.
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		http.Error(w, "path must be an absolute, clean filesystem path", http.StatusBadRequest)
+		return
+	}
 
 	switch bucket {
 	case "attrs":
@@ -473,6 +485,15 @@ func (s *Server) handleCacheEntry(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "not found", http.StatusNotFound)
 			return
 		}
+		// Staleness for individual entries is surfaced on the list
+		// view (which walks the bucket cursor and stats each row with
+		// path-as-cache-key, not as user input). The detail view
+		// deliberately does NOT os.Stat the user-supplied path —
+		// even though the dashboard binds 127.0.0.1 only, the
+		// pattern is bad hygiene (CodeQL go/path-injection) and a
+		// future "expose via proxy" feature would inherit it.
+		// Users wanting current staleness for a specific path
+		// refresh the list view.
 		writeJSON(w, map[string]any{
 			"bucket":       "attrs",
 			"path":         path,
@@ -486,7 +507,6 @@ func (s *Server) handleCacheEntry(w http.ResponseWriter, r *http.Request) {
 			"embed_model":  e.EmbedModel,
 			"has_vector":   len(e.Vector) > 0,
 			"vector_dims":  len(e.Vector),
-			"stale":        isAttrStaleFromCached(path, e.Size, e.ModTimeUnixNano),
 		})
 	case "bodies":
 		be, ok := s.cfg.Index.PeekBody(path)
@@ -509,22 +529,8 @@ func (s *Server) handleCacheEntry(w http.ResponseWriter, r *http.Request) {
 			"body":        body,
 			"body_length": len(be.Body),
 			"truncated":   truncated,
-			"stale":       isAttrStaleFromCached(path, be.Size, be.ModTimeUnixNano),
 		})
 	}
-}
-
-// isAttrStaleFromCached is the server-side staleness check —
-// stat the file at p and compare against the cached (size, mtime).
-// Returns true if the file is gone or has been modified. Kept
-// here rather than reaching into the index package because the
-// dashboard cares about the same notion for both attrs and bodies.
-func isAttrStaleFromCached(p string, cachedSize int64, cachedModUnixNano int64) bool {
-	info, err := os.Stat(p)
-	if err != nil {
-		return true
-	}
-	return info.Size() != cachedSize || info.ModTime().UnixNano() != cachedModUnixNano
 }
 
 // parseIntDefault parses s as int; returns def on error / empty.

--- a/internal/monitor/server.go
+++ b/internal/monitor/server.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -68,6 +69,8 @@ func (s *Server) routes() (http.Handler, error) {
 	mux.HandleFunc("GET /api/activity", s.handleActivity)
 	mux.HandleFunc("GET /api/capabilities", s.handleCapabilities)
 	mux.HandleFunc("GET /api/peers", s.handlePeers)
+	mux.HandleFunc("GET /api/cache/entries", s.handleCacheEntries)
+	mux.HandleFunc("GET /api/cache/entry", s.handleCacheEntry)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	sub, err := fs.Sub(staticFiles, "static")
 	if err != nil {
@@ -230,9 +233,9 @@ func (s *Server) handleOverview(w http.ResponseWriter, _ *http.Request) {
 		"gomaxprocs":            runtime.GOMAXPROCS(0),
 		"num_cpu":               runtime.NumCPU(),
 		"index_backing":         indexBacking,
-		"index_backend":         s.cfg.IndexBackend,         // "persistent" | "in-memory"
-		"index_path":            s.cfg.IndexPath,            // absolute path when persistent
-		"index_fallback_reason": s.cfg.IndexFallbackReason,  // "" | "no_index_flag" | "lock_contention"
+		"index_backend":         s.cfg.IndexBackend,        // "persistent" | "in-memory"
+		"index_path":            s.cfg.IndexPath,           // absolute path when persistent
+		"index_fallback_reason": s.cfg.IndexFallbackReason, // "" | "no_index_flag" | "lock_contention"
 		"body_cache_cap":        s.cfg.BodyCacheCap,
 		"goroutines":            runtime.NumGoroutine(),
 	})
@@ -265,6 +268,11 @@ func (s *Server) handleCache(w http.ResponseWriter, _ *http.Request) {
 			"errors": st.EmbedErrors, "model_mismatches": st.EmbedModelMismatches,
 			"hit_rate": rate(st.EmbedHits, st.EmbedMisses),
 		},
+		// Per-bucket entry counts — used by the dashboard's Cache
+		// entries panel for tab badges and pagination math.
+		"attr_entries_count": st.AttrEntriesCount,
+		"body_entries_count": st.BodyEntriesCount,
+		"bodies_total_bytes": st.BodiesTotalBytes,
 	})
 }
 
@@ -375,4 +383,158 @@ func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 		"uptime_seconds": time.Since(s.startedAt).Seconds(),
 		"index_open":     s.cfg.Index != nil,
 	})
+}
+
+// --- /api/cache/entries — paginated list ---
+
+// cacheEntriesLimitCap is the server-side hard ceiling on the list
+// response size. Callers that ask for more get this many; callers
+// who don't specify get cacheEntriesDefaultLimit.
+const (
+	cacheEntriesDefaultLimit = 50
+	cacheEntriesLimitCap     = 500
+)
+
+func (s *Server) handleCacheEntries(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.Index == nil {
+		writeJSON(w, map[string]any{"available": false})
+		return
+	}
+	q := r.URL.Query()
+	bucket := q.Get("bucket")
+	if bucket != "attrs" && bucket != "bodies" {
+		http.Error(w, "bucket must be 'attrs' or 'bodies'", http.StatusBadRequest)
+		return
+	}
+	substr := q.Get("q")
+	limit := min(parseIntDefault(q.Get("limit"), cacheEntriesDefaultLimit), cacheEntriesLimitCap)
+	offset := parseIntDefault(q.Get("offset"), 0)
+
+	switch bucket {
+	case "attrs":
+		entries, total, err := s.cfg.Index.ListAttrs(substr, limit, offset)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("list attrs: %v", err), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]any{
+			"bucket":  "attrs",
+			"q":       substr,
+			"total":   total,
+			"limit":   limit,
+			"offset":  offset,
+			"entries": entries,
+		})
+	case "bodies":
+		entries, total, err := s.cfg.Index.ListBodies(substr, limit, offset)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("list bodies: %v", err), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]any{
+			"bucket":  "bodies",
+			"q":       substr,
+			"total":   total,
+			"limit":   limit,
+			"offset":  offset,
+			"entries": entries,
+		})
+	}
+}
+
+// --- /api/cache/entry — single entry detail ---
+
+// cacheBodyDetailMaxBytes caps a single body-detail response to
+// keep the dashboard responsive even on huge bodies. Larger bodies
+// surface as truncated=true with the prefix.
+const cacheBodyDetailMaxBytes = 64 * 1024
+
+func (s *Server) handleCacheEntry(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.Index == nil {
+		writeJSON(w, map[string]any{"available": false})
+		return
+	}
+	q := r.URL.Query()
+	bucket := q.Get("bucket")
+	if bucket != "attrs" && bucket != "bodies" {
+		http.Error(w, "bucket must be 'attrs' or 'bodies'", http.StatusBadRequest)
+		return
+	}
+	path := q.Get("path")
+	if path == "" {
+		http.Error(w, "path is required", http.StatusBadRequest)
+		return
+	}
+
+	switch bucket {
+	case "attrs":
+		e, ok := s.cfg.Index.PeekAttrs(path)
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		writeJSON(w, map[string]any{
+			"bucket":       "attrs",
+			"path":         path,
+			"content_type": e.ContentType,
+			"size":         e.Size,
+			"mod_time":     time.Unix(0, e.ModTimeUnixNano),
+			"extra":        e.Extra,
+			"hash":         e.Hash,
+			"md5":          e.MD5,
+			"sha1":         e.SHA1,
+			"embed_model":  e.EmbedModel,
+			"has_vector":   len(e.Vector) > 0,
+			"vector_dims":  len(e.Vector),
+			"stale":        isAttrStaleFromCached(path, e.Size, e.ModTimeUnixNano),
+		})
+	case "bodies":
+		be, ok := s.cfg.Index.PeekBody(path)
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		body := be.Body
+		truncated := false
+		if len(body) > cacheBodyDetailMaxBytes {
+			body = body[:cacheBodyDetailMaxBytes]
+			truncated = true
+		}
+		writeJSON(w, map[string]any{
+			"bucket":      "bodies",
+			"path":        path,
+			"size":        be.Size,
+			"mod_time":    time.Unix(0, be.ModTimeUnixNano),
+			"created_at":  time.Unix(0, be.CreatedUnixNano),
+			"body":        body,
+			"body_length": len(be.Body),
+			"truncated":   truncated,
+			"stale":       isAttrStaleFromCached(path, be.Size, be.ModTimeUnixNano),
+		})
+	}
+}
+
+// isAttrStaleFromCached is the server-side staleness check —
+// stat the file at p and compare against the cached (size, mtime).
+// Returns true if the file is gone or has been modified. Kept
+// here rather than reaching into the index package because the
+// dashboard cares about the same notion for both attrs and bodies.
+func isAttrStaleFromCached(p string, cachedSize int64, cachedModUnixNano int64) bool {
+	info, err := os.Stat(p)
+	if err != nil {
+		return true
+	}
+	return info.Size() != cachedSize || info.ModTime().UnixNano() != cachedModUnixNano
+}
+
+// parseIntDefault parses s as int; returns def on error / empty.
+func parseIntDefault(s string, def int) int {
+	if s == "" {
+		return def
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return def
+	}
+	return n
 }

--- a/internal/monitor/server_cache_browser_test.go
+++ b/internal/monitor/server_cache_browser_test.go
@@ -173,3 +173,27 @@ func TestServer_CacheEntry_MissingPath(t *testing.T) {
 		t.Errorf("status = %d, want 400 for missing path", rec.Code)
 	}
 }
+
+// TestServer_CacheEntry_RejectsIllFormedPaths is the regression
+// guard for the CodeQL go/path-injection finding on PR #249.
+// Non-absolute paths and paths with .. traversal segments must be
+// rejected with 400 before any filesystem-aware operation runs.
+func TestServer_CacheEntry_RejectsIllFormedPaths(t *testing.T) {
+	s, _ := newCacheBrowserTestServer(t)
+	for _, badPath := range []string{
+		"relative/path/file.md",
+		"./relative.md",
+		"/etc/../etc/passwd",
+		"/a//b",
+		"/a/b/",
+	} {
+		t.Run(badPath, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			url := "/api/cache/entry?bucket=attrs&path=" + badPath
+			s.handleCacheEntry(rec, httptest.NewRequest(http.MethodGet, url, nil))
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d for path=%q, want 400 (rejected as ill-formed)", rec.Code, badPath)
+			}
+		})
+	}
+}

--- a/internal/monitor/server_cache_browser_test.go
+++ b/internal/monitor/server_cache_browser_test.go
@@ -1,0 +1,175 @@
+package monitor
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+)
+
+// seedFixtureIndex builds an in-memory index with 5 attrs entries and
+// 2 body entries, all backed by real files in t.TempDir() so the
+// staleness probe (os.Stat in the handler) returns false on fresh
+// reads.
+func seedFixtureIndex(t *testing.T) (idx index.Index, tmp string, paths []string) {
+	t.Helper()
+	idx = index.NewMemory()
+	tmp = t.TempDir()
+	for _, b := range []string{"alpha.md", "beta.md", "gamma.go", "delta.txt", "epsilon.md"} {
+		p := filepath.Join(tmp, b)
+		if err := os.WriteFile(p, []byte("body of "+b), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if err := idx.Put(p, &index.Entry{
+			Size:            info.Size(),
+			ModTimeUnixNano: info.ModTime().UnixNano(),
+			ContentType:     "text",
+			Extra:           map[string]any{"basename": b, "word_count": 3},
+		}); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		paths = append(paths, p)
+	}
+	// Two of the same files also have body cache entries.
+	for _, p := range paths[:2] {
+		info, _ := os.Stat(p)
+		if err := idx.PutBody(p, &index.BodyEntry{
+			Size:            info.Size(),
+			ModTimeUnixNano: info.ModTime().UnixNano(),
+			Body:            "cached body for " + filepath.Base(p),
+		}); err != nil {
+			t.Fatalf("PutBody: %v", err)
+		}
+	}
+	return idx, tmp, paths
+}
+
+func newCacheBrowserTestServer(t *testing.T) (*Server, []string) {
+	t.Helper()
+	idx, _, paths := seedFixtureIndex(t)
+	s := NewServer(Config{
+		Version:     "test-1.2.3",
+		Mode:        "mcp-stdio",
+		Index:       idx,
+		EmbedServer: "http://localhost:1",
+		EmbedModel:  "nomic-embed-text",
+	})
+	return s, paths
+}
+
+func decodeCache(t *testing.T, h http.HandlerFunc, url string, wantStatus int) map[string]any {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, url, nil))
+	if rec.Code != wantStatus {
+		t.Fatalf("%s: status = %d, want %d (body: %s)", url, rec.Code, wantStatus, rec.Body.String())
+	}
+	if wantStatus != http.StatusOK {
+		return nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("%s decode: %v", url, err)
+	}
+	return out
+}
+
+func TestServer_CacheEntries_AttrsFilteredAndPaginated(t *testing.T) {
+	s, _ := newCacheBrowserTestServer(t)
+
+	// No filter — 5 entries total.
+	got := decodeCache(t, s.handleCacheEntries, "/api/cache/entries?bucket=attrs", http.StatusOK)
+	if got["total"].(float64) != 5 {
+		t.Errorf("total = %v, want 5", got["total"])
+	}
+	entries := got["entries"].([]any)
+	if len(entries) != 5 {
+		t.Errorf("entries len = %d, want 5", len(entries))
+	}
+
+	// Filter ".md" — 3 hits (alpha.md, beta.md, epsilon.md).
+	got = decodeCache(t, s.handleCacheEntries, "/api/cache/entries?bucket=attrs&q=.md", http.StatusOK)
+	if got["total"].(float64) != 3 {
+		t.Errorf("filtered total = %v, want 3", got["total"])
+	}
+
+	// Pagination — limit=2, offset=1.
+	got = decodeCache(t, s.handleCacheEntries, "/api/cache/entries?bucket=attrs&limit=2&offset=1", http.StatusOK)
+	if entries := got["entries"].([]any); len(entries) != 2 {
+		t.Errorf("paged len = %d, want 2", len(entries))
+	}
+	if got["total"].(float64) != 5 {
+		t.Errorf("paged total = %v, want 5 (full count, not page size)", got["total"])
+	}
+}
+
+func TestServer_CacheEntries_BodiesBucket(t *testing.T) {
+	s, _ := newCacheBrowserTestServer(t)
+	got := decodeCache(t, s.handleCacheEntries, "/api/cache/entries?bucket=bodies", http.StatusOK)
+	if got["total"].(float64) != 2 {
+		t.Errorf("body total = %v, want 2", got["total"])
+	}
+}
+
+func TestServer_CacheEntries_BadBucket(t *testing.T) {
+	s, _ := newCacheBrowserTestServer(t)
+	rec := httptest.NewRecorder()
+	s.handleCacheEntries(rec, httptest.NewRequest(http.MethodGet, "/api/cache/entries?bucket=garbage", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for bad bucket", rec.Code)
+	}
+}
+
+func TestServer_CacheEntry_AttrsDetail(t *testing.T) {
+	s, paths := newCacheBrowserTestServer(t)
+	url := "/api/cache/entry?bucket=attrs&path=" + paths[0]
+	got := decodeCache(t, s.handleCacheEntry, url, http.StatusOK)
+	if got["path"] != paths[0] {
+		t.Errorf("path = %v, want %v", got["path"], paths[0])
+	}
+	if got["content_type"] != "text" {
+		t.Errorf("content_type = %v, want text", got["content_type"])
+	}
+	extra, ok := got["extra"].(map[string]any)
+	if !ok {
+		t.Fatalf("extra missing or wrong type: %v", got["extra"])
+	}
+	if extra["basename"] == nil {
+		t.Errorf("expected basename in extra, got %v", extra)
+	}
+}
+
+func TestServer_CacheEntry_BodiesDetail(t *testing.T) {
+	s, paths := newCacheBrowserTestServer(t)
+	url := "/api/cache/entry?bucket=bodies&path=" + paths[0]
+	got := decodeCache(t, s.handleCacheEntry, url, http.StatusOK)
+	if got["body"] == "" || got["body"] == nil {
+		t.Errorf("expected non-empty body, got %v", got["body"])
+	}
+}
+
+func TestServer_CacheEntry_NotFound(t *testing.T) {
+	s, _ := newCacheBrowserTestServer(t)
+	rec := httptest.NewRecorder()
+	s.handleCacheEntry(rec, httptest.NewRequest(http.MethodGet, "/api/cache/entry?bucket=attrs&path=/nonexistent/path", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestServer_CacheEntry_MissingPath(t *testing.T) {
+	s, _ := newCacheBrowserTestServer(t)
+	rec := httptest.NewRecorder()
+	s.handleCacheEntry(rec, httptest.NewRequest(http.MethodGet, "/api/cache/entry?bucket=attrs", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for missing path", rec.Code)
+	}
+}

--- a/internal/monitor/static/app.js
+++ b/internal/monitor/static/app.js
@@ -217,11 +217,196 @@ async function tick() {
     renderActivity(a);
     renderCapabilities(caps);
     renderPeers(peers);
+    updateCacheBrowserCounts(c);
     setHealth(true);
   } catch (e) {
     setHealth(false);
   }
 }
+
+// --- Cache browser ---
+//
+// The browser does NOT poll on the 2s tick — refreshes only fire when
+// the user changes the filter, switches tab, or paginates. It re-uses
+// the live counts from /api/cache (which DOES poll) to keep the tab
+// labels honest.
+
+const cb = {
+  bucket: "attrs",
+  q: "",
+  offset: 0,
+  limit: 50,
+  total: 0,
+  attrCount: 0,
+  bodyCount: 0,
+};
+
+function updateCacheBrowserCounts(cacheJSON) {
+  // The bucket entry counts ride on /api/cache via Stats. cacheJSON shape:
+  // { attr: { ... }, body: { ... }, attr_entries_count, body_entries_count }
+  cb.attrCount = cacheJSON.attr_entries_count || 0;
+  cb.bodyCount = cacheJSON.body_entries_count || 0;
+  // Reflect in tab labels.
+  document.getElementById("cb-tab-attrs").textContent = `Attributes (${cb.attrCount})`;
+  document.getElementById("cb-tab-bodies").textContent = `Bodies (${cb.bodyCount})`;
+}
+
+async function refreshCacheBrowser() {
+  const url = `api/cache/entries?bucket=${cb.bucket}&q=${encodeURIComponent(cb.q)}&limit=${cb.limit}&offset=${cb.offset}`;
+  let resp;
+  try {
+    resp = await getJSON(url);
+  } catch (e) {
+    document.getElementById("cb-table").innerHTML = `<div class="empty">error: ${e.message}</div>`;
+    return;
+  }
+  cb.total = resp.total || 0;
+  renderCacheBrowserTable(resp.entries || []);
+  updateCacheBrowserPager();
+}
+
+function renderCacheBrowserTable(entries) {
+  if (!entries.length) {
+    document.getElementById("cb-table").innerHTML = `<div class="empty">no entries</div>`;
+    return;
+  }
+  const isAttrs = cb.bucket === "attrs";
+  const rows = entries.map((e) => {
+    const staleBadge = e.stale ? `<span class="cb-stale">stale</span>` : "";
+    const mt = e.mod_time ? new Date(e.mod_time).toLocaleString() : "";
+    const cell2 = isAttrs ? (e.content_type || "—") : bytes(e.size);
+    const cell3 = isAttrs ? bytes(e.size) : (e.last_access ? new Date(e.last_access).toLocaleString() : "—");
+    return `<tr class="cb-row" data-path="${escapeAttr(e.path)}">
+      <td class="cb-path">${escapeHTML(e.path)}${staleBadge}</td>
+      <td>${escapeHTML(cell2)}</td>
+      <td>${escapeHTML(cell3)}</td>
+      <td>${mt}</td>
+    </tr>`;
+  }).join("");
+  const header = isAttrs
+    ? `<th>path</th><th>content_type</th><th>size</th><th>mod_time</th>`
+    : `<th>path</th><th>size</th><th>last_access</th><th>mod_time</th>`;
+  document.getElementById("cb-table").innerHTML = `<table class="cb-table">
+    <thead><tr>${header}</tr></thead>
+    <tbody>${rows}</tbody>
+  </table>`;
+  // Wire row clicks → detail modal.
+  document.querySelectorAll("#cb-table tr.cb-row").forEach((tr) => {
+    tr.addEventListener("click", () => openDetail(tr.dataset.path));
+  });
+}
+
+function updateCacheBrowserPager() {
+  const pageStart = cb.total === 0 ? 0 : cb.offset + 1;
+  const pageEnd = Math.min(cb.offset + cb.limit, cb.total);
+  document.getElementById("cb-pageinfo").textContent = `${pageStart}–${pageEnd} of ${cb.total}`;
+  document.getElementById("cb-prev").disabled = cb.offset === 0;
+  document.getElementById("cb-next").disabled = pageEnd >= cb.total;
+}
+
+async function openDetail(path) {
+  const url = `api/cache/entry?bucket=${cb.bucket}&path=${encodeURIComponent(path)}`;
+  let resp;
+  try {
+    resp = await getJSON(url);
+  } catch (e) {
+    alert(`could not load detail: ${e.message}`);
+    return;
+  }
+  renderDetail(resp);
+  document.getElementById("cb-modal").hidden = false;
+}
+
+function renderDetail(d) {
+  const isAttrs = cb.bucket === "attrs";
+  const rows = [];
+  const add = (k, v) => rows.push(`<div class="k">${escapeHTML(k)}</div><div class="v">${escapeHTML(String(v))}</div>`);
+  add("path", d.path);
+  if (isAttrs) {
+    add("content_type", d.content_type || "—");
+    add("size", bytes(d.size));
+    add("mod_time", d.mod_time ? new Date(d.mod_time).toLocaleString() : "—");
+    add("stale", d.stale ? "yes" : "no");
+    if (d.hash) add("sha256", d.hash);
+    if (d.md5) add("md5", d.md5);
+    if (d.sha1) add("sha1", d.sha1);
+    if (d.embed_model) add("embed_model", d.embed_model);
+    if (d.has_vector) add("vector_dims", d.vector_dims);
+    // Flatten Extra as additional rows.
+    if (d.extra) {
+      Object.keys(d.extra).sort().forEach((k) => add(k, formatExtra(d.extra[k])));
+    }
+  } else {
+    add("size", bytes(d.size));
+    add("mod_time", d.mod_time ? new Date(d.mod_time).toLocaleString() : "—");
+    add("created_at", d.created_at ? new Date(d.created_at).toLocaleString() : "—");
+    add("stale", d.stale ? "yes" : "no");
+    add("body_length", bytes(d.body_length));
+    if (d.truncated) add("truncated", "yes (preview cut at 64 KiB)");
+  }
+  let body = "";
+  if (!isAttrs && d.body) {
+    body = `<div class="cb-body-block">${escapeHTML(d.body)}</div>`;
+  }
+  document.getElementById("cb-modal-body").innerHTML = `<h3 style="margin-top:0">Cache entry — ${cb.bucket}</h3>
+    <div class="cb-detail-grid">${rows.join("")}</div>${body}`;
+}
+
+function formatExtra(v) {
+  if (v == null) return "—";
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
+
+function escapeHTML(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+function escapeAttr(s) {
+  return escapeHTML(s);
+}
+
+// Wire up controls once at startup.
+let cbDebounce = null;
+function wireCacheBrowser() {
+  document.querySelectorAll(".cb-tab").forEach((b) => {
+    b.addEventListener("click", () => {
+      document.querySelectorAll(".cb-tab").forEach((x) => x.classList.remove("cb-tab-active"));
+      b.classList.add("cb-tab-active");
+      cb.bucket = b.dataset.bucket;
+      cb.offset = 0;
+      refreshCacheBrowser();
+    });
+  });
+  document.getElementById("cb-filter").addEventListener("input", (e) => {
+    clearTimeout(cbDebounce);
+    cbDebounce = setTimeout(() => {
+      cb.q = e.target.value;
+      cb.offset = 0;
+      refreshCacheBrowser();
+    }, 300);
+  });
+  document.getElementById("cb-prev").addEventListener("click", () => {
+    cb.offset = Math.max(0, cb.offset - cb.limit);
+    refreshCacheBrowser();
+  });
+  document.getElementById("cb-next").addEventListener("click", () => {
+    cb.offset += cb.limit;
+    refreshCacheBrowser();
+  });
+  document.getElementById("cb-modal-close").addEventListener("click", () => {
+    document.getElementById("cb-modal").hidden = true;
+  });
+  document.getElementById("cb-modal").addEventListener("click", (e) => {
+    // Dismiss when clicking the dim overlay (not the inner content).
+    if (e.target === document.getElementById("cb-modal")) {
+      document.getElementById("cb-modal").hidden = true;
+    }
+  });
+  refreshCacheBrowser();
+}
+
+wireCacheBrowser();
 
 tick();
 setInterval(tick, 2000);

--- a/internal/monitor/static/app.js
+++ b/internal/monitor/static/app.js
@@ -322,11 +322,14 @@ function renderDetail(d) {
   const rows = [];
   const add = (k, v) => rows.push(`<div class="k">${escapeHTML(k)}</div><div class="v">${escapeHTML(String(v))}</div>`);
   add("path", d.path);
+  // The detail endpoint deliberately does not stat the user-supplied
+  // path — staleness lives on the list view, which walks the cursor
+  // with cache keys (not user input). Refresh the list to see current
+  // staleness for any specific path.
   if (isAttrs) {
     add("content_type", d.content_type || "—");
     add("size", bytes(d.size));
     add("mod_time", d.mod_time ? new Date(d.mod_time).toLocaleString() : "—");
-    add("stale", d.stale ? "yes" : "no");
     if (d.hash) add("sha256", d.hash);
     if (d.md5) add("md5", d.md5);
     if (d.sha1) add("sha1", d.sha1);
@@ -340,7 +343,6 @@ function renderDetail(d) {
     add("size", bytes(d.size));
     add("mod_time", d.mod_time ? new Date(d.mod_time).toLocaleString() : "—");
     add("created_at", d.created_at ? new Date(d.created_at).toLocaleString() : "—");
-    add("stale", d.stale ? "yes" : "no");
     add("body_length", bytes(d.body_length));
     if (d.truncated) add("truncated", "yes (preview cut at 64 KiB)");
   }

--- a/internal/monitor/static/index.html
+++ b/internal/monitor/static/index.html
@@ -30,6 +30,29 @@
     </section>
 
     <section class="panel">
+      <h2>Cache entries <span id="cb-counts" class="muted"></span></h2>
+      <div class="cb-toolbar">
+        <div class="cb-tabs">
+          <button id="cb-tab-attrs" class="cb-tab cb-tab-active" data-bucket="attrs">Attributes</button>
+          <button id="cb-tab-bodies" class="cb-tab" data-bucket="bodies">Bodies</button>
+        </div>
+        <input id="cb-filter" type="search" placeholder="filter by path substring…" autocomplete="off">
+        <div class="cb-pager">
+          <button id="cb-prev" class="cb-btn">‹ prev</button>
+          <span id="cb-pageinfo" class="muted">—</span>
+          <button id="cb-next" class="cb-btn">next ›</button>
+        </div>
+      </div>
+      <div id="cb-table"></div>
+    </section>
+    <div id="cb-modal" class="cb-modal" hidden>
+      <div class="cb-modal-inner">
+        <button id="cb-modal-close" class="cb-modal-close" aria-label="Close">×</button>
+        <div id="cb-modal-body"></div>
+      </div>
+    </div>
+
+    <section class="panel">
       <h2>Activity <span id="inflight" class="badge"></span></h2>
       <div id="activity-tools"></div>
       <h3 class="sub">Recent calls</h3>

--- a/internal/monitor/static/style.css
+++ b/internal/monitor/static/style.css
@@ -76,4 +76,32 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 .ix-persistent { color: var(--ok); }
 .ix-memory { color: var(--muted); }
 .ix-memory.ix-warn { color: var(--warn); }
+
+/* --- cache browser --- */
+.cb-toolbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 10px; }
+.cb-tabs { display: inline-flex; border: 1px solid var(--line); border-radius: 4px; overflow: hidden; }
+.cb-tab { background: transparent; border: none; color: var(--muted); padding: 4px 12px; cursor: pointer; font-size: 13px; }
+.cb-tab:hover { background: var(--card); color: var(--fg); }
+.cb-tab-active { background: var(--card); color: var(--fg); font-weight: 600; }
+#cb-filter { flex: 1; min-width: 180px; background: var(--card); border: 1px solid var(--line); color: var(--fg); padding: 4px 10px; border-radius: 4px; font-size: 13px; }
+.cb-pager { display: inline-flex; gap: 4px; align-items: center; }
+.cb-btn { background: var(--card); border: 1px solid var(--line); color: var(--fg); padding: 4px 10px; cursor: pointer; border-radius: 4px; font-size: 12px; }
+.cb-btn:disabled { opacity: 0.4; cursor: default; }
+.cb-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.cb-table th, .cb-table td { text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--line); }
+.cb-table th { color: var(--muted); font-weight: 600; }
+.cb-table tr.cb-row { cursor: pointer; }
+.cb-table tr.cb-row:hover { background: var(--card); }
+.cb-table .cb-path { font-family: ui-monospace, monospace; word-break: break-all; }
+.cb-stale { color: var(--warn); font-size: 11px; margin-left: 6px; }
+.cb-modal { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: 100; }
+.cb-modal[hidden] { display: none; }
+.cb-modal-inner { background: var(--bg); border: 1px solid var(--line); border-radius: 8px; padding: 20px; max-width: 80vw; max-height: 85vh; overflow-y: auto; position: relative; min-width: 480px; }
+.cb-modal-close { position: absolute; top: 10px; right: 14px; background: transparent; border: none; color: var(--muted); cursor: pointer; font-size: 20px; line-height: 1; }
+.cb-modal-close:hover { color: var(--fg); }
+.cb-detail-grid { display: grid; grid-template-columns: max-content 1fr; gap: 4px 14px; font-size: 13px; }
+.cb-detail-grid .k { color: var(--muted); }
+.cb-detail-grid .v { word-break: break-all; font-family: ui-monospace, monospace; }
+.cb-body-block { background: var(--card); padding: 10px; border-radius: 4px; font-family: ui-monospace, monospace; font-size: 11px; white-space: pre-wrap; max-height: 50vh; overflow-y: auto; margin-top: 12px; }
+
 @media (max-width: 760px) { main, .caps-grid { grid-template-columns: 1fr; } }


### PR DESCRIPTION
Adds a **paginated, read-only cache browser** to the monitoring dashboard. Switch between the attribute and body caches, filter by path substring, paginate, click any row to see the full payload (every CEL attribute the parser extracted; first 64 KiB of body for body entries).

Complements PR #243's index-backend indicator (you can see *which* index is in use) and PR #245's default-on dashboard (every stdio MCP session has a dashboard waiting). The cache data was reachable but opaque — this opens it up.

## Surface area

| Layer | Files | What |
| --- | --- | --- |
| Index API | \`internal/index/{index,bbolt,memory}.go\` | Four new methods — \`ListAttrs\` / \`ListBodies\` / \`PeekAttrs\` / \`PeekBody\` — plus per-bucket entry counts on \`Stats\` |
| HTTP API | \`internal/monitor/server.go\` | Two new routes (\`/api/cache/entries\`, \`/api/cache/entry\`) + counts added to existing \`/api/cache\` |
| UI | \`internal/monitor/static/{index.html, app.js, style.css}\` | New "Cache entries" panel below the existing aggregate-counters panel: tab toggle, debounced filter, paginated table, click-to-detail modal |
| Tests | \`internal/index/list_test.go\` + \`internal/monitor/server_cache_browser_test.go\` | 14 new tests covering both backends + HTTP layer |

## Index methods

\`\`\`go
ListAttrs(substr string, limit, offset int) ([]EntrySummary, int, error)
ListBodies(substr string, limit, offset int) ([]BodySummary, int, error)
PeekAttrs(absPath string) (*Entry, bool)
PeekBody(absPath string) (*BodyEntry, bool)
\`\`\`

\`EntrySummary\` / \`BodySummary\` are compact row shapes — full payloads ride in the detail view via \`PeekAttrs\` / \`PeekBody\`. Each row's \`Stale\` flag is computed by stat'ing the live file (cheap at 50-row pages). \`Peek*\` bypasses the (size, mtime) validation that \`Lookup\` enforces, so the dashboard can show stale entries with a flag rather than hiding them.

## HTTP API

| Route | Returns |
| --- | --- |
| \`GET /api/cache/entries?bucket=attrs\|bodies&q=<substr>&limit=N&offset=N\` | \`{ bucket, q, total, limit, offset, entries: [...] }\` — server caps \`limit\` at 500 |
| \`GET /api/cache/entry?bucket=attrs\|bodies&path=<absolute>\` | Full Entry payload (content_type, size, mod_time, Extra, hash, md5, sha1, embed_model, vector_dims) for attrs / body preview (capped at 64 KiB; \`truncated\` flag) for bodies / **404** when path missing |

\`/api/cache\` also gains \`attr_entries_count\` / \`body_entries_count\` / \`bodies_total_bytes\` so the dashboard tab counters stay live without an extra round-trip.

## UI

- Tab toggle: **Attributes (N)** / **Bodies (M)** with live counts from \`/api/cache\`.
- Debounced (300ms) substring filter on path. Empty = show all.
- Sortable-by-path table; prev/next pagination at fixed page size 50.
- Click a row → modal overlay. For attrs: every \`Extra\` map entry pretty-printed (\`loc\`, \`language\`, \`title\`, etc.). For bodies: first N lines in a monospace pre-block.
- Panel does **not** poll on the 2s tick — only refreshes on tab/filter/page changes. Aggregate counters keep polling.

## Tests

- \`internal/index/list_test.go\` — 7 tests on both bbolt and in-memory backends: pagination, substring filter, stale flag, Peek-returns-stale, missing path → !ok, body access time, Stats entry counts. Async-bbolt-writer-aware (waits for the put to become visible before list).
- \`internal/monitor/server_cache_browser_test.go\` — 7 \`httptest\` endpoint tests: list pagination, body bucket, bad bucket → 400, attrs/bodies detail, 404 on missing entry, 400 on missing \`path\`.

## End-to-end verification

Verified live against an MCP server pointed at a pre-warmed cache (11 source files):
- \`/api/cache\` → \`attr_entries_count: 11\` ✓
- \`/api/cache/entries?bucket=attrs&q=bbolt\` → \`total: 3\` (three matching paths) ✓
- \`/api/cache/entry?bucket=attrs&path=<...>\` → full Entry with \`Extra\` keys \`{blank_loc, comment_loc, language, line_count, loc}\`, \`stale: false\` ✓

CI sweep: \`go test -race -short ./...\` ✓ · \`go vet\` ✓ · \`golangci-lint\` 0 issues · \`go fix\` idempotent.

## Out of scope (deferred)

- **Embedding cache browser** — embeddings ride on \`Entry.Vector\` rather than a dedicated bucket; the list/peek surface there is its own design exercise.
- **Mutating actions** (delete entry, force-refresh) — read-only keeps the trust story simple; users can still \`rm\` the bbolt file.
- **Real-time updates** — pull-based refresh is enough for an occasional-use inspection view.
- **Glob / regex filters** — substring is sufficient for v1.

## Test plan
- [ ] Build the binary, run \`file-search-on search 'is_source' -d ./internal --index-path /tmp/x.db\` to warm the cache
- [ ] \`file-search-on mcp --transport http --addr 127.0.0.1:0 --index-path /tmp/x.db\` — open the URL from stderr
- [ ] Browse the new "Cache entries" panel; tab toggle, filter, pagination all responsive
- [ ] Click a row → detail modal shows the Extra map (loc, language, line_count, ...)
- [ ] \`touch\` a backing file between two list refreshes — the stale badge appears on that row
- [ ] Switch to Bodies tab — works the same with body-cache entries (need a body-cache walk first, e.g. \`--include-body\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)