### PR TITLE
fix(search): functions + type_names projectable via fields

### DIFF
--- a/internal/search/match.go
+++ b/internal/search/match.go
@@ -507,6 +507,22 @@ type Match struct {
 	// via `fields: ["imports"]`, and answer "who depends on X?".
 	Imports []string `json:"imports,omitempty"`
 
+	// Functions lists the top-level + nested function / method names
+	// declared in this source file. Populated by the same per-language
+	// extractor pass that populates Imports — source/go (via go/ast,
+	// includes receiver-bound methods as bare names) and source/python +
+	// source/java + source/csharp + source/php + source/perl +
+	// source/r + source/matlab (regex). Surfaces the CEL `functions`
+	// variable in the wire format so `fields: ["functions"]` works.
+	// Issue #278.
+	Functions []string `json:"functions,omitempty"`
+
+	// TypeNames lists the top-level + nested type / class / interface /
+	// enum / record names declared in this source file. Renamed in CEL
+	// from `types` to avoid a CEL-keyword collision. Populated by the
+	// same per-language extractor as Functions / Imports. Issue #278.
+	TypeNames []string `json:"type_names,omitempty"`
+
 	CellCount         int64  `json:"cell_count,omitempty"`
 	CodeCellCount     int64  `json:"code_cell_count,omitempty"`
 	MarkdownCellCount int64  `json:"markdown_cell_count,omitempty"`

--- a/internal/search/match_from.go
+++ b/internal/search/match_from.go
@@ -392,12 +392,20 @@ func applyEmailSourceAttrs(m *Match, a *celexpr.FileAttributes) {
 	if v, ok := a.Extra["blank_loc"].(int64); ok {
 		m.BlankLOC = v
 	}
-	// imports lives on Extra as []string from the per-language
-	// extractors in internal/content/source_symbols_*.go. Surfacing
-	// to the typed Match field unblocks fields: ["imports"] projection
-	// and gets the dependency list into the wire response. #275.
+	// imports / functions / type_names all live on Extra as []string
+	// from the per-language extractors in
+	// internal/content/source_symbols_*.go. Surfacing each to a typed
+	// Match field unblocks fields: ["imports"|"functions"|"type_names"]
+	// projection and gets the lists into the wire response.
+	// #275 (imports), #278 (functions + type_names).
 	if v, ok := a.Extra["imports"].([]string); ok {
 		m.Imports = v
+	}
+	if v, ok := a.Extra["functions"].([]string); ok {
+		m.Functions = v
+	}
+	if v, ok := a.Extra["type_names"].([]string); ok {
+		m.TypeNames = v
 	}
 	if v, ok := a.Extra["cell_count"].(int64); ok {
 		m.CellCount = v

--- a/internal/search/match_project_test.go
+++ b/internal/search/match_project_test.go
@@ -171,3 +171,37 @@ func TestProjectMatch_Imports_Preserved(t *testing.T) {
 		t.Errorf("projection NOT including imports should zero it; got %+v", dropped.Imports)
 	}
 }
+
+// TestValidateFields_FunctionsAndTypeNamesAccepted is the #278
+// regression guard: the symbol-extractor outputs land in `functions`
+// and `type_names`, both must be accepted as projection field names.
+func TestValidateFields_FunctionsAndTypeNamesAccepted(t *testing.T) {
+	if err := search.ValidateFields([]string{"path", "functions", "type_names"}); err != nil {
+		t.Errorf("functions / type_names should be valid projection fields: %v", err)
+	}
+}
+
+// TestProjectMatch_FunctionsAndTypeNames_Preserved confirms projection
+// keeps the typed source-symbol fields when requested, zeroes when not.
+func TestProjectMatch_FunctionsAndTypeNames_Preserved(t *testing.T) {
+	m := search.Match{
+		Path:        "/a.go",
+		ContentType: "source/go",
+		Functions:   []string{"NewClient", "Close"},
+		TypeNames:   []string{"Client", "Config"},
+	}
+	kept := search.ProjectMatch(m, []string{"functions", "type_names"})
+	if len(kept.Functions) != 2 {
+		t.Errorf("projection keeping functions lost it: %+v", kept.Functions)
+	}
+	if len(kept.TypeNames) != 2 {
+		t.Errorf("projection keeping type_names lost it: %+v", kept.TypeNames)
+	}
+	dropped := search.ProjectMatch(m, []string{"title"})
+	if len(dropped.Functions) != 0 {
+		t.Errorf("projection NOT including functions should zero it; got %+v", dropped.Functions)
+	}
+	if len(dropped.TypeNames) != 0 {
+		t.Errorf("projection NOT including type_names should zero it; got %+v", dropped.TypeNames)
+	}
+}


### PR DESCRIPTION
Closes #278.

## Summary

Companion to #275 (which surfaced \`imports\` on \`Match\`). The dogfood that filed #278 called the missing fields \`symbols\` — the actual CEL variables are \`functions\` and \`type_names\` (renamed from plain \`types\` to avoid the CEL-keyword collision).

This PR adds \`Functions\` and \`TypeNames\` typed fields to \`search.Match\` and wires \`Extra[\"functions\"]\` / \`Extra[\"type_names\"]\` → typed copies in \`MatchFrom\`. After this, \`fields: [\"path\", \"functions\", \"type_names\"]\` validates + projects correctly, and the JSON / MCP search response carries the lists for any source file that has them populated.

## Dogfood

\`\`\`
$ /tmp/fso 'is_source && language == \"go\" && functions.size() > 3' --output json --limit 1
{
  \"path\":\"...\",\"language\":\"go\",\"loc\":90,
  \"imports\":[\"encoding/json\",\"path/filepath\",\"strings\",\"testing\"],
  \"functions\":[\"TestDuplicatesCmd_Run_FindsSha256Duplicates\",\"...\"]
}
\`\`\`

## Test plan

- [x] \`go test -race -timeout 180s ./...\` — all green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` idempotent
- [x] 2 new tests: \`ValidateFields\` accepts \`functions\` and \`type_names\`; \`ProjectMatch\` preserves / zeroes them based on the projection list (mirroring the #275 \`imports\` test)
- [x] Manual dogfood confirms \`functions\` lands in JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)