### PR TITLE
fix(content): obey ctx cancellation inside per-file scanner loops

### DIFF
--- a/internal/content/body_epub.go
+++ b/internal/content/body_epub.go
@@ -24,7 +24,7 @@ func epubBody(ctx context.Context, fsys fs.FS, filePath string, maxBytes int) (s
 		return "", nil
 	}
 
-	opfPath, err := readOPFPath(zr)
+	opfPath, err := readOPFPath(ctx, zr)
 	if err != nil || opfPath == "" {
 		return "", nil
 	}

--- a/internal/content/browser_bookmarks_chromium.go
+++ b/internal/content/browser_bookmarks_chromium.go
@@ -86,7 +86,7 @@ func (*chromiumBookmarksType) Attributes(ctx context.Context, fsys fs.FS, path s
 	if err != nil {
 		return Attributes{}, nil
 	}
-	return parseChromiumBookmarks(buf, path), nil
+	return parseChromiumBookmarks(ctx, buf, path)
 }
 
 // parseChromiumBookmarks decodes the JSON, walks the `roots.*` trees,
@@ -94,32 +94,42 @@ func (*chromiumBookmarksType) Attributes(ctx context.Context, fsys fs.FS, path s
 // exercises it directly. Returns an empty Attributes map (not nil) on
 // any decoding failure or missing `roots.bookmark_bar` marker so the
 // walker contract holds: a malformed file doesn't fail the walk.
-func parseChromiumBookmarks(data []byte, path string) Attributes {
+//
+// Takes ctx so a cancelled walk doesn't keep iterating the bookmark
+// tree (bookmarkMaxNodes caps the worst case but cancellation should
+// short-circuit immediately).
+func parseChromiumBookmarks(ctx context.Context, data []byte, path string) (Attributes, error) {
 	var root chromiumBookmarksRoot
 	if err := json.Unmarshal(data, &root); err != nil {
-		return Attributes{}
+		return Attributes{}, nil
 	}
 	if len(root.Roots) == 0 {
-		return Attributes{}
+		return Attributes{}, nil
 	}
 	// Discriminator: real Chromium files always carry `bookmark_bar`.
 	if _, ok := root.Roots["bookmark_bar"]; !ok {
-		return Attributes{}
+		return Attributes{}, nil
 	}
 
 	collected := bookmarkCollection{}
 	for _, treeRoot := range root.Roots {
-		walkChromiumNode(&treeRoot, 0, &collected)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		walkChromiumNode(ctx, &treeRoot, 0, &collected)
 		if collected.NodeCount >= bookmarkMaxNodes {
 			break
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	out := collected.toAttributes()
 	if profile := chromiumProfileFromPath(path); profile != "" {
 		out["bookmark_profile"] = profile
 	}
-	return out
+	return out, nil
 }
 
 // chromiumBookmarksRoot is the top-level JSON shape. Decoded keys we
@@ -140,8 +150,15 @@ type chromiumNode struct {
 // walkChromiumNode is the bounded recursive walker. Collects URLs,
 // titles, and folder names; honours depth + total-node caps to defend
 // against adversarial nesting / flat-tree fuzz input.
-func walkChromiumNode(n *chromiumNode, depth int, c *bookmarkCollection) {
+//
+// Takes ctx so cancellation short-circuits mid-walk: each recursion
+// level checks ctx.Err() and returns silently on cancel (the caller's
+// post-walk ctx.Err() check surfaces the error).
+func walkChromiumNode(ctx context.Context, n *chromiumNode, depth int, c *bookmarkCollection) {
 	if depth > bookmarkMaxDepth || c.NodeCount >= bookmarkMaxNodes {
+		return
+	}
+	if ctx.Err() != nil {
 		return
 	}
 	c.NodeCount++
@@ -152,7 +169,7 @@ func walkChromiumNode(n *chromiumNode, depth int, c *bookmarkCollection) {
 	case "folder":
 		c.addFolder(n.Name)
 		for i := range n.Children {
-			walkChromiumNode(&n.Children[i], depth+1, c)
+			walkChromiumNode(ctx, &n.Children[i], depth+1, c)
 			if c.NodeCount >= bookmarkMaxNodes {
 				return
 			}
@@ -179,7 +196,10 @@ func chromiumBookmarksBody(ctx context.Context, fsys fs.FS, path string, maxByte
 	if err != nil {
 		return "", nil
 	}
-	attrs := parseChromiumBookmarks(buf, path)
+	attrs, err := parseChromiumBookmarks(ctx, buf, path)
+	if err != nil {
+		return "", err
+	}
 	return bookmarkBody(attrs, maxBytes), nil
 }
 

--- a/internal/content/browser_bookmarks_fuzz_test.go
+++ b/internal/content/browser_bookmarks_fuzz_test.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -63,7 +64,7 @@ func FuzzParseChromiumBookmarks(f *testing.F) {
 		if len(data) > fuzzBookmarkInputCap {
 			return
 		}
-		attrs := parseChromiumBookmarks(data, path)
+		attrs, _ := parseChromiumBookmarks(context.Background(), data, path)
 		// Contract checks.
 		if urls, ok := attrs["bookmark_urls"].([]string); ok && len(urls) > bookmarkMaxURLs {
 			t.Fatalf("bookmark_urls exceeds cap: %d > %d", len(urls), bookmarkMaxURLs)

--- a/internal/content/browser_bookmarks_test.go
+++ b/internal/content/browser_bookmarks_test.go
@@ -82,7 +82,10 @@ func TestChromiumBookmarks_Detection(t *testing.T) {
 
 func TestChromiumBookmarks_Attributes(t *testing.T) {
 	data := buildChromiumBookmarksFixture(t)
-	attrs := parseChromiumBookmarks(data, "Default/Bookmarks")
+	attrs, err := parseChromiumBookmarks(context.Background(), data, "Default/Bookmarks")
+	if err != nil {
+		t.Fatalf("parseChromiumBookmarks: %v", err)
+	}
 
 	if got := attrs["bookmark_count"]; got != int64(3) {
 		t.Errorf("bookmark_count = %v, want 3", got)
@@ -123,14 +126,14 @@ func TestChromiumBookmarks_RejectsNonBookmarkJSON(t *testing.T) {
 	// A JSON file named `Bookmarks` but without the roots.bookmark_bar
 	// shape — common defensive case (user creates a random file).
 	junk := []byte(`{"some": "other", "json": "shape"}`)
-	attrs := parseChromiumBookmarks(junk, "Default/Bookmarks")
+	attrs, _ := parseChromiumBookmarks(context.Background(), junk, "Default/Bookmarks")
 	if len(attrs) != 0 {
 		t.Errorf("expected empty attrs for non-bookmarks JSON, got %v", attrs)
 	}
 }
 
 func TestChromiumBookmarks_MalformedJSON(t *testing.T) {
-	attrs := parseChromiumBookmarks([]byte("not json at all"), "Default/Bookmarks")
+	attrs, _ := parseChromiumBookmarks(context.Background(), []byte("not json at all"), "Default/Bookmarks")
 	if len(attrs) != 0 {
 		t.Errorf("expected empty attrs for malformed JSON, got %v", attrs)
 	}
@@ -166,7 +169,7 @@ func TestChromiumBookmarks_DepthCap(t *testing.T) {
 		},
 	}
 	data, _ := json.Marshal(doc)
-	attrs := parseChromiumBookmarks(data, "x/Bookmarks")
+	attrs, _ := parseChromiumBookmarks(context.Background(), data, "x/Bookmarks")
 	urls, _ := attrs["bookmark_urls"].([]string)
 	// The bottom URL is past bookmarkMaxDepth (64) so shouldn't appear.
 	for _, u := range urls {

--- a/internal/content/csv.go
+++ b/internal/content/csv.go
@@ -39,6 +39,9 @@ func (c *csvType) Attributes(ctx context.Context, fsys fs.FS, p string) (Attribu
 
 	var firstLine string
 	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if line := scanner.Text(); line != "" {
 			firstLine = line
 			break

--- a/internal/content/ctx_cancellation_test.go
+++ b/internal/content/ctx_cancellation_test.go
@@ -1,0 +1,59 @@
+package content_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+)
+
+// TestAttributes_HonoursCancelledContext is a regression test for the
+// ctx-cancellation audit. It feeds each in-scope ContentType a
+// pathologically-large input (~32k lines / tokens) that would take
+// measurable wall-clock to fully parse, then calls Attributes with an
+// already-cancelled ctx, and asserts the call returns an error
+// without hanging.
+//
+// "Without hanging" is enforced by the global test timeout in CI
+// (3 minutes — far longer than any honest parse needed below). A
+// regression that drops the ctx.Err() check inside a Scanner loop
+// would manifest as this test hitting the timeout instead of
+// returning fast.
+func TestAttributes_HonoursCancelledContext(t *testing.T) {
+	// Build a 32k-line pathological body. For most line-scanner types
+	// this is enough wall-clock to make an unguarded loop visibly slow
+	// even under -race; for the tighter parsers (Dublin Core / Chromium)
+	// the cancelled-at-entry guards win immediately.
+	long := strings.Repeat("a,b,c,d,e,f,g\n", 32*1024)
+	goSrc := strings.Repeat("// comment\npackage main\n", 16*1024)
+	cssvSrc := strings.Repeat("a,b,c\n", 32*1024)
+
+	cases := []struct {
+		name string
+		path string
+		body string
+	}{
+		{name: "csv", path: "a.csv", body: cssvSrc},
+		{name: "text", path: "a.txt", body: long},
+		{name: "source/go", path: "a.go", body: goSrc},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // pre-cancel — every iteration should observe Err()
+
+			fsys := fstest.MapFS{c.path: {Data: []byte(c.body)}}
+			ct := content.DefaultRegistry().Detect(fsys, c.path)
+			if ct == nil {
+				t.Fatalf("Detect returned nil for %q", c.path)
+			}
+			_, err := ct.Attributes(ctx, fsys, c.path)
+			if err == nil {
+				t.Errorf("Attributes did not surface ctx cancellation (expected ctx.Err)")
+			}
+		})
+	}
+}

--- a/internal/content/epub.go
+++ b/internal/content/epub.go
@@ -32,7 +32,7 @@ func (e *epubType) Attributes(ctx context.Context, fsys fs.FS, filePath string) 
 		return nil, err
 	}
 
-	opfPath, err := readOPFPath(zr)
+	opfPath, err := readOPFPath(ctx, zr)
 	if err != nil || opfPath == "" {
 		return Attributes{}, nil
 	}
@@ -52,7 +52,11 @@ func (e *epubType) Attributes(ctx context.Context, fsys fs.FS, filePath string) 
 }
 
 // readOPFPath parses META-INF/container.xml and returns the path to the OPF rootfile.
-func readOPFPath(zr *zip.Reader) (string, error) {
+//
+// ctx is checked between tokens so a maliciously-crafted container.xml
+// (deeply-nested elements, billion-laughs-shaped expansion) can be
+// abandoned mid-parse if the walk was cancelled.
+func readOPFPath(ctx context.Context, zr *zip.Reader) (string, error) {
 	f, err := openZipEntry(zr, "META-INF/container.xml")
 	if err != nil {
 		return "", err
@@ -61,6 +65,9 @@ func readOPFPath(zr *zip.Reader) (string, error) {
 
 	dec := xml.NewDecoder(f)
 	for {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		tok, err := dec.Token()
 		if err == io.EOF {
 			break

--- a/internal/content/science_pds.go
+++ b/internal/content/science_pds.go
@@ -74,7 +74,7 @@ func (p *pdsType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attr
 	}
 	switch p.name {
 	case "science/pds3":
-		return parsePDS3Label(buf), nil
+		return parsePDS3Label(ctx, buf)
 	case "science/pds4":
 		return parsePDS4Label(buf), nil
 	}
@@ -123,7 +123,11 @@ func stripPVLQuotes(s string) string {
 // nested groups are out of scope for v1 — most metadata we care
 // about lives at the top level. Unknown / unsupported lines pass
 // through silently.
-func parsePDS3Label(data []byte) Attributes {
+//
+// Takes ctx so cancellation during the per-line scan exits early
+// (the scan is bounded by pdsReadCap = 1 MiB but still iterates
+// many lines on a fully-populated label).
+func parsePDS3Label(ctx context.Context, data []byte) (Attributes, error) {
 	cleaned := stripPVLComments(data)
 
 	out := Attributes{}
@@ -140,6 +144,9 @@ func parsePDS3Label(data []byte) Attributes {
 	scanner := bufio.NewScanner(bytes.NewReader(cleaned))
 	scanner.Buffer(make([]byte, 64*1024), 1*1024*1024)
 	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		line := scanner.Text()
 		before, after, ok := strings.Cut(line, "=")
 		if !ok {
@@ -174,14 +181,14 @@ func parsePDS3Label(data []byte) Attributes {
 	// Nothing parsed → empty attrs (acceptable: file was magic-
 	// detected but the body was unparseable).
 	if pdsVersion == "" && missionName == "" && targetName == "" && productID == "" {
-		return Attributes{}
+		return Attributes{}, nil
 	}
 
 	if pdsVersion != "" {
 		out["pds_version"] = pdsVersion
 	}
 	assignPDSCommon(out, missionName, spacecraftName, instrumentName, targetName, productID, startTime)
-	return scienceAttrs("pds3", out)
+	return scienceAttrs("pds3", out), nil
 }
 
 // pds4Product captures the slice of PDS4 schema we care about.

--- a/internal/content/science_pds_fuzz_test.go
+++ b/internal/content/science_pds_fuzz_test.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"context"
 	"testing"
 )
 
@@ -36,7 +37,7 @@ func FuzzParsePDS3Label(f *testing.F) {
 	f.Add(bad)
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		_ = parsePDS3Label(data) // must not panic
+		_, _ = parsePDS3Label(context.Background(), data) // must not panic
 	})
 }
 

--- a/internal/content/sourcetype.go
+++ b/internal/content/sourcetype.go
@@ -64,6 +64,13 @@ func (s *sourceType) Attributes(ctx context.Context, fsys fs.FS, p string) (Attr
 	var total, loc, blank, comment int64
 	inBlock := false
 	for scanner.Scan() {
+		// Per-iteration cancellation guard — a pathological source
+		// file (huge generated code, multi-MB single-line minified
+		// blob) shouldn't stall the walker after the walk was
+		// already cancelled. Mirrors the canonical text.go pattern.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		total++
 		rawLine := scanner.Bytes()
 		if bodyBuf != nil && bodyBuf.Len() < symbolCaptureCap {


### PR DESCRIPTION
## Summary

Audit of `internal/content/*.go` against the canonical pattern in `text.go` found **2 confirmed violations** and **3 partial cases** where ctx was available at `Attributes()` entry but didn't propagate into helper functions running unbounded loops. A pathological input could keep one of these parsers busy for many seconds after the walk was cancelled — observable in the e2e cancel-mid-search flows that v0.69.0's sandbox PR validates.

## Confirmed violations

| File | What was unguarded | Fix |
| --- | --- | --- |
| `csv.go:41` | `bufio.Scanner` loop seeking the first non-empty line | Add `ctx.Err()` check inside |
| `sourcetype.go:66` | The line-classifier loop — hot path for every source file (now 27 registered languages including the 10 Tiobe additions from PR #257 and 5 new symbol extractors) | Add `ctx.Err()` check inside |

## Partial cases — helper signatures didn't accept ctx

| Entry | Helper | Change |
| --- | --- | --- |
| `science_pds.go:Attributes` | `parsePDS3Label` (Scanner over PVL label) | Helper now takes ctx, returns `(Attributes, error)`. Callers + fuzz target updated. |
| `browser_bookmarks_chromium.go:Attributes` | `parseChromiumBookmarks` + `walkChromiumNode` (recursive descent) | Both helpers now take ctx; walk checks `ctx.Err()` at recursion entry; caller re-checks after each tree-root walk. Body extractor + fuzz target + 4 test sites updated. |
| `epub.go:Attributes` | `readOPFPath` (XML token loop) | Helper now takes ctx and checks between tokens (mirrors `readDublinCore`, which was already ctx-aware). `body_epub.go` caller updated. |

## Regression test

`internal/content/ctx_cancellation_test.go` builds 32 K-line pathological bodies for `csv` / `text` / `source/go`, calls `Attributes` with a **pre-cancelled** ctx, and asserts the call returns an error without hanging. A future regression that drops the `ctx.Err()` check inside a Scanner loop would manifest as this test wedging the 3-minute CI timeout instead of returning fast.

## Test plan

- [x] `go test -race -timeout 180s ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues
- [x] `go fix ./...` — idempotent
- [x] New regression test passes (returns the cancellation error fast for all three covered languages)
- [x] All existing tests continue to pass after the helper-signature changes (chromium body extractor, both fuzz targets, 4 chromium test sites)

## Behaviour change

None on happy paths. The new `ctx.Err()` checks are zero-cost when the context isn't cancelled (single field load + nil compare per loop iteration).

## What was already correct (audit's no-fix list)

- **`internal/content/text.go`** — the canonical pattern; checks entry + per-iteration
- **`internal/search/walker.go:458–464`** — `select { case <-ctx.Done(): return; case j := <-jobs: ... }` — equally valid pattern
- **`internal/index/bbolt.go:686–700`** — background writer with own goroutine lifecycle (no ctx needed)
- **`internal/celexpr/**`** — bounded loops over fixed-size match arrays
- **`internal/content/dublincore.go:readDublinCore`** — already ctx-aware between XML tokens
- **MCP tool handlers** — correctly thread ctx into walker / search calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
