### PR TITLE
feat(mcp): list_attributes pagination / filtering

### DIFF
--- a/internal/mcpserver/list_attributes_tool.go
+++ b/internal/mcpserver/list_attributes_tool.go
@@ -2,6 +2,8 @@ package mcpserver
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -15,22 +17,217 @@ type ContentTypeDoc struct {
 	Extensions []string `json:"extensions"`
 }
 
-// ListAttributesOutput is the structured output of the `list_attributes` tool.
-type ListAttributesOutput struct {
-	CommonOutput
-	Schema       celexpr.SchemaDoc `json:"schema"`
-	ContentTypes []ContentTypeDoc  `json:"content_types"`
+// ListAttributesInput selects which slice of the schema list_attributes
+// returns. All fields optional — the default (no args) returns a small
+// summary that the agent can drill into. Issue #273.
+//
+// Precedence (first non-empty wins):
+//
+//  1. names — exact-name lookup across every section. Returns the
+//     matching attribute / function / content-type entries from
+//     wherever they live. Use when an agent already knows what it's
+//     looking up.
+//  2. section — fetch one full section (common / type_specific /
+//     frontmatter / functions / content_types) with optional
+//     limit + offset pagination. The full type_specific section is
+//     ~250 entries / >80kB JSON; paginate when total > limit.
+//  3. neither — summary mode: counts per section + every function's
+//     name + a hint string explaining how to drill in. Sub-1kB
+//     response — token-safe for MCP framing.
+type ListAttributesInput struct {
+	Section string   `json:"section,omitempty" jsonschema:"Fetch one full section: 'common' (attrs on every file), 'type_specific' (per-content-type attrs), 'frontmatter' (markdown YAML keys), 'functions' (CEL builtins like levenshtein/soundex), 'content_types' (registered content type names + extensions). Empty returns a summary instead. Unknown values error."`
+	Names   []string `json:"names,omitempty" jsonschema:"Direct name lookup across every section. Returns matching attribute / function / content-type entries from wherever they live. Use when you already know what you're looking up (saves an extra summary round-trip)."`
+	Limit   int      `json:"limit,omitempty" jsonschema:"Cap the per-section response. Default 50; server cap 500. Ignored in names + summary modes."`
+	Offset  int      `json:"offset,omitempty" jsonschema:"Pagination offset within a section. Ignored in names + summary modes."`
 }
 
-func (h *handlers) listAttributesHandler(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, ListAttributesOutput, error) {
+// ListAttributesOutput is one of three shapes depending on Mode:
+//
+//   - Mode=summary  → Summary populated; everything else empty
+//   - Mode=section  → Section + (Attributes | Functions | ContentTypes)
+//     populated; Total / Limit / Offset describe the slice
+//   - Mode=names    → Attributes / Functions / ContentTypes hold every
+//     match found in any section; Total counts the union
+type ListAttributesOutput struct {
+	CommonOutput
+	Mode         string                 `json:"mode"`
+	Summary      *SchemaSummary         `json:"summary,omitempty"`
+	Section      string                 `json:"section,omitempty"`
+	Attributes   []celexpr.AttributeDoc `json:"attributes,omitempty"`
+	Functions    []celexpr.FunctionDoc  `json:"functions,omitempty"`
+	ContentTypes []ContentTypeDoc       `json:"content_types,omitempty"`
+	Total        int                    `json:"total,omitempty"`
+	Limit        int                    `json:"limit,omitempty"`
+	Offset       int                    `json:"offset,omitempty"`
+}
+
+// SchemaSummary is the default (no-args) response: counts per section
+// plus the cheap-to-enumerate function-name list and a hint. Together
+// this is small enough to land in any MCP client's response budget.
+type SchemaSummary struct {
+	Sections      map[string]int `json:"sections"`
+	FunctionNames []string       `json:"function_names"`
+	Hint          string         `json:"hint"`
+}
+
+// listAttributesDefaultLimit / Cap mirror cache-entries pagination so
+// agents can reuse the same mental model.
+const (
+	listAttributesDefaultLimit = 50
+	listAttributesLimitCap     = 500
+)
+
+func (h *handlers) listAttributesHandler(_ context.Context, _ *mcp.CallToolRequest, in ListAttributesInput) (*mcp.CallToolResult, ListAttributesOutput, error) {
+	schema := celexpr.Schema()
+	contentTypes := contentTypeDocs()
+
+	out := ListAttributesOutput{
+		CommonOutput: CommonOutput{ServerVersion: h.version},
+	}
+
+	// Names mode: lookup across every section.
+	if len(in.Names) > 0 {
+		out.Mode = "names"
+		want := make(map[string]struct{}, len(in.Names))
+		for _, n := range in.Names {
+			want[n] = struct{}{}
+		}
+		for _, a := range schema.Common {
+			if _, ok := want[a.Name]; ok {
+				out.Attributes = append(out.Attributes, a)
+			}
+		}
+		for _, a := range schema.TypeSpecific {
+			if _, ok := want[a.Name]; ok {
+				out.Attributes = append(out.Attributes, a)
+			}
+		}
+		for _, a := range schema.Frontmatter {
+			if _, ok := want[a.Name]; ok {
+				out.Attributes = append(out.Attributes, a)
+			}
+		}
+		for _, f := range schema.Functions {
+			if _, ok := want[f.Name]; ok {
+				out.Functions = append(out.Functions, f)
+			}
+		}
+		for _, ct := range contentTypes {
+			if _, ok := want[ct.Name]; ok {
+				out.ContentTypes = append(out.ContentTypes, ct)
+			}
+		}
+		out.Total = len(out.Attributes) + len(out.Functions) + len(out.ContentTypes)
+		return nil, out, nil
+	}
+
+	// Section mode: paginate the requested slice.
+	if in.Section != "" {
+		out.Mode = "section"
+		out.Section = in.Section
+		limit := in.Limit
+		if limit <= 0 {
+			limit = listAttributesDefaultLimit
+		}
+		if limit > listAttributesLimitCap {
+			limit = listAttributesLimitCap
+		}
+		offset := max(in.Offset, 0)
+		out.Limit = limit
+		out.Offset = offset
+
+		switch in.Section {
+		case "common":
+			out.Total = len(schema.Common)
+			out.Attributes = paginateAttrs(schema.Common, offset, limit)
+		case "type_specific":
+			out.Total = len(schema.TypeSpecific)
+			out.Attributes = paginateAttrs(schema.TypeSpecific, offset, limit)
+		case "frontmatter":
+			out.Total = len(schema.Frontmatter)
+			out.Attributes = paginateAttrs(schema.Frontmatter, offset, limit)
+		case "functions":
+			out.Total = len(schema.Functions)
+			out.Functions = paginateFuncs(schema.Functions, offset, limit)
+		case "content_types":
+			out.Total = len(contentTypes)
+			out.ContentTypes = paginateCTs(contentTypes, offset, limit)
+		default:
+			return nil, ListAttributesOutput{}, fmt.Errorf(
+				"unknown section %q (want one of: common, type_specific, frontmatter, functions, content_types)",
+				in.Section,
+			)
+		}
+		return nil, out, nil
+	}
+
+	// Default: summary.
+	out.Mode = "summary"
+	fnNames := make([]string, len(schema.Functions))
+	for i, f := range schema.Functions {
+		fnNames[i] = f.Name
+	}
+	out.Summary = &SchemaSummary{
+		Sections: map[string]int{
+			"common":        len(schema.Common),
+			"type_specific": len(schema.TypeSpecific),
+			"frontmatter":   len(schema.Frontmatter),
+			"functions":     len(schema.Functions),
+			"content_types": len(contentTypes),
+		},
+		FunctionNames: fnNames,
+		Hint: strings.Join([]string{
+			"Pass section: 'common' for every-file attrs (~35),",
+			"'type_specific' for per-content-type attrs (~250; paginate with limit+offset),",
+			"'frontmatter' for markdown YAML keys (~12),",
+			"'functions' for CEL builtins (~8),",
+			"'content_types' for registered content type names (~100).",
+			"Pass names: ['loc', 'symbols', 'levenshtein', ...] to fetch specific entries across every section in one call.",
+		}, " "),
+	}
+	return nil, out, nil
+}
+
+// contentTypeDocs builds the registry view used by both section=content_types
+// and names mode. Extracted so both code paths share one source of truth.
+func contentTypeDocs() []ContentTypeDoc {
 	types := content.DefaultRegistry().Types()
 	docs := make([]ContentTypeDoc, len(types))
 	for i, t := range types {
 		docs[i] = ContentTypeDoc{Name: t.Name(), Extensions: t.Extensions()}
 	}
-	return nil, ListAttributesOutput{
-		CommonOutput: CommonOutput{ServerVersion: h.version},
-		Schema:       celexpr.Schema(),
-		ContentTypes: docs,
-	}, nil
+	return docs
+}
+
+// paginateAttrs returns the [offset, offset+limit) slice of attrs, with
+// offset clamped to len(attrs) so over-runs return an empty slice
+// rather than panicking. Mirrors the index/list.go ListAttrs shape.
+func paginateAttrs(attrs []celexpr.AttributeDoc, offset, limit int) []celexpr.AttributeDoc {
+	if offset >= len(attrs) {
+		return nil
+	}
+	end := min(offset+limit, len(attrs))
+	out := make([]celexpr.AttributeDoc, end-offset)
+	copy(out, attrs[offset:end])
+	return out
+}
+
+func paginateFuncs(fns []celexpr.FunctionDoc, offset, limit int) []celexpr.FunctionDoc {
+	if offset >= len(fns) {
+		return nil
+	}
+	end := min(offset+limit, len(fns))
+	out := make([]celexpr.FunctionDoc, end-offset)
+	copy(out, fns[offset:end])
+	return out
+}
+
+func paginateCTs(cts []ContentTypeDoc, offset, limit int) []ContentTypeDoc {
+	if offset >= len(cts) {
+		return nil
+	}
+	end := min(offset+limit, len(cts))
+	out := make([]ContentTypeDoc, end-offset)
+	copy(out, cts[offset:end])
+	return out
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -339,7 +339,7 @@ func New(version string, idx index.Index, defaultTimeout time.Duration, embedDef
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_attributes",
-		Description: "List every CEL attribute available to the search tool, the built-in functions (levenshtein, soundex, ngrams, ngram_similarity, point_in_polygon) with their signatures, and the registered content types.",
+		Description: "Schema discovery for the search tool. Three modes — default is a small summary that fits any MCP token budget; drill in via inputs. Pass no args for the summary (counts per section + every CEL function's name + a hint). Pass section='common' / 'type_specific' / 'frontmatter' / 'functions' / 'content_types' to fetch one section with optional limit+offset pagination (default 50, cap 500). Pass names=['loc','symbols','levenshtein',…] for direct lookup across every section — returns matching attribute / function / content-type entries from wherever they live. The legacy 'return the full schema' call would emit ~100kB of JSON and blow the per-response budget; #273 split it into the three drill-in paths above.",
 	}, instrument(h.metrics, "list_attributes", h.listAttributesHandler))
 
 	mcp.AddTool(s, &mcp.Tool{

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -198,37 +198,208 @@ func TestReadAttributesToolMissingPath(t *testing.T) {
 	}
 }
 
-func TestListAttributesTool(t *testing.T) {
+func TestListAttributesTool_SummaryByDefault(t *testing.T) {
 	ctx, cs := newSession(t)
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "list_attributes", Arguments: ListAttributesInput{}})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	var out ListAttributesOutput
+	mustDecodeStructured(t, res, &out)
 
+	if out.Mode != "summary" {
+		t.Fatalf("Mode = %q, want summary", out.Mode)
+	}
+	if out.Summary == nil {
+		t.Fatal("Summary nil in summary mode")
+	}
+	for _, sec := range []string{"common", "type_specific", "frontmatter", "functions", "content_types"} {
+		if n, ok := out.Summary.Sections[sec]; !ok || n == 0 {
+			t.Errorf("Summary.Sections[%q] = %d/%v, want >0", sec, n, ok)
+		}
+	}
+	if len(out.Summary.FunctionNames) == 0 {
+		t.Error("Summary.FunctionNames empty; want >=1")
+	}
+	if out.Summary.Hint == "" {
+		t.Error("Summary.Hint empty; want drill-in instructions")
+	}
+	// Detail fields must be empty in summary mode.
+	if len(out.Attributes) != 0 || len(out.Functions) != 0 || len(out.ContentTypes) != 0 {
+		t.Error("detail fields should be empty in summary mode")
+	}
+}
+
+func TestListAttributesTool_SummaryStaysSmall(t *testing.T) {
+	// The whole point of #273: the summary mode must be token-budget-safe.
+	// The legacy full-schema response is ~100kB. Assert the summary is
+	// dramatically smaller — under 4kB even with the hint string and
+	// function-name list inflating it.
+	ctx, cs := newSession(t)
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "list_attributes", Arguments: ListAttributesInput{}})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if sc := res.StructuredContent; sc != nil {
+		raw, err := json.Marshal(sc)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if len(raw) > 4096 {
+			t.Errorf("summary response = %d bytes, want < 4096 (#273 budget)", len(raw))
+		}
+	}
+}
+
+func TestListAttributesTool_SectionCommon(t *testing.T) {
+	ctx, cs := newSession(t)
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "list_attributes",
-		Arguments: struct{}{},
+		Arguments: ListAttributesInput{Section: "common"},
 	})
 	if err != nil {
 		t.Fatalf("CallTool: %v", err)
 	}
-
 	var out ListAttributesOutput
 	mustDecodeStructured(t, res, &out)
 
-	if len(out.Schema.Common) == 0 {
-		t.Fatal("expected non-empty Common schema")
+	if out.Mode != "section" || out.Section != "common" {
+		t.Errorf("Mode=%q Section=%q, want section/common", out.Mode, out.Section)
 	}
-	if len(out.ContentTypes) == 0 {
-		t.Fatal("expected at least one registered content type")
+	if out.Total == 0 {
+		t.Fatal("Total = 0; want >0 common attrs")
 	}
-
-	// Sanity: at least one expected attribute is present.
+	if len(out.Attributes) == 0 {
+		t.Fatal("Attributes empty for section=common")
+	}
+	// is_markdown is a known Common entry — guard the regression.
 	found := false
-	for _, a := range out.Schema.Common {
+	for _, a := range out.Attributes {
 		if a.Name == "is_markdown" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatal("expected is_markdown in Common attributes")
+		t.Error("expected is_markdown in section=common slice")
+	}
+}
+
+func TestListAttributesTool_SectionPagination(t *testing.T) {
+	ctx, cs := newSession(t)
+	// First page: limit 5, offset 0.
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "list_attributes",
+		Arguments: ListAttributesInput{Section: "type_specific", Limit: 5, Offset: 0},
+	})
+	if err != nil {
+		t.Fatalf("page1 CallTool: %v", err)
+	}
+	var page1 ListAttributesOutput
+	mustDecodeStructured(t, res, &page1)
+	if len(page1.Attributes) != 5 {
+		t.Errorf("page1 size = %d, want 5", len(page1.Attributes))
+	}
+
+	// Second page: limit 5, offset 5 — must be distinct entries.
+	res, err = cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "list_attributes",
+		Arguments: ListAttributesInput{Section: "type_specific", Limit: 5, Offset: 5},
+	})
+	if err != nil {
+		t.Fatalf("page2 CallTool: %v", err)
+	}
+	var page2 ListAttributesOutput
+	mustDecodeStructured(t, res, &page2)
+	if len(page2.Attributes) != 5 {
+		t.Errorf("page2 size = %d, want 5", len(page2.Attributes))
+	}
+	if page1.Attributes[0].Name == page2.Attributes[0].Name {
+		t.Errorf("page1 and page2 first entries identical (%q); pagination not advancing", page1.Attributes[0].Name)
+	}
+	// Same total reported on both pages.
+	if page1.Total != page2.Total {
+		t.Errorf("Total differs between pages: %d vs %d", page1.Total, page2.Total)
+	}
+}
+
+func TestListAttributesTool_SectionFunctions(t *testing.T) {
+	ctx, cs := newSession(t)
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "list_attributes",
+		Arguments: ListAttributesInput{Section: "functions"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	var out ListAttributesOutput
+	mustDecodeStructured(t, res, &out)
+	if out.Mode != "section" || out.Section != "functions" {
+		t.Errorf("Mode=%q Section=%q", out.Mode, out.Section)
+	}
+	if len(out.Functions) == 0 {
+		t.Fatal("Functions empty for section=functions")
+	}
+	if len(out.Attributes) != 0 {
+		t.Errorf("Attributes should be empty for section=functions; got %d", len(out.Attributes))
+	}
+}
+
+func TestListAttributesTool_NamesAcrossSections(t *testing.T) {
+	ctx, cs := newSession(t)
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "list_attributes",
+		Arguments: ListAttributesInput{
+			// Mix of attribute (loc — type_specific) + function (levenshtein) + content_type (markdown).
+			Names: []string{"loc", "levenshtein", "markdown"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	var out ListAttributesOutput
+	mustDecodeStructured(t, res, &out)
+	if out.Mode != "names" {
+		t.Errorf("Mode = %q, want names", out.Mode)
+	}
+
+	gotAttrs := make(map[string]bool, len(out.Attributes))
+	for _, a := range out.Attributes {
+		gotAttrs[a.Name] = true
+	}
+	if !gotAttrs["loc"] {
+		t.Error("expected 'loc' in Attributes")
+	}
+
+	gotFuncs := make(map[string]bool, len(out.Functions))
+	for _, f := range out.Functions {
+		gotFuncs[f.Name] = true
+	}
+	if !gotFuncs["levenshtein"] {
+		t.Error("expected 'levenshtein' in Functions")
+	}
+
+	gotCTs := make(map[string]bool, len(out.ContentTypes))
+	for _, c := range out.ContentTypes {
+		gotCTs[c.Name] = true
+	}
+	if !gotCTs["markdown"] {
+		t.Error("expected 'markdown' in ContentTypes")
+	}
+}
+
+func TestListAttributesTool_UnknownSectionErrors(t *testing.T) {
+	ctx, cs := newSession(t)
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "list_attributes",
+		Arguments: ListAttributesInput{Section: "bogus"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	// MCP wraps handler errors into the CallToolResult via IsError=true.
+	if !res.IsError {
+		t.Errorf("expected IsError=true for unknown section; got %+v", res)
 	}
 }
 


### PR DESCRIPTION
Closes #273.

## Summary

The legacy `list_attributes` call returned ~100kB of JSON (every common attr + every type-specific attr + every frontmatter key + every CEL function + every content type) — well past every MCP client's per-response token budget. The schema-discovery tool was literally unusable through the MCP framing.

Splits the surface into three drill-in paths:

| Mode | Args | Returns | Size |
|---|---|---|---|
| **summary** | (none — default) | Counts per section + every CEL function's name + a hint string explaining how to drill in | <4kB |
| **section** | `section: \"<name>\"` | Paginated slice of one section (\`common\` / \`type_specific\` / \`frontmatter\` / \`functions\` / \`content_types\`). Default limit 50, cap 500. \`Total\` reports the full section size for pagination math | bounded by limit |
| **names** | `names: [\"a\", \"b\", ...]` | Direct lookup across every section. Matching attribute / function / content-type entries returned in their typed slot | bounded by len(names) |

Test confirms the summary mode is <4kB. Section + names modes are bounded by the operator-supplied limit / names array.

## Why this shape

- **Default = summary** matches the principle of least surprise: an agent calling `list_attributes` without args gets enough info to decide what to fetch next (counts tell them \"type_specific is large\", function names are cheap enough to enumerate inline).
- **section** mirrors the existing `cache_entries` pagination shape (limit/offset/total) — same mental model.
- **names** is the zero-round-trip shortcut when the agent already knows what it's looking up (e.g. `list_attributes` from a CEL compile error suggesting \"did you mean 'loc'?\" — fetch and verify in one call).

## Out of scope for v1

- **Family filter** (`family: \"audio\"` from the issue) — would need a `Family` field on every AttributeDoc (~250 touchpoints) or a hand-curated name→family map. Skipping keeps the v1 surface focused on the headline budget fix. The `names` path lets agents fetch any subset by enumeration.

## Backward compatibility

Breaking: the old monolithic `Schema` + `ContentTypes` output fields are replaced by `Mode + Summary | Attributes | Functions | ContentTypes`. Since the previous shape couldn't actually serve a real MCP client (the response was too large for every client we know of), there are no production callers to migrate.

## Test plan

- [x] \`go test -race -timeout 180s ./...\` — all green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` idempotent
- [x] 7 new test cases:
  - Summary default returns mode=summary + counts + function names + hint
  - Summary response is <4kB (the #273 budget test)
  - section=common returns mode=section, common attrs, includes \`is_markdown\`
  - section pagination — page1 and page2 are distinct, Total consistent
  - section=functions returns Functions field, not Attributes
  - names=['loc','levenshtein','markdown'] hits attribute + function + content-type in one call
  - Unknown section sets IsError on the CallToolResult

🤖 Generated with [Claude Code](https://claude.com/claude-code)