### PR TITLE
feat(mcp): opt-in sandbox restricting agent filesystem access

### DIFF
--- a/cmd/file-search-on/mcp_cmd.go
+++ b/cmd/file-search-on/mcp_cmd.go
@@ -31,6 +31,8 @@ type MCPCmd struct {
 	WarmWorkers       int           `name:"warm-workers" help:"Worker count for the warmer. Defaults to max(1, NumCPU/4) — a quarter of the cores so the MCP server, the agent driving it, and the rest of the box keep their headroom. Pass 1 for minimum CPU; ignored when --warm is off."`
 	WarmTimeout       time.Duration `name:"warm-timeout" default:"10m" help:"Hard deadline on the warmer (Go duration: 30s, 5m). The MCP server keeps running if the warmer is killed by the deadline. Ignored when --warm is off."`
 	WarmEmbeddings    bool          `name:"warm-embeddings" help:"At startup, walk the warm root in the background and pre-populate the search_semantic embeddings cache. Requires --embedding-model to be set. Reads every walked file's body and calls Ollama once per file (expensive: ~1s/file on localhost) — appropriate as a pre-flight to interactive use. Walks concurrently with the MCP server, so clients connect immediately. Combine with --warm to populate both caches in one walk."`
+	Sandbox           bool          `name:"sandbox" help:"Restrict agent filesystem access to the cwd at server startup. Path-accepting MCP tool inputs (dir / dirs / path / tree_a / tree_b / hash_allowlist_path / hash_denylist_path) that resolve outside the sandbox are rejected with a clear error. Off by default; opt in when running file-search-on as an MCP server for an agent you want to scope to a single project. Combine with --sandbox-dir to specify explicit roots."`
+	SandboxDir        []string      `name:"sandbox-dir" help:"Sandbox root directory. Repeatable for multiple roots (e.g. --sandbox-dir ~/Code/foo --sandbox-dir ~/Code/bar). Implies --sandbox. Symlinks pointing outside the sandbox are rejected; follow_symlinks=true is rejected entirely when the sandbox is active (the walker doesn't yet enforce sandbox per-entry)."`
 }
 
 func (m *MCPCmd) Run(ctx context.Context) error {
@@ -145,6 +147,17 @@ func (m *MCPCmd) Run(ctx context.Context) error {
 	mcpOpts := []mcpserver.Option{
 		mcpserver.WithCollector(collector),
 		mcpserver.WithMonitor(controller),
+	}
+
+	sandboxRoots := append([]string(nil), m.SandboxDir...)
+	if m.Sandbox && len(sandboxRoots) == 0 {
+		if cwd, err := os.Getwd(); err == nil {
+			sandboxRoots = []string{cwd}
+		}
+	}
+	if len(sandboxRoots) > 0 {
+		mcpOpts = append(mcpOpts, mcpserver.WithSandbox(sandboxRoots))
+		fmt.Fprintf(os.Stderr, "sandbox: restricting agent access to %v\n", sandboxRoots)
 	}
 
 	switch m.Transport {

--- a/internal/mcpserver/detect_project_tool.go
+++ b/internal/mcpserver/detect_project_tool.go
@@ -33,6 +33,9 @@ func (h *handlers) detectProjectHandler(ctx context.Context, _ *mcp.CallToolRequ
 	if err != nil {
 		return nil, DetectProjectOutput{}, fmt.Errorf("expand dir: %w", err)
 	}
+	if dir, err = h.validatePath(dir); err != nil {
+		return nil, DetectProjectOutput{}, err
+	}
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, DetectProjectOutput{}, fmt.Errorf("resolve dir: %w", err)

--- a/internal/mcpserver/diff_tool.go
+++ b/internal/mcpserver/diff_tool.go
@@ -52,6 +52,15 @@ func (h *handlers) diffTreesHandler(ctx context.Context, _ *mcp.CallToolRequest,
 	if treeA == "" || treeB == "" {
 		return nil, DiffTreesOutput{}, fmt.Errorf("tree_a and tree_b are both required")
 	}
+	if err := h.checkFollowSymlinks(in.FollowSymlinks); err != nil {
+		return nil, DiffTreesOutput{}, err
+	}
+	if treeA, err = h.validatePath(treeA); err != nil {
+		return nil, DiffTreesOutput{}, err
+	}
+	if treeB, err = h.validatePath(treeB); err != nil {
+		return nil, DiffTreesOutput{}, err
+	}
 	op := in.Op
 	if op == "" {
 		op = string(search.OpAMinusB)

--- a/internal/mcpserver/find_duplicates_tool.go
+++ b/internal/mcpserver/find_duplicates_tool.go
@@ -67,6 +67,15 @@ func (h *handlers) findDuplicatesHandler(ctx context.Context, _ *mcp.CallToolReq
 	if dir == "" && len(dirs) == 0 {
 		dir = "."
 	}
+	if err := h.checkFollowSymlinks(in.FollowSymlinks); err != nil {
+		return nil, FindDuplicatesOutput{}, err
+	}
+	if dir, err = h.validatePath(dir); err != nil {
+		return nil, FindDuplicatesOutput{}, err
+	}
+	if dirs, err = h.validatePaths(dirs); err != nil {
+		return nil, FindDuplicatesOutput{}, err
+	}
 
 	var cancel context.CancelFunc
 	ctx, cancel = h.resolveTimeout(ctx, in.TimeoutSeconds)

--- a/internal/mcpserver/find_matches_tool.go
+++ b/internal/mcpserver/find_matches_tool.go
@@ -77,6 +77,15 @@ func (h *handlers) findMatchesHandler(ctx context.Context, _ *mcp.CallToolReques
 	if err != nil {
 		return nil, FindMatchesOutput{}, fmt.Errorf("expand dirs: %w", err)
 	}
+	if err := h.checkFollowSymlinks(in.FollowSymlinks); err != nil {
+		return nil, FindMatchesOutput{}, err
+	}
+	if dir, err = h.validatePath(dir); err != nil {
+		return nil, FindMatchesOutput{}, err
+	}
+	if dirs, err = h.validatePaths(dirs); err != nil {
+		return nil, FindMatchesOutput{}, err
+	}
 	if dir == "" && len(dirs) == 0 {
 		dir = "."
 	}

--- a/internal/mcpserver/find_near_duplicates_tool.go
+++ b/internal/mcpserver/find_near_duplicates_tool.go
@@ -75,6 +75,15 @@ func (h *handlers) findNearDuplicatesHandler(ctx context.Context, _ *mcp.CallToo
 	if dir == "" && len(dirs) == 0 {
 		dir = "."
 	}
+	if err := h.checkFollowSymlinks(in.FollowSymlinks); err != nil {
+		return nil, FindNearDuplicatesOutput{}, err
+	}
+	if dir, err = h.validatePath(dir); err != nil {
+		return nil, FindNearDuplicatesOutput{}, err
+	}
+	if dirs, err = h.validatePaths(dirs); err != nil {
+		return nil, FindNearDuplicatesOutput{}, err
+	}
 
 	var cancel context.CancelFunc
 	ctx, cancel = h.resolveTimeout(ctx, in.TimeoutSeconds)

--- a/internal/mcpserver/find_projects_tool.go
+++ b/internal/mcpserver/find_projects_tool.go
@@ -42,6 +42,9 @@ func (h *handlers) findProjectsHandler(ctx context.Context, _ *mcp.CallToolReque
 	if err != nil {
 		return nil, FindProjectsOutput{}, fmt.Errorf("expand dir: %w", err)
 	}
+	if dir, err = h.validatePath(dir); err != nil {
+		return nil, FindProjectsOutput{}, err
+	}
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, FindProjectsOutput{}, fmt.Errorf("resolve dir: %w", err)

--- a/internal/mcpserver/list_archive_contents_tool.go
+++ b/internal/mcpserver/list_archive_contents_tool.go
@@ -61,6 +61,9 @@ func (h *handlers) listArchiveContentsHandler(ctx context.Context, _ *mcp.CallTo
 	if path == "" {
 		return nil, ListArchiveContentsOutput{}, errors.New("path is required")
 	}
+	if path, err = h.validatePath(path); err != nil {
+		return nil, ListArchiveContentsOutput{}, err
+	}
 
 	var cancel context.CancelFunc
 	ctx, cancel = h.resolveTimeout(ctx, in.TimeoutSeconds)

--- a/internal/mcpserver/read_attributes_tool.go
+++ b/internal/mcpserver/read_attributes_tool.go
@@ -50,6 +50,23 @@ func (h *handlers) readAttributesHandler(ctx context.Context, _ *mcp.CallToolReq
 	if err != nil {
 		return nil, ReadAttributesOutput{}, fmt.Errorf("expand path: %w", err)
 	}
+	if path, err = h.validatePath(path); err != nil {
+		return nil, ReadAttributesOutput{}, err
+	}
+	if in.HashAllowlistPath != "" {
+		if p, err := h.validatePath(in.HashAllowlistPath); err != nil {
+			return nil, ReadAttributesOutput{}, err
+		} else {
+			in.HashAllowlistPath = p
+		}
+	}
+	if in.HashDenylistPath != "" {
+		if p, err := h.validatePath(in.HashDenylistPath); err != nil {
+			return nil, ReadAttributesOutput{}, err
+		} else {
+			in.HashDenylistPath = p
+		}
+	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, ReadAttributesOutput{}, fmt.Errorf("resolve path: %w", err)

--- a/internal/mcpserver/read_file_in_archive_tool.go
+++ b/internal/mcpserver/read_file_in_archive_tool.go
@@ -53,6 +53,9 @@ func (h *handlers) readFileInArchiveHandler(ctx context.Context, _ *mcp.CallTool
 	if in.EntryPath == "" {
 		return nil, ReadFileInArchiveOutput{}, errors.New("entry_path is required")
 	}
+	if archivePath, err = h.validatePath(archivePath); err != nil {
+		return nil, ReadFileInArchiveOutput{}, err
+	}
 
 	var cancel context.CancelFunc
 	ctx, cancel = h.resolveTimeout(ctx, in.Timeout)

--- a/internal/mcpserver/read_lines_tool.go
+++ b/internal/mcpserver/read_lines_tool.go
@@ -40,6 +40,9 @@ func (h *handlers) readLinesHandler(ctx context.Context, _ *mcp.CallToolRequest,
 	if err != nil {
 		return nil, ReadLinesOutput{}, fmt.Errorf("expand path: %w", err)
 	}
+	if path, err = h.validatePath(path); err != nil {
+		return nil, ReadLinesOutput{}, err
+	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, ReadLinesOutput{}, fmt.Errorf("resolve path: %w", err)

--- a/internal/mcpserver/resolve_project_tool.go
+++ b/internal/mcpserver/resolve_project_tool.go
@@ -37,6 +37,9 @@ func (h *handlers) resolveProjectForPathHandler(ctx context.Context, _ *mcp.Call
 	if err != nil {
 		return nil, ResolveProjectForPathOutput{}, fmt.Errorf("expand path: %w", err)
 	}
+	if path, err = h.validatePath(path); err != nil {
+		return nil, ResolveProjectForPathOutput{}, err
+	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, ResolveProjectForPathOutput{}, fmt.Errorf("resolve path: %w", err)

--- a/internal/mcpserver/sandbox.go
+++ b/internal/mcpserver/sandbox.go
@@ -1,0 +1,172 @@
+package mcpserver
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// errSandboxFollowSymlinksUnsupported is returned when a walk tool is
+// called with follow_symlinks=true while the sandbox is active. The
+// walker doesn't yet enforce the sandbox per-entry, so following
+// symlinks could escape — defence-in-depth: reject up-front rather
+// than ship a leak. Plumbing the sandbox into search.Options is the
+// long-term fix; see the v1 plan's "out of scope".
+var errSandboxFollowSymlinksUnsupported = errors.New("sandbox active: follow_symlinks=true is unsupported in this release (the walker does not yet enforce the sandbox per-entry)")
+
+// WithSandbox configures the server to reject every path-accepting tool
+// input that resolves outside the given roots. Empty / nil = unrestricted
+// (today's behaviour). Roots are canonicalised at construction time:
+// each is filepath.Abs + filepath.Clean. Roots that fail Abs are
+// silently dropped — operators get the stderr startup line to verify
+// what landed.
+//
+// Operators pass roots from --sandbox / --sandbox-dir on the mcp
+// subcommand; agents see a clear MCP tool error (IsError=true) when
+// they try to access a path outside the canonical roots.
+func WithSandbox(roots []string) Option {
+	return func(h *handlers) {
+		if len(roots) == 0 {
+			return
+		}
+		canonical := make([]string, 0, len(roots))
+		for _, r := range roots {
+			if r == "" {
+				continue
+			}
+			abs, err := filepath.Abs(r)
+			if err != nil {
+				continue
+			}
+			abs = filepath.Clean(abs)
+			// EvalSymlinks the root so canonical comparison is
+			// symmetric: validatePath EvalSymlinks the input, so
+			// roots that traverse a symlink (e.g. /tmp → /private/tmp
+			// on macOS) must be resolved the same way. Non-existent
+			// roots fall back to the lexical form — operators can
+			// pre-configure paths that get populated later.
+			if r2, err := filepath.EvalSymlinks(abs); err == nil {
+				abs = filepath.Clean(r2)
+			}
+			canonical = append(canonical, abs)
+		}
+		h.sandbox = canonical
+	}
+}
+
+// validatePath returns p (after the caller's expandHomeDir step) if it
+// resolves under any configured sandbox root, or an error otherwise.
+// Empty sandbox = pass-through (sandbox is opt-in).
+//
+// Validation order:
+//  1. filepath.Abs canonicalises relative paths against the server's cwd.
+//  2. filepath.EvalSymlinks, when the target exists, resolves symlinks
+//     so a "ln -s /etc/passwd <root>/sneaky" inside the sandbox is
+//     caught. Non-existent paths fall back to the lexical Abs+Clean —
+//     the actual filesystem op will produce its own clear error.
+//  3. Separator-aware prefix check against every canonical root.
+//     "/home/foo" doesn't match a root of "/home/foo-bar" (and vice
+//     versa) thanks to the trailing-separator-or-exact comparison.
+//
+// On success returns the lexical absolute path (not the EvalSymlinks
+// resolution), so callers that pass the result straight into the
+// walker / file open see the same path the agent supplied — keeps
+// downstream output stable for symlink-aware callers.
+func (h *handlers) validatePath(p string) (string, error) {
+	if len(h.sandbox) == 0 {
+		return p, nil
+	}
+	if p == "" {
+		// Empty inputs typically mean "use the tool's default" (cwd)
+		// — pass through so the handler's existing default logic
+		// (which may then call validatePath again with the resolved
+		// cwd) is the chokepoint.
+		return p, nil
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("sandbox: resolve %q: %w", p, err)
+	}
+	abs = filepath.Clean(abs)
+	resolved := resolveDeepest(abs)
+	for _, root := range h.sandbox {
+		if pathUnder(resolved, root) {
+			return abs, nil
+		}
+	}
+	return "", fmt.Errorf("sandbox: %q is outside the allowed roots %v", p, h.sandbox)
+}
+
+// resolveDeepest walks up p until filepath.EvalSymlinks succeeds, then
+// reattaches the non-existent suffix. This canonicalises symlinked
+// ancestors (e.g. /tmp → /private/tmp on macOS) for paths that don't
+// fully exist yet — important so the sandbox check sees the same
+// canonical form for both existing and not-yet-existing inputs.
+// Returns abs unchanged when no ancestor resolves.
+func resolveDeepest(abs string) string {
+	suffix := ""
+	cur := abs
+	for {
+		if r, err := filepath.EvalSymlinks(cur); err == nil {
+			if suffix == "" {
+				return filepath.Clean(r)
+			}
+			return filepath.Clean(filepath.Join(r, suffix))
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached the root without finding a resolvable ancestor.
+			return abs
+		}
+		base := filepath.Base(cur)
+		if suffix == "" {
+			suffix = base
+		} else {
+			suffix = filepath.Join(base, suffix)
+		}
+		cur = parent
+	}
+}
+
+// validatePaths is the slice variant for tools that take `dirs` /
+// `tree_a` + `tree_b` style multiple roots. Returns an error on the
+// first violation so the agent sees a deterministic failure mode (not
+// partial-success with a silently-dropped entry).
+func (h *handlers) validatePaths(ps []string) ([]string, error) {
+	if len(h.sandbox) == 0 || len(ps) == 0 {
+		return ps, nil
+	}
+	out := make([]string, 0, len(ps))
+	for _, p := range ps {
+		v, err := h.validatePath(p)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// checkFollowSymlinks rejects a tool call when follow_symlinks=true and
+// the sandbox is active. See errSandboxFollowSymlinksUnsupported.
+// Returns nil when either the sandbox is off, or follow_symlinks is
+// false — the common cases.
+func (h *handlers) checkFollowSymlinks(follow bool) error {
+	if len(h.sandbox) > 0 && follow {
+		return errSandboxFollowSymlinksUnsupported
+	}
+	return nil
+}
+
+// pathUnder is a separator-aware "is p inside root?" prefix check.
+// Returns true when p == root (the root itself is a valid input) or
+// when p starts with root + the path separator (so "/home/foo-bar"
+// doesn't sneak through when root is "/home/foo"). Both inputs are
+// expected to be canonical (filepath.Clean + Abs) before being passed.
+func pathUnder(p, root string) bool {
+	if p == root {
+		return true
+	}
+	return strings.HasPrefix(p, root+string(filepath.Separator))
+}

--- a/internal/mcpserver/sandbox_integration_test.go
+++ b/internal/mcpserver/sandbox_integration_test.go
@@ -1,0 +1,215 @@
+package mcpserver
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+)
+
+// newSandboxedSession is the newSession variant that wraps the server
+// with WithSandbox(roots). Used by sandbox integration tests so they
+// exercise the same wiring real callers go through.
+func newSandboxedSession(t *testing.T, roots ...string) (context.Context, *mcp.ClientSession) {
+	t.Helper()
+	ctx := t.Context()
+
+	server := New("test", index.NewMemory(), 0, EmbedDefaults{}, WithSandbox(roots))
+	t1, t2 := mcp.NewInMemoryTransports()
+
+	ss, err := server.Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	return ctx, cs
+}
+
+// TestSearchTool_SandboxRejectsOutside is the load-bearing assertion:
+// when the server is wrapped with WithSandbox, an agent asking to walk
+// /etc gets a tool error with a "sandbox" message, not a search result.
+func TestSearchTool_SandboxRejectsOutside(t *testing.T) {
+	sandbox := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sandbox, "a.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	ctx, cs := newSandboxedSession(t, sandbox)
+
+	// /etc is definitely outside any tempdir-based sandbox.
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search",
+		Arguments: SearchInput{Dir: "/etc"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError=true for outside-sandbox dir, got %+v", res)
+	}
+}
+
+func TestSearchTool_SandboxAllowsInside(t *testing.T) {
+	sandbox := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sandbox, "a.md"), []byte("# hello\nbody body body body body\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	ctx, cs := newSandboxedSession(t, sandbox)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search",
+		Arguments: SearchInput{Expr: "is_markdown", Dir: sandbox},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("inside-sandbox dir should be accepted, got IsError; res=%+v", res)
+	}
+}
+
+// TestSearchTool_SandboxRejectsFollowSymlinks asserts the v1 hard
+// rejection: follow_symlinks=true is unsupported when the sandbox is
+// active because the walker doesn't yet enforce sandbox per-entry.
+func TestSearchTool_SandboxRejectsFollowSymlinks(t *testing.T) {
+	sandbox := t.TempDir()
+	ctx, cs := newSandboxedSession(t, sandbox)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "search",
+		Arguments: SearchInput{
+			Dir:            sandbox,
+			FollowSymlinks: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError for follow_symlinks=true under sandbox, got %+v", res)
+	}
+}
+
+// TestReadAttributesTool_SandboxRejectsOutside locks in the single-file
+// tool path — agents can't sneak /etc/passwd in via read_attributes.
+func TestReadAttributesTool_SandboxRejectsOutside(t *testing.T) {
+	sandbox := t.TempDir()
+	ctx, cs := newSandboxedSession(t, sandbox)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "read_attributes",
+		Arguments: ReadAttributesInput{Path: "/etc/hosts"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError for /etc/hosts under sandbox, got %+v", res)
+	}
+}
+
+// TestReadLinesTool_SandboxRejectsOutside — same shape for read_lines.
+func TestReadLinesTool_SandboxRejectsOutside(t *testing.T) {
+	sandbox := t.TempDir()
+	ctx, cs := newSandboxedSession(t, sandbox)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "read_lines",
+		Arguments: ReadLinesInput{Path: "/etc/hosts"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError for /etc/hosts under sandbox, got %+v", res)
+	}
+}
+
+// TestDiffTreesTool_SandboxRejectsOutside — the two-tree tool. Catches
+// the case where one tree is fine but the other isn't.
+func TestDiffTreesTool_SandboxRejectsOutside(t *testing.T) {
+	sandbox := t.TempDir()
+	ctx, cs := newSandboxedSession(t, sandbox)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "diff_trees",
+		Arguments: DiffTreesInput{
+			TreeA: sandbox,
+			TreeB: "/tmp",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError when one tree is outside sandbox, got %+v", res)
+	}
+}
+
+// TestSearchTool_SandboxRejectsHashAllowlistPath — the side-channel
+// path: hash_allowlist_path is a path the agent supplies; without
+// sandbox enforcement it could be used to read arbitrary files for
+// hash membership lookup.
+func TestSearchTool_SandboxRejectsHashAllowlistPath(t *testing.T) {
+	sandbox := t.TempDir()
+	ctx, cs := newSandboxedSession(t, sandbox)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "search",
+		Arguments: SearchInput{
+			Dir:               sandbox,
+			HashAllowlistPath: "/etc/hosts",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError when hash_allowlist_path is outside sandbox, got %+v", res)
+	}
+}
+
+// TestSearchTool_NoSandboxAllowsAnywhere — sanity-check the
+// pass-through path: with no WithSandbox option, /etc is accepted (it
+// errors later for unrelated reasons like permission denied, but the
+// sandbox itself doesn't reject).
+func TestSearchTool_NoSandboxAllowsAnywhere(t *testing.T) {
+	// newSession (without WithSandbox) — same as the existing tests.
+	ctx, cs := newSession(t)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "search",
+		Arguments: SearchInput{
+			Dir:  "/tmp", // some path that probably exists
+			Expr: "false",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	// Should not be a sandbox error — either IsError=false (if /tmp is
+	// walkable) or IsError=true for some other reason. The point is
+	// the sandbox never fired.
+	if res.IsError {
+		var out SearchOutput
+		_ = out
+		// We don't make an assertion about the specific error — just
+		// confirm the sandbox isn't responsible. If the test
+		// environment doesn't have /tmp this would fail for a
+		// different reason; skip in that case rather than fail.
+		t.Logf("res.IsError=true for /tmp with no sandbox; this is fine (env-specific)")
+	}
+}

--- a/internal/mcpserver/sandbox_test.go
+++ b/internal/mcpserver/sandbox_test.go
@@ -1,0 +1,286 @@
+package mcpserver
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newSandboxedHandlers makes a *handlers with the given roots applied
+// via WithSandbox, so tests exercise the same path real callers walk.
+func newSandboxedHandlers(t *testing.T, roots ...string) *handlers {
+	t.Helper()
+	h := &handlers{}
+	WithSandbox(roots)(h)
+	return h
+}
+
+func TestValidatePath_NoSandboxPassthrough(t *testing.T) {
+	h := &handlers{} // empty sandbox
+	got, err := h.validatePath("/etc/passwd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "/etc/passwd" {
+		t.Errorf("got %q, want /etc/passwd", got)
+	}
+}
+
+func TestValidatePath_AllowsUnderRoot(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "sub", "file.go")
+	if err := os.MkdirAll(filepath.Dir(child), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(child, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	h := newSandboxedHandlers(t, root)
+	got, err := h.validatePath(child)
+	if err != nil {
+		t.Fatalf("expected accept, got err: %v", err)
+	}
+	if got != filepath.Clean(child) {
+		t.Errorf("got %q, want %q", got, filepath.Clean(child))
+	}
+}
+
+func TestValidatePath_AllowsRootItself(t *testing.T) {
+	root := t.TempDir()
+	h := newSandboxedHandlers(t, root)
+	got, err := h.validatePath(root)
+	if err != nil {
+		t.Errorf("root itself should be allowed, got err: %v", err)
+	}
+	if got == "" {
+		t.Errorf("expected non-empty result, got empty")
+	}
+}
+
+func TestValidatePath_RejectsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	h := newSandboxedHandlers(t, root)
+	_, err := h.validatePath("/etc/passwd")
+	if err == nil {
+		t.Fatal("expected reject, got nil")
+	}
+	if !strings.Contains(err.Error(), "sandbox") {
+		t.Errorf("error should mention sandbox, got %v", err)
+	}
+}
+
+func TestValidatePath_RejectsDotDotEscape(t *testing.T) {
+	root := t.TempDir()
+	// /tmp/xxx/../../../etc/passwd — resolves outside root via lexical Clean.
+	escape := filepath.Join(root, "..", "..", "..", "etc", "passwd")
+	h := newSandboxedHandlers(t, root)
+	_, err := h.validatePath(escape)
+	if err == nil {
+		t.Fatalf("expected reject for dot-dot escape %q, got nil", escape)
+	}
+}
+
+func TestValidatePath_RejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	// Create a symlink inside the sandbox pointing OUTSIDE it (to /etc).
+	linkPath := filepath.Join(root, "sneaky")
+	if err := os.Symlink("/etc", linkPath); err != nil {
+		t.Skipf("cannot create symlink (filesystem may not support): %v", err)
+	}
+
+	h := newSandboxedHandlers(t, root)
+	_, err := h.validatePath(linkPath)
+	if err == nil {
+		t.Fatal("expected reject for symlink pointing outside root, got nil")
+	}
+}
+
+func TestValidatePath_AllowsSymlinkInsideRoot(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target.txt")
+	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	h := newSandboxedHandlers(t, root)
+	if _, err := h.validatePath(link); err != nil {
+		t.Errorf("symlink inside root should be allowed, got err: %v", err)
+	}
+}
+
+func TestValidatePath_PrefixCollision(t *testing.T) {
+	// Two TempDirs that happen to share a prefix would be ideal but
+	// t.TempDir uses unique names. Build the collision manually under
+	// a parent TempDir.
+	parent := t.TempDir()
+	root := filepath.Join(parent, "foo")
+	collider := filepath.Join(parent, "foo-bar", "file.go")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(collider), 0o755); err != nil {
+		t.Fatalf("mkdir collider parent: %v", err)
+	}
+
+	h := newSandboxedHandlers(t, root)
+	_, err := h.validatePath(collider)
+	if err == nil {
+		t.Fatalf("expected reject for prefix-collision path %q under root %q", collider, root)
+	}
+}
+
+func TestValidatePath_MultiRoot(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	h := newSandboxedHandlers(t, rootA, rootB)
+
+	// Both roots accept their own children.
+	if _, err := h.validatePath(filepath.Join(rootA, "x")); err != nil {
+		t.Errorf("rootA child should be allowed: %v", err)
+	}
+	if _, err := h.validatePath(filepath.Join(rootB, "y")); err != nil {
+		t.Errorf("rootB child should be allowed: %v", err)
+	}
+	// A third unrelated path is rejected.
+	if _, err := h.validatePath("/etc/passwd"); err == nil {
+		t.Errorf("expected reject for unrelated path")
+	}
+}
+
+func TestValidatePath_NonExistentPathStillEvaluated(t *testing.T) {
+	root := t.TempDir()
+	h := newSandboxedHandlers(t, root)
+	// Path doesn't exist but is lexically under root → allowed.
+	// EvalSymlinks errors silently; lexical Abs+Clean is enough.
+	if _, err := h.validatePath(filepath.Join(root, "does", "not", "exist.txt")); err != nil {
+		t.Errorf("non-existent under-root path should still be accepted (walker errors later): %v", err)
+	}
+	// Lexically outside → rejected even if it doesn't exist.
+	if _, err := h.validatePath("/tmp/this/does/not/exist.txt"); err == nil {
+		t.Errorf("non-existent outside-root path should be rejected at validate time")
+	}
+}
+
+func TestValidatePath_EmptyInputPassthrough(t *testing.T) {
+	root := t.TempDir()
+	h := newSandboxedHandlers(t, root)
+	got, err := h.validatePath("")
+	if err != nil {
+		t.Errorf("empty input should pass through (handler default applies), got err: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestValidatePath_TrailingSlashRoot(t *testing.T) {
+	tmp := t.TempDir()
+	rootWithSlash := tmp + string(filepath.Separator)
+	h := newSandboxedHandlers(t, rootWithSlash)
+
+	// WithSandbox calls filepath.Clean on the input; the canonical root
+	// should be the no-slash form, and a child under it must be allowed.
+	if _, err := h.validatePath(filepath.Join(tmp, "child")); err != nil {
+		t.Errorf("child should be allowed despite trailing slash on root: %v", err)
+	}
+}
+
+func TestValidatePaths_FirstViolationFails(t *testing.T) {
+	root := t.TempDir()
+	h := newSandboxedHandlers(t, root)
+	_, err := h.validatePaths([]string{filepath.Join(root, "a"), "/etc/passwd"})
+	if err == nil {
+		t.Fatal("expected error on second path, got nil")
+	}
+}
+
+func TestValidatePaths_AllowAll(t *testing.T) {
+	root := t.TempDir()
+	h := newSandboxedHandlers(t, root)
+	got, err := h.validatePaths([]string{
+		filepath.Join(root, "a"),
+		filepath.Join(root, "b"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2", len(got))
+	}
+}
+
+func TestValidatePaths_Passthrough(t *testing.T) {
+	// Empty sandbox → input returned unchanged (even paths that would
+	// be rejected if sandbox were active).
+	h := &handlers{}
+	got, err := h.validatePaths([]string{"/etc/passwd", "/var/log"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2", len(got))
+	}
+}
+
+func TestCheckFollowSymlinks_PassthroughWhenSandboxOff(t *testing.T) {
+	h := &handlers{}
+	if err := h.checkFollowSymlinks(true); err != nil {
+		t.Errorf("follow_symlinks should be allowed when sandbox is off: %v", err)
+	}
+}
+
+func TestCheckFollowSymlinks_AllowsFalseUnderSandbox(t *testing.T) {
+	h := newSandboxedHandlers(t, t.TempDir())
+	if err := h.checkFollowSymlinks(false); err != nil {
+		t.Errorf("follow_symlinks=false should be allowed under sandbox: %v", err)
+	}
+}
+
+func TestCheckFollowSymlinks_RejectsTrueUnderSandbox(t *testing.T) {
+	h := newSandboxedHandlers(t, t.TempDir())
+	err := h.checkFollowSymlinks(true)
+	if !errors.Is(err, errSandboxFollowSymlinksUnsupported) {
+		t.Errorf("expected errSandboxFollowSymlinksUnsupported, got %v", err)
+	}
+}
+
+func TestWithSandbox_DropsEmptyAndBadAbs(t *testing.T) {
+	h := &handlers{}
+	WithSandbox([]string{"", "/tmp/valid"})(h)
+	if len(h.sandbox) != 1 {
+		t.Fatalf("len = %d, want 1 (empty string dropped)", len(h.sandbox))
+	}
+	if h.sandbox[0] != "/tmp/valid" {
+		t.Errorf("got %q, want /tmp/valid", h.sandbox[0])
+	}
+}
+
+func TestWithSandbox_NilLeavesSandboxEmpty(t *testing.T) {
+	h := &handlers{}
+	WithSandbox(nil)(h)
+	if len(h.sandbox) != 0 {
+		t.Errorf("nil roots should leave sandbox empty, got %v", h.sandbox)
+	}
+}
+
+func TestPathUnder_ExactMatch(t *testing.T) {
+	if !pathUnder("/a/b", "/a/b") {
+		t.Errorf("exact match should be 'under'")
+	}
+}
+
+func TestPathUnder_SeparatorAware(t *testing.T) {
+	if pathUnder("/a/foo-bar", "/a/foo") {
+		t.Errorf("/a/foo-bar should NOT be under /a/foo (prefix collision)")
+	}
+	if !pathUnder("/a/foo/x", "/a/foo") {
+		t.Errorf("/a/foo/x should be under /a/foo")
+	}
+}

--- a/internal/mcpserver/search_semantic_tool.go
+++ b/internal/mcpserver/search_semantic_tool.go
@@ -91,6 +91,15 @@ func (h *handlers) searchSemanticHandler(ctx context.Context, req *mcp.CallToolR
 	if dir == "" {
 		dir = "."
 	}
+	if err := h.checkFollowSymlinks(in.FollowSymlinks); err != nil {
+		return nil, SearchSemanticOutput{}, err
+	}
+	if dir, err = h.validatePath(dir); err != nil {
+		return nil, SearchSemanticOutput{}, err
+	}
+	if dirs, err = h.validatePaths(dirs); err != nil {
+		return nil, SearchSemanticOutput{}, err
+	}
 
 	parentCtx := ctx
 	var cancel context.CancelFunc

--- a/internal/mcpserver/search_tool.go
+++ b/internal/mcpserver/search_tool.go
@@ -100,6 +100,29 @@ func (h *handlers) searchHandler(ctx context.Context, req *mcp.CallToolRequest, 
 	if dir == "" {
 		dir = "."
 	}
+	if err := h.checkFollowSymlinks(in.FollowSymlinks); err != nil {
+		return nil, SearchOutput{}, err
+	}
+	if dir, err = h.validatePath(dir); err != nil {
+		return nil, SearchOutput{}, err
+	}
+	if dirs, err = h.validatePaths(dirs); err != nil {
+		return nil, SearchOutput{}, err
+	}
+	if in.HashAllowlistPath != "" {
+		if p, err := h.validatePath(in.HashAllowlistPath); err != nil {
+			return nil, SearchOutput{}, err
+		} else {
+			in.HashAllowlistPath = p
+		}
+	}
+	if in.HashDenylistPath != "" {
+		if p, err := h.validatePath(in.HashDenylistPath); err != nil {
+			return nil, SearchOutput{}, err
+		} else {
+			in.HashDenylistPath = p
+		}
+	}
 
 	// parentCtx is captured before the timeout wrap so we can later
 	// distinguish a server-level cancellation (transport close, parent

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -35,6 +35,10 @@ type handlers struct {
 	// (optionally) start it on demand. nil when monitoring isn't wired
 	// (e.g. tests, or transports that never attach it).
 	monitorCtl *monitor.Controller
+	// sandbox, when non-empty, is the canonical absolute-path list of
+	// allowed roots for every path-accepting tool input. Empty means
+	// unrestricted (today's behaviour). Wired via WithSandbox.
+	sandbox []string
 }
 
 // Option configures the MCP server at construction. Used to attach

--- a/internal/mcpserver/stats_tool.go
+++ b/internal/mcpserver/stats_tool.go
@@ -77,6 +77,15 @@ func (h *handlers) statsHandler(ctx context.Context, _ *mcp.CallToolRequest, in 
 	if dir == "" {
 		dir = "."
 	}
+	if err := h.checkFollowSymlinks(in.FollowSymlinks); err != nil {
+		return nil, StatsOutput{}, err
+	}
+	if dir, err = h.validatePath(dir); err != nil {
+		return nil, StatsOutput{}, err
+	}
+	if dirs, err = h.validatePaths(dirs); err != nil {
+		return nil, StatsOutput{}, err
+	}
 
 	// parentCtx separation isn't needed because ComputeStats itself
 	// surfaces cancelled=true via the Stats struct rather than via the

--- a/internal/mcpserver/watch_tool.go
+++ b/internal/mcpserver/watch_tool.go
@@ -69,6 +69,12 @@ func (h *handlers) watchSearchHandler(ctx context.Context, _ *mcp.CallToolReques
 	if dir == "" && len(dirs) == 0 {
 		dir = "."
 	}
+	if dir, err = h.validatePath(dir); err != nil {
+		return nil, WatchSearchOutput{}, err
+	}
+	if dirs, err = h.validatePaths(dirs); err != nil {
+		return nil, WatchSearchOutput{}, err
+	}
 	// search.Watch registers opts.Roots only (not opts.Root), so fold
 	// the single-dir case into the slice.
 	roots := dirs


### PR DESCRIPTION
## Summary

Today the 20 MCP tools accept paths verbatim — an agent driving \`file-search-on mcp\` can \`read_lines /etc/passwd\`, \`diff_trees / /tmp\`, or walk anything the server's process can read. For an MCP server running inside Claude / Cursor / VS Code that's an unbounded blast radius.

Adds an opt-in **sandbox** policy on the \`mcp\` subcommand:

\`\`\`sh
file-search-on mcp --sandbox                         # restrict to cwd at startup
file-search-on mcp --sandbox-dir ~/Code/my-project   # explicit root
file-search-on mcp --sandbox-dir ~/a --sandbox-dir ~/b  # multi-root
\`\`\`

When active, every path-accepting tool input is validated **before any filesystem operation**. Paths resolving outside any sandbox root get a clear MCP \`IsError=true\` tool result:

\`\`\`
sandbox: "/etc/passwd" is outside the allowed roots [/Users/foo/Code/my-project]
\`\`\`

Off by default in v0.69.0 for back-compat; help text flags the longer-term default-on direction.

## What's sandboxed

- Walk inputs: \`dir\`, \`dirs\`, \`tree_a\`, \`tree_b\` on every walking tool (search, stats, find_matches, find_duplicates, find_near_duplicates, search_semantic, watch_search, find_projects, diff_trees)
- Single-file paths: \`path\` on read_attributes, read_lines, list_archive_contents, read_file_in_archive, resolve_project_for_path, detect_project
- **Side-channel inputs**: \`hash_allowlist_path\` / \`hash_denylist_path\` on search + read_attributes (otherwise an agent could read arbitrary files for hash-membership lookup)
- \`follow_symlinks=true\` is rejected outright when sandbox is active (the walker doesn't yet enforce sandbox per-entry; that's the v2 defence-in-depth follow-up)

## What's exempt

Operator-controlled at startup, not agent-driven:
- \`--index-path\` (file-search-on STORES its bbolt cache here)
- \`--embedding-server\` (HTTP URL, not filesystem)
- \`--monitor-addr\` (TCP bind)
- \`--warm-dir\` (operator's walk root)

## Implementation

- New \`internal/mcpserver/sandbox.go\` — \`validatePath\` + \`validatePaths\` methods on \`*handlers\`; \`WithSandbox(roots []string) Option\`
- Validation uses \`filepath.Abs\` + a smart \`EvalSymlinks\` that walks up to the deepest existing ancestor (so non-existent paths under the sandbox are still accepted — the actual filesystem op produces the error). Root comparison is separator-aware, so \`/home/foo-bar\` doesn't sneak past a \`/home/foo\` root.
- One \`h.validatePath(...)\` call per path field, before existing \`filepath.Abs\` — wired across 14 tool files in a uniform pattern.
- New flags on \`MCPCmd\` (\`Sandbox bool\`, \`SandboxDir []string\`) resolve to canonical roots in \`Run\` and feed \`WithSandbox\`.

## Test plan

- [x] \`go test -race -short ./...\` — all packages green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` — idempotent
- [x] 22 unit tests in \`sandbox_test.go\` covering: pass-through, allows-under-root, rejects-outside, dot-dot-escape, symlink-escape, symlink-inside-root, prefix-collision, multi-root, non-existent paths, empty input, trailing-slash root, slice variant, follow_symlinks rejection, WithSandbox edge cases, pathUnder separator-awareness
- [x] 8 integration tests in \`sandbox_integration_test.go\`:
  - \`search\` rejects \`/etc\`, allows inside dir
  - \`search\` rejects \`follow_symlinks=true\`
  - \`read_attributes\` / \`read_lines\` / \`diff_trees\` reject outside paths
  - \`search\` rejects \`hash_allowlist_path=/etc/hosts\`
  - No-sandbox path is pass-through
- [x] E2E: \`mcp --sandbox --sandbox-dir <tempdir>\` emits the expected stderr policy line at startup

## Out of scope (deferred)

- **Sandbox enforcement during walk.** Validator catches symlinks at input time but doesn't prevent the walker from following a symlink encountered mid-walk that leads outside. v1 dodges by rejecting \`follow_symlinks=true\`. Long-term: plumb \`sandbox\` into \`search.Options\` and check per-entry.
- **CLI sandboxing.** User-driven shell access is already trusted; sandbox is about agent restriction.
- **\`--no-sandbox\` opt-out / default-on.** Off in v0.69.0 for back-compat; flip in a future release.
- **Sandbox visualisation on the monitor dashboard.** Worth adding later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)