### PR TITLE
fix(mcp): stats accepts prune_build_artefacts

### DIFF
--- a/internal/mcpserver/server_phase4_test.go
+++ b/internal/mcpserver/server_phase4_test.go
@@ -166,3 +166,76 @@ func itoaForTest(n int) string {
 	}
 	return string(b)
 }
+
+// TestStatsTool_PruneBuildArtefacts confirms the new input plumbs
+// through to the walker, parity-fixing the gap dogfooding surfaced:
+// stats over a Go module would over-count by walking ./vendor. With
+// prune_build_artefacts=true the vendor tree is excluded the same
+// way the search tool already does it. Issue #277.
+func TestStatsTool_PruneBuildArtefacts(t *testing.T) {
+	dir := t.TempDir()
+	// Marker file makes the dir a Go module — the project-type
+	// detector then knows "vendor" is a Go build artefact and adds
+	// it to the prune list.
+	mustWrite(t, filepath.Join(dir, "go.mod"), "module example.com/foo\n")
+	mustWrite(t, filepath.Join(dir, "main.go"), "package main\n")
+	// Synthesise a vendor dir with two more .go files.
+	vendorDir := filepath.Join(dir, "vendor", "github.com", "x", "y")
+	if err := os.MkdirAll(vendorDir, 0o755); err != nil {
+		t.Fatalf("mkdir vendor: %v", err)
+	}
+	mustWrite(t, filepath.Join(vendorDir, "a.go"), "package y\n")
+	mustWrite(t, filepath.Join(vendorDir, "b.go"), "package y\n")
+
+	ctx, cs := newSession(t)
+
+	// Baseline: prune_build_artefacts=false counts all 3 Go files.
+	resAll, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "stats",
+		Arguments: StatsInput{
+			Dir:     dir,
+			Expr:    "is_source && language == \"go\"",
+			GroupBy: "language",
+		},
+	})
+	if err != nil {
+		t.Fatalf("baseline CallTool: %v", err)
+	}
+	var outAll StatsOutput
+	mustDecodeStructured(t, resAll, &outAll)
+	var allGo int64
+	for _, b := range outAll.Groups {
+		if b.Name == "go" {
+			allGo = b.Count
+		}
+	}
+	if allGo != 3 {
+		t.Fatalf("baseline go count = %d, want 3 (main.go + 2 vendored)", allGo)
+	}
+
+	// With prune_build_artefacts=true the vendor subtree is pruned;
+	// only main.go survives.
+	resPruned, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "stats",
+		Arguments: StatsInput{
+			Dir:                 dir,
+			Expr:                "is_source && language == \"go\"",
+			GroupBy:             "language",
+			PruneBuildArtefacts: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("pruned CallTool: %v", err)
+	}
+	var outPruned StatsOutput
+	mustDecodeStructured(t, resPruned, &outPruned)
+	var prunedGo int64
+	for _, b := range outPruned.Groups {
+		if b.Name == "go" {
+			prunedGo = b.Count
+		}
+	}
+	if prunedGo != 1 {
+		t.Errorf("pruned go count = %d, want 1 (vendor pruned)", prunedGo)
+	}
+}

--- a/internal/mcpserver/stats_tool.go
+++ b/internal/mcpserver/stats_tool.go
@@ -22,8 +22,9 @@ type StatsInput struct {
 	TimeoutSeconds   *float64 `json:"timeout_seconds,omitempty" jsonschema:"Override the server's default per-call timeout. Same semantics as the search tool: positive = seconds, 0 = no timeout, omitted = server default. On timeout the partial histogram is returned with cancelled=true."`
 	Excludes         []string `json:"excludes,omitempty" jsonschema:"Glob patterns matched against file/dir basenames; matches are pruned. Same as the search tool."`
 	RespectGitignore bool     `json:"respect_gitignore,omitempty" jsonschema:"When true, parse a .gitignore at the walk root and skip matching paths."`
-	FollowSymlinks   bool     `json:"follow_symlinks,omitempty" jsonschema:"When true, descend through symbolic links to directories. Off by default; symlinks-to-dirs surface as is_symlink=true leaf entries."`
-	GroupBy          string   `json:"group_by,omitempty" jsonschema:"Bucket key. Default 'content_type'. Recognised: content_type, ext, dir, language, camera_make, camera_model, lens, artist, album, genre, kernel, binary_format, binary_type, frontmatter_format. Unknown values fall back to content_type. Use group_by=ext to histogram by file extension, group_by=language to count source files per language, group_by=camera_make to bucket photos by camera, etc."`
+	FollowSymlinks      bool     `json:"follow_symlinks,omitempty" jsonschema:"When true, descend through symbolic links to directories. Off by default; symlinks-to-dirs surface as is_symlink=true leaf entries."`
+	PruneBuildArtefacts bool     `json:"prune_build_artefacts,omitempty" jsonschema:"When true, pre-walks each root to discover project subdirectories and prunes the canonical build-artefact basenames for every detected project type — vendor (Go), node_modules (Node), target (Rust / Java Maven), __pycache__/.venv/.tox (Python), bin/obj (.NET), .terraform (Terraform), etc. Unioned with 'excludes'. Saves the boilerplate exclude list when running stats over monorepos or large multi-project trees. Opt-in: pre-walk I/O is proportional to tree size. Parity with the search / find_matches / find_near_duplicates tools. Issue #277."`
+	GroupBy             string   `json:"group_by,omitempty" jsonschema:"Bucket key. Default 'content_type'. Recognised: content_type, ext, dir, language, camera_make, camera_model, lens, artist, album, genre, kernel, binary_format, binary_type, frontmatter_format. Unknown values fall back to content_type. Use group_by=ext to histogram by file extension, group_by=language to count source files per language, group_by=camera_make to bucket photos by camera, etc."`
 }
 
 // StatsOutput is the structured output of the `stats` tool — a
@@ -96,16 +97,17 @@ func (h *handlers) statsHandler(ctx context.Context, _ *mcp.CallToolRequest, in 
 
 	start := time.Now()
 	stats, err := search.ComputeStats(ctx, search.Options{
-		Root:             dir,
-		Roots:            dirs,
-		Expr:             expr,
-		Workers:          in.Workers,
-		MaxLineBytes:     in.MaxLineBytes,
-		Index:            h.idx,
-		Excludes:         in.Excludes,
-		RespectGitignore: in.RespectGitignore,
-		FollowSymlinks:   in.FollowSymlinks,
-		GroupBy:          in.GroupBy,
+		Root:                dir,
+		Roots:               dirs,
+		Expr:                expr,
+		Workers:             in.Workers,
+		MaxLineBytes:        in.MaxLineBytes,
+		Index:               h.idx,
+		Excludes:            in.Excludes,
+		RespectGitignore:    in.RespectGitignore,
+		FollowSymlinks:      in.FollowSymlinks,
+		PruneBuildArtefacts: in.PruneBuildArtefacts,
+		GroupBy:             in.GroupBy,
 	}, content.DefaultRegistry())
 	elapsed := time.Since(start).Seconds()
 


### PR DESCRIPTION
Closes #277.

## Summary

Parity fix: \`search\`, \`find_matches\`, and \`find_near_duplicates\` all accept \`prune_build_artefacts\`, but \`stats\` rejected it as an unknown field. Dogfooding surfaced this when a stats over a Go monorepo needed the same vendor / node_modules / target / __pycache__ / .terraform pruning the other tools already do.

## Change

One-line plumbing: add the input field, thread it through to the \`search.Options\` literal. The walker already honours the flag — no changes needed downstream.

## Test plan

- [x] \`go test -race -timeout 180s ./...\` — all green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` idempotent
- [x] New \`TestStatsTool_PruneBuildArtefacts\`: vendored Go module with 3 .go files (main.go + 2 vendored). Baseline returns 3; \`prune_build_artefacts=true\` returns 1 (vendor pruned via the project-type detector's build-artefact list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)