### PR TITLE
feat(find_matches): comments-only / code-only filtering via match_in

### DIFF
--- a/cmd/file-search-on/find_matches_cmd.go
+++ b/cmd/file-search-on/find_matches_cmd.go
@@ -22,6 +22,7 @@ type FindMatchesCmd struct {
 	ContextAfter        int           `short:"A" name:"after" help:"Number of lines of trailing context to attach to each match." default:"0"`
 	Context             int           `short:"C" name:"context" help:"Shortcut: set both --before and --after to this value. Ignored when --before or --after is set explicitly." default:"0"`
 	MaxMatchesPerFile   int           `name:"max-matches-per-file" help:"Cap on matches reported per file. 0 = unlimited." default:"0"`
+	MatchIn             string        `name:"match-in" enum:"any,comments,code" default:"any" help:"Filter matches by per-line role. 'any' (default) keeps every regex hit. 'comments' returns only hits on lines classified as a comment under the source file's language syntax (Go //, Python #, C /* */, etc.) — drops the typical TODO-sweep noise (test fixtures, string literals, fuzz seeds). 'code' returns only hits on lines that AREN'T comments. Non-source files (markdown / json / plain text) are unaffected. Issue #272."`
 	Exclude             []string      `name:"exclude" help:"Basename glob pruned during the walk (e.g. node_modules, .git, target). Repeatable."`
 	RespectGitignore    bool          `name:"respect-gitignore" help:"Parse a .gitignore at each walk root and skip matching paths."`
 	FollowSymlinks      bool          `name:"follow-symlinks" help:"Descend through symbolic links to directories. Off by default."`
@@ -72,6 +73,7 @@ func (f *FindMatchesCmd) Run(ctx context.Context) error {
 		ContextBefore:       before,
 		ContextAfter:        after,
 		MaxMatchesPerFile:   f.MaxMatchesPerFile,
+		MatchIn:             f.MatchIn,
 	}, contentpkg.DefaultRegistry())
 
 	// Print whatever was collected even on cancellation — FindMatches

--- a/examples/find-matches.md
+++ b/examples/find-matches.md
@@ -101,6 +101,28 @@ Response:
 }
 ```
 
+## Filtering by line role (`--match-in`)
+
+A `TODO|FIXME|XXX|HACK` sweep across a typical source tree returns mostly noise: test fixtures with `"TODO"` inside string literals, fuzz seeds with `XXXX`, identifiers like `FooTODOBar`, ID3 frame names like `TXXX`. To filter to *real* annotations:
+
+```sh
+# Comments only — drops every match that isn't on a comment line.
+file-search-on find-matches 'TODO|FIXME|XXX|HACK' \
+  -e 'is_source && language == "go" && !is_test_file' \
+  --match-in comments
+
+# Code only — useful for finding patterns hidden in string literals.
+file-search-on find-matches 'http://[^\s"]+' \
+  -e 'is_source' \
+  --match-in code
+```
+
+How it works: for source files the scanner classifies each line under the language's comment syntax (Go `//` + `/* */`, Python `#`, C/C++/Java/Rust/JS/TS/Swift/Kotlin/Scala/Zig `//` + `/* */`, PHP `//` + `#` + `/* */`, SQL `--`, Lua `--` + `--[[ ]]`, Haskell `--` + `{- -}`, OCaml `(* *)`, Clojure `;`, VB `'`, MATLAB `%`, Fortran `!`, Pascal `//` + `(* *)`, assembly `;` / `#`). Block comments track state across lines.
+
+The classifier is **line-granular**: a trailing-comment line like `x := 1 // TODO` classifies as code (matches the hand-rolled `^\s*//<pattern>` regex shape an agent would otherwise write). Pure comment lines and lines inside an open block comment are `comments`; everything else is `code`. Non-source files (markdown, JSON, plain text) have no syntax registered — `--match-in` is a no-op for them and every match passes.
+
+`strings` mode (matching inside string literals — useful for hunting hardcoded URLs / credentials) is deferred to a follow-up issue; v1 ships `any` / `comments` / `code`.
+
 ## Patterns
 
 The regex flavour is [RE2](https://github.com/google/re2/wiki/Syntax) — Google's regex syntax, same as Go's `regexp` package and CEL's `matches()`. Highlights:

--- a/internal/mcpserver/find_matches_tool.go
+++ b/internal/mcpserver/find_matches_tool.go
@@ -23,6 +23,7 @@ type FindMatchesInput struct {
 	ContextBefore       int      `json:"context_before,omitempty" jsonschema:"Number of lines of leading context to attach to each match. 0 means no Before window."`
 	ContextAfter        int      `json:"context_after,omitempty" jsonschema:"Number of lines of trailing context to attach to each match. 0 means no After window."`
 	MaxMatchesPerFile   int      `json:"max_matches_per_file,omitempty" jsonschema:"Cap on matches reported per file. 0 = unlimited. The scan keeps reading past the cap until pending After windows are filled, so the last matches still carry full trailing context."`
+	MatchIn             string   `json:"match_in,omitempty" jsonschema:"Filter matches by per-line role. One of: 'any' (default — every regex hit), 'comments' (only hits on lines classified as a comment under the source file's language syntax: Go //, Python #, C /* */, plus block-comment continuation lines), 'code' (only hits on lines that AREN'T comments). Drops the typical TODO-sweep noise (test fixtures, string literals, fuzz seeds) without the agent having to hand-roll '^\\\\s*//<pattern>' regexes. Non-source files (markdown / json / plain text) are unaffected — they have no language syntax registered and the filter no-ops. Line-granular: a trailing-comment line like 'x := 1 // TODO' classifies as code. 'strings' mode (matching inside string literals) is deferred to a follow-up. Unknown values return an error. Issue #272."`
 	Excludes            []string `json:"excludes,omitempty" jsonschema:"Glob patterns matched against file/dir basenames; matches are pruned. Same semantics as search."`
 	RespectGitignore    bool     `json:"respect_gitignore,omitempty" jsonschema:"When true, parse a .gitignore at the walk root and skip matching paths."`
 	FollowSymlinks      bool     `json:"follow_symlinks,omitempty" jsonschema:"When true, descend through symbolic links to directories. Off by default."`
@@ -109,6 +110,7 @@ func (h *handlers) findMatchesHandler(ctx context.Context, _ *mcp.CallToolReques
 		ContextBefore:       in.ContextBefore,
 		ContextAfter:        in.ContextAfter,
 		MaxMatchesPerFile:   in.MaxMatchesPerFile,
+		MatchIn:             in.MatchIn,
 	}, content.DefaultRegistry())
 
 	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {

--- a/internal/search/comment_syntax.go
+++ b/internal/search/comment_syntax.go
@@ -1,0 +1,195 @@
+package search
+
+import "strings"
+
+// lineRole is the per-line classification used by FindMatches when the
+// caller passes a non-default MatchIn filter. roleCode is anything
+// that isn't recognised as a comment; roleComment is a line whose
+// content (after leading whitespace) starts with a line-comment marker
+// OR a line that lies fully inside an open block-comment region. The
+// v1 contract is line-granular — a trailing-comment line like
+// `x := 1 // TODO` classifies as roleCode (matches the agent's hand-
+// rolled `^\s*//` regex behaviour). Issue #272.
+type lineRole uint8
+
+const (
+	roleCode lineRole = iota
+	roleComment
+)
+
+// commentSyntax describes a language's comment markers. LinePrefixes
+// lists every line-comment marker (most languages have one; PHP has
+// `//` AND `#`). BlockStart / BlockEnd are the block-comment delimiters
+// — empty when the language has none (Zig, Python, shell). Nested
+// blocks (Haskell, OCaml, Rust) aren't supported in v1 — we treat the
+// first BlockEnd as terminating the block.
+type commentSyntax struct {
+	LinePrefixes []string
+	BlockStart   string
+	BlockEnd     string
+}
+
+// languageSyntax maps the `language` attribute (the bare name without
+// the source/ prefix) to its comment syntax. Covers the Tiobe top 20
+// (May 2026) plus common adjacent languages. Languages absent from
+// the map fall through to "no syntax known" — MatchIn filtering
+// effectively becomes a no-op (every line stays roleCode) so the user
+// gets the unfiltered result rather than a silent empty.
+var languageSyntax = map[string]commentSyntax{
+	// C-family: //, /* */
+	"go":         {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"c":          {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"cpp":        {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"javascript": {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"typescript": {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"rust":       {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"java":       {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"csharp":     {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"swift":      {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"kotlin":     {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"scala":      {LinePrefixes: []string{"//"}, BlockStart: "/*", BlockEnd: "*/"},
+	"zig":        {LinePrefixes: []string{"//"}}, // Zig has no block comments
+	"php":        {LinePrefixes: []string{"//", "#"}, BlockStart: "/*", BlockEnd: "*/"},
+
+	// Hash-family: #
+	"python": {LinePrefixes: []string{"#"}},
+	"ruby":   {LinePrefixes: []string{"#"}},
+	"perl":   {LinePrefixes: []string{"#"}},
+	"shell":  {LinePrefixes: []string{"#"}},
+	"r":      {LinePrefixes: []string{"#"}},
+	"elixir": {LinePrefixes: []string{"#"}},
+
+	// Dash-family: --
+	"sql":     {LinePrefixes: []string{"--"}, BlockStart: "/*", BlockEnd: "*/"},
+	"lua":     {LinePrefixes: []string{"--"}, BlockStart: "--[[", BlockEnd: "]]"},
+	"haskell": {LinePrefixes: []string{"--"}, BlockStart: "{-", BlockEnd: "-}"},
+	"ada":     {LinePrefixes: []string{"--"}},
+
+	// One-offs
+	"clojure":  {LinePrefixes: []string{";"}},
+	"vb":       {LinePrefixes: []string{"'"}},
+	"matlab":   {LinePrefixes: []string{"%"}, BlockStart: "%{", BlockEnd: "%}"},
+	"fortran":  {LinePrefixes: []string{"!"}},
+	"ocaml":    {BlockStart: "(*", BlockEnd: "*)"},
+	"pascal":   {LinePrefixes: []string{"//"}, BlockStart: "(*", BlockEnd: "*)"},
+	"assembly": {LinePrefixes: []string{";", "#"}},
+}
+
+// commentSyntaxFor returns the syntax for language plus whether one is
+// registered. The lookup is case-sensitive and matches the bare
+// language attribute (e.g. "go" / "python"). Unknown languages return
+// the zero syntax + false; callers treat this as "no filtering
+// possible" — same effect as MatchIn="any".
+func commentSyntaxFor(language string) (commentSyntax, bool) {
+	s, ok := languageSyntax[language]
+	return s, ok
+}
+
+// languageFromContentType extracts the bare language name from a
+// content type like "source/go" → "go". Returns "" when the content
+// type doesn't follow the source/* pattern (markdown, json, etc.) —
+// non-source files have no commentSyntax, so MatchIn filtering does
+// nothing for them (matches the issue's "ignored for non-source"
+// contract).
+func languageFromContentType(contentType string) string {
+	rest, ok := strings.CutPrefix(contentType, "source/")
+	if !ok {
+		return ""
+	}
+	return rest
+}
+
+// classifyLine determines whether the given line is a comment under
+// syntax, given whether we entered the line inside an unclosed block
+// comment (inBlock). Returns the role plus the updated in-block state
+// for the NEXT line.
+//
+// Decision rule (line-granular, v1):
+//
+//  1. If we entered inside a block and BlockEnd doesn't appear on
+//     this line → roleComment, still inBlock.
+//  2. If we entered inside a block and BlockEnd appears → roleComment;
+//     check whether a new BlockStart appears AFTER the end to set the
+//     next-line state.
+//  3. Otherwise, strip leading whitespace and:
+//     a. If the trimmed line starts with any LinePrefix → roleComment.
+//     b. If it starts with BlockStart → roleComment; track whether the
+//     block closes on the same line.
+//     c. If it contains BlockStart somewhere but doesn't START with it
+//     (mixed line like `x := 1; /* note */`) → roleCode; track block
+//     state for trailing unclosed blocks.
+//  4. Default → roleCode.
+//
+// Mixed lines (`x := 1 // TODO`) classify as roleCode — the same shape
+// as the user's `^\s*//` hand-rolled regex.
+func classifyLine(line string, syntax commentSyntax, inBlock bool) (lineRole, bool) {
+	if inBlock {
+		if syntax.BlockEnd != "" {
+			if idx := strings.Index(line, syntax.BlockEnd); idx >= 0 {
+				// Block ends on this line. Check for a new block-start
+				// after the end.
+				after := line[idx+len(syntax.BlockEnd):]
+				stillInBlock := syntax.BlockStart != "" && blockStartUnclosed(after, syntax)
+				return roleComment, stillInBlock
+			}
+		}
+		// No end marker (or none on this line) → entire line is comment.
+		return roleComment, true
+	}
+
+	trimmed := strings.TrimLeft(line, " \t")
+	for _, prefix := range syntax.LinePrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return roleComment, false
+		}
+	}
+
+	if syntax.BlockStart == "" {
+		return roleCode, false
+	}
+
+	// Block-start may appear anywhere on the line.
+	idx := strings.Index(line, syntax.BlockStart)
+	if idx < 0 {
+		return roleCode, false
+	}
+	startsWithBlock := strings.HasPrefix(trimmed, syntax.BlockStart)
+	after := line[idx+len(syntax.BlockStart):]
+	endIdx := -1
+	if syntax.BlockEnd != "" {
+		endIdx = strings.Index(after, syntax.BlockEnd)
+	}
+	if endIdx >= 0 {
+		// Block opens AND closes on this line. After-end content
+		// determines the next-line state via blockStartUnclosed.
+		afterEnd := after[endIdx+len(syntax.BlockEnd):]
+		stillInBlock := blockStartUnclosed(afterEnd, syntax)
+		if startsWithBlock {
+			return roleComment, stillInBlock
+		}
+		return roleCode, stillInBlock
+	}
+	// Block opens, doesn't close on this line.
+	if startsWithBlock {
+		return roleComment, true
+	}
+	return roleCode, true
+}
+
+// blockStartUnclosed reports whether tail contains an unclosed block
+// start (a BlockStart that isn't followed by BlockEnd before the end
+// of tail). Used to track whether the next line begins inside a block.
+func blockStartUnclosed(tail string, syntax commentSyntax) bool {
+	if syntax.BlockStart == "" {
+		return false
+	}
+	idx := strings.Index(tail, syntax.BlockStart)
+	if idx < 0 {
+		return false
+	}
+	if syntax.BlockEnd == "" {
+		return true
+	}
+	rest := tail[idx+len(syntax.BlockStart):]
+	return !strings.Contains(rest, syntax.BlockEnd)
+}

--- a/internal/search/comment_syntax_test.go
+++ b/internal/search/comment_syntax_test.go
@@ -1,0 +1,109 @@
+package search
+
+import "testing"
+
+func TestClassifyLine_Go(t *testing.T) {
+	syntax, ok := commentSyntaxFor("go")
+	if !ok {
+		t.Fatal("go syntax should be registered")
+	}
+	cases := []struct {
+		name      string
+		line      string
+		inBlock   bool
+		wantRole  lineRole
+		wantBlock bool
+	}{
+		{"plain code", `x := 1`, false, roleCode, false},
+		{"line comment", `// TODO: fix`, false, roleComment, false},
+		{"indented line comment", `	// TODO`, false, roleComment, false},
+		{"trailing line comment (line is code)", `x := 1 // TODO`, false, roleCode, false},
+		{"block-only line", `/* TODO */`, false, roleComment, false},
+		{"block opens, doesn't close", `/* TODO`, false, roleComment, true},
+		{"inside block continuing", `   continues here`, true, roleComment, true},
+		{"block end terminates", ` ends here */`, true, roleComment, false},
+		{"mixed open block at end", `x := 1 /* note `, false, roleCode, true},
+		{"closing block + new code after", ` */ y := 2`, true, roleComment, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			role, stillInBlock := classifyLine(tc.line, syntax, tc.inBlock)
+			if role != tc.wantRole {
+				t.Errorf("role = %d, want %d", role, tc.wantRole)
+			}
+			if stillInBlock != tc.wantBlock {
+				t.Errorf("stillInBlock = %v, want %v", stillInBlock, tc.wantBlock)
+			}
+		})
+	}
+}
+
+func TestClassifyLine_Python(t *testing.T) {
+	syntax, ok := commentSyntaxFor("python")
+	if !ok {
+		t.Fatal("python syntax should be registered")
+	}
+	cases := []struct {
+		name     string
+		line     string
+		wantRole lineRole
+	}{
+		{"line comment", `# TODO`, roleComment},
+		{"indented line comment", `    # TODO`, roleComment},
+		{"trailing comment is code", `x = 1  # note`, roleCode},
+		{"code", `x = 1`, roleCode},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			role, _ := classifyLine(tc.line, syntax, false)
+			if role != tc.wantRole {
+				t.Errorf("role = %d, want %d", role, tc.wantRole)
+			}
+		})
+	}
+}
+
+func TestClassifyLine_MultiPrefix_PHP(t *testing.T) {
+	syntax, ok := commentSyntaxFor("php")
+	if !ok {
+		t.Fatal("php syntax should be registered")
+	}
+	for _, tc := range []struct {
+		line     string
+		wantRole lineRole
+	}{
+		{`// php-style`, roleComment},
+		{`# python-style in php`, roleComment},
+		{`$x = 1;`, roleCode},
+		{`/* block */`, roleComment},
+	} {
+		role, _ := classifyLine(tc.line, syntax, false)
+		if role != tc.wantRole {
+			t.Errorf("PHP line %q → role=%d, want %d", tc.line, role, tc.wantRole)
+		}
+	}
+}
+
+func TestCommentSyntaxFor_UnknownLanguage(t *testing.T) {
+	if _, ok := commentSyntaxFor("brainfuck"); ok {
+		t.Error("unknown language should return ok=false")
+	}
+	if _, ok := commentSyntaxFor(""); ok {
+		t.Error("empty language should return ok=false")
+	}
+}
+
+func TestLanguageFromContentType(t *testing.T) {
+	cases := map[string]string{
+		"source/go":     "go",
+		"source/python": "python",
+		"markdown":      "",
+		"image/jpeg":    "",
+		"":              "",
+	}
+	for ct, want := range cases {
+		if got := languageFromContentType(ct); got != want {
+			t.Errorf("languageFromContentType(%q) = %q, want %q", ct, got, want)
+		}
+	}
+}

--- a/internal/search/findmatches.go
+++ b/internal/search/findmatches.go
@@ -52,6 +52,43 @@ type FindMatchesResult struct {
 // surface different messages.
 var ErrEmptyPattern = errors.New("pattern is required")
 
+// matchInMode is the internal enum behind the user-facing Options.MatchIn
+// string. Validated up front in parseMatchIn so each per-file scan
+// reads an enum, not the string. Issue #272.
+type matchInMode uint8
+
+const (
+	matchInAny matchInMode = iota
+	matchInComments
+	matchInCode
+)
+
+// MatchInAny / MatchInComments / MatchInCode are the user-facing
+// string constants for Options.MatchIn. Exposed so CLI / MCP layers
+// can validate at parse time and the CEL prune layer (find_matches
+// preset, etc) doesn't have to keep magic strings.
+const (
+	MatchInAny      = "any"
+	MatchInComments = "comments"
+	MatchInCode     = "code"
+)
+
+// parseMatchIn maps the user-facing string to the internal enum.
+// Empty / "any" → matchInAny (no filtering). Unknown values error
+// at the entry point — fail-fast is better than silent no-op when
+// the user typo'd the mode.
+func parseMatchIn(s string) (matchInMode, error) {
+	switch s {
+	case "", MatchInAny:
+		return matchInAny, nil
+	case MatchInComments:
+		return matchInComments, nil
+	case MatchInCode:
+		return matchInCode, nil
+	}
+	return matchInAny, fmt.Errorf("match_in: unknown value %q (want one of any|comments|code)", s)
+}
+
 // findMatchesLineCap bounds the per-line scanner buffer. Matches the
 // read_lines / snippet pattern: pathological single-line files (rolled
 // logs, minified JSON) don't blow up the response — the offending line
@@ -86,6 +123,10 @@ func FindMatches(ctx context.Context, opts Options, registry *content.Registry) 
 	re, err := regexp.Compile(opts.Pattern)
 	if err != nil {
 		return nil, fmt.Errorf("compile pattern: %w", err)
+	}
+	matchIn, err := parseMatchIn(opts.MatchIn)
+	if err != nil {
+		return nil, err
 	}
 
 	// Match the CLI / MCP search-handler convention: empty CEL expr
@@ -142,7 +183,7 @@ func FindMatches(ctx context.Context, opts Options, registry *content.Registry) 
 				if ctx.Err() != nil {
 					return
 				}
-				hits := scanResultForMatches(ctx, opts.FS, r, re, opts.ContextBefore, opts.ContextAfter, opts.MaxMatchesPerFile)
+				hits := scanResultForMatches(ctx, opts.FS, r, re, opts.ContextBefore, opts.ContextAfter, opts.MaxMatchesPerFile, matchIn)
 				mu.Lock()
 				filesScanned++
 				if len(hits) > 0 {
@@ -211,7 +252,7 @@ func FindMatches(ctx context.Context, opts Options, registry *content.Registry) 
 // drop that file silently — matches the broader "broken file doesn't
 // abort the walk" pattern. fsys is non-nil only in test paths that
 // pass Options.FS.
-func scanResultForMatches(ctx context.Context, fsys fs.FS, r Result, re *regexp.Regexp, ctxBefore, ctxAfter, maxPerFile int) []LineMatch {
+func scanResultForMatches(ctx context.Context, fsys fs.FS, r Result, re *regexp.Regexp, ctxBefore, ctxAfter, maxPerFile int, matchIn matchInMode) []LineMatch {
 	if err := ctx.Err(); err != nil {
 		return nil
 	}
@@ -231,7 +272,21 @@ func scanResultForMatches(ctx context.Context, fsys fs.FS, r Result, re *regexp.
 	}
 	defer func() { _ = rd.Close() }()
 
-	hits := scanReaderForMatches(ctx, rd, re, ctxBefore, ctxAfter, maxPerFile)
+	// Resolve per-language syntax once per file. matchIn=any short-
+	// circuits the lookup entirely (zero syntax → classifier never
+	// runs). Non-source content types (markdown / json / etc) have no
+	// syntax registered — the scanner sees ok=false and skips role
+	// filtering, so MatchIn="comments" against a markdown file is a
+	// no-op. Issue #272.
+	var (
+		syntax commentSyntax
+		hasSyntax bool
+	)
+	if matchIn != matchInAny {
+		syntax, hasSyntax = commentSyntaxFor(languageFromContentType(r.ContentType))
+	}
+
+	hits := scanReaderForMatches(ctx, rd, re, ctxBefore, ctxAfter, maxPerFile, matchIn, syntax, hasSyntax)
 	for i := range hits {
 		hits[i].Path = r.Path
 		hits[i].ContentType = r.ContentType
@@ -248,7 +303,7 @@ func scanResultForMatches(ctx context.Context, fsys fs.FS, r Result, re *regexp.
 // (without adding new matches) until every pending After window is
 // filled — otherwise the last few matches would carry truncated
 // After lines, which is surprising.
-func scanReaderForMatches(ctx context.Context, rd io.Reader, re *regexp.Regexp, ctxBefore, ctxAfter, maxPerFile int) []LineMatch {
+func scanReaderForMatches(ctx context.Context, rd io.Reader, re *regexp.Regexp, ctxBefore, ctxAfter, maxPerFile int, matchIn matchInMode, syntax commentSyntax, hasSyntax bool) []LineMatch {
 	scanner := bufio.NewScanner(rd)
 	scanner.Buffer(make([]byte, 0, 4096), findMatchesLineCap)
 
@@ -256,8 +311,13 @@ func scanReaderForMatches(ctx context.Context, rd io.Reader, re *regexp.Regexp, 
 		matches []LineMatch
 		before  []string // ring; len <= ctxBefore
 		pending []int    // indices into matches waiting for their After window
+		inBlock bool     // running block-comment state for the classifier
 	)
 	lineNo := 0
+	// filterByRole is true only when the caller asked for comments/code
+	// AND we recognised the file's language. Files without syntax
+	// (markdown, json, raw text) or matchIn=any leave filtering off.
+	filterByRole := matchIn != matchInAny && hasSyntax
 
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
@@ -266,6 +326,14 @@ func scanReaderForMatches(ctx context.Context, rd io.Reader, re *regexp.Regexp, 
 		lineNo++
 		// scanner.Bytes() is reused on next Scan(); copy.
 		line := string(scanner.Bytes())
+
+		// Classify role + advance block-comment state. We always
+		// advance the state (so the classifier stays accurate across
+		// the file) but only USE the role when filterByRole is set.
+		var role lineRole
+		if hasSyntax {
+			role, inBlock = classifyLine(line, syntax, inBlock)
+		}
 
 		// Fill any pending After windows; drop those whose After is
 		// full. Reuse pending's backing array (kept = pending[:0]).
@@ -283,7 +351,7 @@ func scanReaderForMatches(ctx context.Context, rd io.Reader, re *regexp.Regexp, 
 		}
 
 		atCap := maxPerFile > 0 && len(matches) >= maxPerFile
-		if !atCap && re.MatchString(line) {
+		if !atCap && re.MatchString(line) && roleMatches(filterByRole, matchIn, role) {
 			m := LineMatch{Line: lineNo, Text: line}
 			if len(before) > 0 {
 				m.Before = append([]string(nil), before...)
@@ -310,4 +378,21 @@ func scanReaderForMatches(ctx context.Context, rd io.Reader, re *regexp.Regexp, 
 	// scanner.Err() deliberately ignored — pathological lines are
 	// truncated; matches the snippet / read_lines degradation pattern.
 	return matches
+}
+
+// roleMatches reports whether a line of role `r` survives the MatchIn
+// filter. When filtering is off (filterByRole=false), every role
+// passes — that covers matchIn=any AND the "language unrecognised /
+// non-source" no-op path.
+func roleMatches(filterByRole bool, mode matchInMode, r lineRole) bool {
+	if !filterByRole {
+		return true
+	}
+	switch mode {
+	case matchInComments:
+		return r == roleComment
+	case matchInCode:
+		return r == roleCode
+	}
+	return true
 }

--- a/internal/search/findmatches_matchin_test.go
+++ b/internal/search/findmatches_matchin_test.go
@@ -1,0 +1,132 @@
+package search_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"testing"
+
+	contentpkg "github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// Per-file Go fixture exercising every match-in interesting case. The
+// TODO landmark appears five times:
+//
+//  1. on a line-comment line                     → comments
+//  2. inside a string literal                    → code (whole line is code)
+//  3. as a trailing comment after code            → code (rule: line-start classifier)
+//  4. inside an open block comment, line 2 of 3  → comments (block-continuation)
+//  5. inside an identifier (FooTODOBar)           → code
+//
+// Each case lands on a distinct line so we can assert by line number.
+const fixtureGo = `package main
+
+// TODO: this is a real comment-line match
+const s = "TODO inside string"
+var x = 1 // TODO trailing
+/*
+  TODO inside block
+*/
+var FooTODOBar = 2
+`
+
+func writeFixture(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func runFindMatches(t *testing.T, dir, pattern, matchIn string) []int {
+	t.Helper()
+	res, err := search.FindMatches(context.Background(), search.Options{
+		Root:    dir,
+		Expr:    `is_source && language == "go"`,
+		Pattern: pattern,
+		Workers: 1,
+		MatchIn: matchIn,
+	}, contentpkg.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("FindMatches: %v", err)
+	}
+	lines := make([]int, len(res.Matches))
+	for i, m := range res.Matches {
+		lines[i] = m.Line
+	}
+	sort.Ints(lines)
+	return lines
+}
+
+func TestFindMatches_MatchInAny_ReturnsEveryHit(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "fixture.go", fixtureGo)
+	got := runFindMatches(t, dir, "TODO", "any")
+	want := []int{3, 4, 5, 7, 9}
+	if !slices.Equal(got, want) {
+		t.Errorf("match_in=any lines = %v, want %v", got, want)
+	}
+}
+
+func TestFindMatches_MatchInComments_DropsCodeNoise(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "fixture.go", fixtureGo)
+	got := runFindMatches(t, dir, "TODO", "comments")
+	// Lines 3 (line comment) + 7 (block-comment continuation) survive.
+	// Lines 4 (string literal), 5 (trailing comment after code), 9
+	// (identifier) all classify as code and drop.
+	want := []int{3, 7}
+	if !slices.Equal(got, want) {
+		t.Errorf("match_in=comments lines = %v, want %v", got, want)
+	}
+}
+
+func TestFindMatches_MatchInCode_DropsCommentLines(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "fixture.go", fixtureGo)
+	got := runFindMatches(t, dir, "TODO", "code")
+	// Inverse of comments: lines 4 / 5 / 9 are code-classified.
+	want := []int{4, 5, 9}
+	if !slices.Equal(got, want) {
+		t.Errorf("match_in=code lines = %v, want %v", got, want)
+	}
+}
+
+func TestFindMatches_MatchInUnknown_Errors(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "fixture.go", fixtureGo)
+	_, err := search.FindMatches(context.Background(), search.Options{
+		Root:    dir,
+		Pattern: "TODO",
+		Workers: 1,
+		MatchIn: "trailing-trivia",
+	}, contentpkg.DefaultRegistry())
+	if err == nil {
+		t.Fatal("unknown match_in should error")
+	}
+}
+
+// TestFindMatches_MatchInComments_NoOpOnMarkdown confirms the
+// contract: non-source files (markdown, JSON, plain text) have no
+// language syntax registered, so match_in is a no-op for them. A
+// markdown file with TODO in body text still matches under
+// match_in=comments — because we'd otherwise silently drop matches
+// that the user almost certainly wants.
+func TestFindMatches_MatchInComments_NoOpOnMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "notes.md", "# Notes\n\n- TODO: write this\n")
+	res, err := search.FindMatches(context.Background(), search.Options{
+		Root:    dir,
+		Pattern: "TODO",
+		Workers: 1,
+		MatchIn: "comments",
+	}, contentpkg.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("FindMatches: %v", err)
+	}
+	if res.Count != 1 {
+		t.Errorf("markdown with TODO should still match under match_in=comments; got %d", res.Count)
+	}
+}

--- a/internal/search/walker.go
+++ b/internal/search/walker.go
@@ -306,6 +306,21 @@ type Options struct {
 	// the requested trailing context.
 	MaxMatchesPerFile int
 
+	// MatchIn filters FindMatches hits by per-line role. Empty / "any"
+	// keeps every match (default). "comments" returns only matches on
+	// lines classified as a comment under the source file's per-
+	// language syntax (Go //, Python #, C/C++ /* */, ...). "code"
+	// returns only matches on lines that AREN'T comments. Non-source
+	// files (markdown / json / plain text) are unaffected — they have
+	// no language syntax registered and the filter no-ops. v1 doesn't
+	// support a "strings" mode; defer to a follow-up issue.
+	//
+	// Filtering is line-granular: a trailing-comment line like
+	// `x := 1 // TODO` classifies as code (matches the hand-rolled
+	// `^\s*//<pattern>` regex shape an agent would otherwise write).
+	// Issue #272.
+	MatchIn string
+
 	// SkipAttributesParse, when true, makes BuildAttributesWith detect
 	// the file's content type and run setTypeFlags but skip the
 	// expensive ContentType.Attributes() parse. The walker still


### PR DESCRIPTION
Closes #272.

## Summary

Adds a \`match_in\` input to \`find_matches\` (CLI \`--match-in\`, MCP \`match_in\`) that filters regex hits by per-line role:

- \`any\` — every hit (default; today's behaviour)
- \`comments\` — hits on lines classified as comment under the source file's language syntax
- \`code\` — hits on lines that AREN'T comments

Solves the headline #272 friction: a \`TODO|FIXME|XXX|HACK\` sweep returns mostly noise (TXXX ID3 frame names, XXXX in fuzz seeds, identifiers like FooTODOBar, TODO inside test-fixture string literals). The user had to hand-roll \`^\\s*//\\s*(TODO|FIXME|XXX|HACK)\\b\` — fragile and language-specific.

## How it works

For source files the scanner classifies each line under the language's comment syntax. The table ships syntax for the Tiobe top 20 + adjacent common languages:

| Family | Languages | Markers |
|---|---|---|
| C-family | Go, C, C++, JS, TS, Rust, Java, C#, Swift, Kotlin, Scala, Zig, PHP, Pascal | \`//\` + \`/* */\` |
| Hash | Python, Ruby, Perl, shell, R, Elixir | \`#\` |
| Dash | SQL, Lua, Haskell, Ada | \`--\` + (block varies) |
| One-offs | Clojure (\`;\`), VB (\`'\`), MATLAB (\`%\`), Fortran (\`!\`), OCaml (\`(* *)\`), assembly (\`;\` / \`#\`) | |

Block-comment state is tracked across lines so a multi-line \`/* ... */\` region classifies every contained line as comment, including the closing line.

**Decision rule (line-granular)**: a line is a comment iff (a) we entered the line inside an unclosed block comment, OR (b) after stripping leading whitespace it starts with a line-comment prefix, OR (c) it starts with a block-comment opener. Trailing-comment lines like \`x := 1 // TODO\` classify as code — matches the hand-rolled \`^\\s*//<pattern>\` regex shape.

Languages absent from the table (or non-source content types: markdown, JSON, plain text) are treated as \"no syntax\" and the filter no-ops — every match passes. Documented as the v1 contract; a markdown TODO sweep still works under \`match_in=comments\`.

\`strings\` mode (matching inside string literals) is deferred to a follow-up — useful for credential / URL hunting but requires per-language tokenization that doubles the implementation footprint. Out-of-scope is documented in the example doc.

## Dogfood result on this repo

\`TODO|FIXME|XXX|HACK\` across Go source (\`!is_test_file\`):

| Mode | Matches | Files |
|---|---|---|
| \`any\` (baseline) | 20 | 10 |
| \`comments\` | 13 | 7 |
| \`code\` | 7 | 4 |

\`13 + 7 = 20\` — the split is exact. The 7 \`code\`-classified hits are exactly the original false positives the issue called out: TXXX in a switch-case, XXX in regex literals, identifier substrings.

## Test plan

- [x] \`go test -race -timeout 180s ./...\` — all green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` idempotent
- [x] Per-language classifier tests (Go, Python, PHP-multi-prefix, unknown-language fallback, content-type extraction)
- [x] 5 integration tests on a Go fixture with TODOs in: line comment, string literal, trailing comment, block comment continuation, identifier — confirm each mode returns the right line numbers
- [x] Markdown no-op test (markdown TODO still matches under \`match_in=comments\`)
- [x] Unknown match_in value errors at FindMatches entry point
- [x] Manual dogfood on this repo confirms the 20 → 13/7 split

🤖 Generated with [Claude Code](https://claude.com/claude-code)