### PR TITLE
feat(near_duplicates): members_limit_per_group + group_limit

### DIFF
--- a/cmd/file-search-on/near_duplicates_cmd.go
+++ b/cmd/file-search-on/near_duplicates_cmd.go
@@ -26,6 +26,8 @@ type NearDuplicatesCmd struct {
 	RespectGitignore bool          `name:"respect-gitignore" help:"Parse a .gitignore at each walk root and skip matching paths."`
 	FollowSymlinks   bool          `name:"follow-symlinks" help:"Descend through symbolic links to directories. Off by default."`
 	MinSize          int64         `name:"min-size" default:"0" help:"Skip files smaller than this many bytes (on-disk size, not extracted body)."`
+	MembersLimit     int           `name:"members-limit" default:"0" help:"Cap the per-group members list to this many entries. 0 (default) returns every member. Truncated groups stamp members_total + members_truncated in JSON output. Members are kept similarity-desc so the survivors are the strongest matches. Issue #279."`
+	GroupLimit       int           `name:"group-limit" default:"0" help:"Cap the number of groups returned. 0 (default) returns every group. Groups are sorted by member count desc / representative size desc before truncation. Issue #279."`
 	Output           string        `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table (default; human-readable) | json (machine-readable)."`
 }
 
@@ -61,6 +63,8 @@ func (n *NearDuplicatesCmd) Run(ctx context.Context) error {
 		FollowSymlinks:      n.FollowSymlinks,
 		MinSize:             n.MinSize,
 		SimilarityThreshold: n.Threshold,
+		NearDupMembersLimit: n.MembersLimit,
+		NearDupGroupLimit:   n.GroupLimit,
 	}, contentpkg.DefaultRegistry())
 
 	if dups != nil {

--- a/internal/mcpserver/find_near_duplicates_tool.go
+++ b/internal/mcpserver/find_near_duplicates_tool.go
@@ -26,7 +26,9 @@ type FindNearDuplicatesInput struct {
 	Excludes         []string `json:"excludes,omitempty" jsonschema:"Glob patterns matched against file/dir basenames; matches are pruned."`
 	RespectGitignore bool     `json:"respect_gitignore,omitempty" jsonschema:"When true, parse a .gitignore at each walk root and skip matching paths."`
 	FollowSymlinks   bool     `json:"follow_symlinks,omitempty" jsonschema:"When true, descend through symbolic links to directories. Off by default."`
-	MinSize          int64    `json:"min_size,omitempty" jsonschema:"Skip files smaller than this many bytes (on-disk size, not extracted body)."`
+	MinSize              int64 `json:"min_size,omitempty" jsonschema:"Skip files smaller than this many bytes (on-disk size, not extracted body)."`
+	MembersLimitPerGroup int   `json:"members_limit_per_group,omitempty" jsonschema:"Cap the per-group members list to this many entries. 0 (default) returns every member. Members are sorted by similarity descending before truncation so the survivors are the strongest matches. When a group is truncated, members_total + members_truncated are stamped on the group so the caller knows there's more to drill into. Useful for triage queries that just want a top-N preview per cluster. Issue #279."`
+	GroupLimit           int   `json:"group_limit,omitempty" jsonschema:"Cap the number of groups returned. 0 (default) returns every group. Groups are sorted by member count desc / representative size desc before truncation, so the largest / most-interesting clusters are kept. Pair with members_limit_per_group for bounded responses on huge corpora. Issue #279."`
 }
 
 // FindNearDuplicatesOutput mirrors search.NearDuplicates with a
@@ -44,12 +46,18 @@ type FindNearDuplicatesOutput struct {
 }
 
 // NearDuplicateGroupWire is one group on the wire. Members are
-// sorted similarity-desc so the representative leads.
+// sorted similarity-desc so the representative leads. When the
+// caller passed members_limit_per_group AND the group had more
+// members, MembersTotal carries the pre-truncation count and
+// MembersTruncated is true — the caller can drill in via a fresh
+// call against the representative if needed. Issue #279.
 type NearDuplicateGroupWire struct {
-	Representative string                    `json:"representative"`
-	Fingerprint    string                    `json:"fingerprint"`
-	Count          int                       `json:"count"`
-	Members        []NearDuplicateMemberWire `json:"members"`
+	Representative   string                    `json:"representative"`
+	Fingerprint      string                    `json:"fingerprint"`
+	Count            int                       `json:"count"`
+	Members          []NearDuplicateMemberWire `json:"members"`
+	MembersTotal     int                       `json:"members_total,omitempty"`
+	MembersTruncated bool                      `json:"members_truncated,omitempty"`
 }
 
 // NearDuplicateMemberWire is one file inside a near-duplicate group.
@@ -103,6 +111,8 @@ func (h *handlers) findNearDuplicatesHandler(ctx context.Context, _ *mcp.CallToo
 		FollowSymlinks:      in.FollowSymlinks,
 		MinSize:             in.MinSize,
 		SimilarityThreshold: in.Threshold,
+		NearDupMembersLimit: in.MembersLimitPerGroup,
+		NearDupGroupLimit:   in.GroupLimit,
 	}, content.DefaultRegistry())
 	elapsed := time.Since(start).Seconds()
 
@@ -129,10 +139,12 @@ func (h *handlers) findNearDuplicatesHandler(ctx context.Context, _ *mcp.CallToo
 				}
 			}
 			out.Groups[i] = NearDuplicateGroupWire{
-				Representative: g.Representative,
-				Fingerprint:    g.Fingerprint,
-				Count:          g.Count,
-				Members:        members,
+				Representative:   g.Representative,
+				Fingerprint:      g.Fingerprint,
+				Count:            g.Count,
+				Members:          members,
+				MembersTotal:     g.MembersTotal,
+				MembersTruncated: g.MembersTruncated,
 			}
 		}
 	}

--- a/internal/search/near_duplicates.go
+++ b/internal/search/near_duplicates.go
@@ -29,8 +29,21 @@ type NearDuplicateMember struct {
 type NearDuplicateGroup struct {
 	Representative string                `json:"representative"`
 	Fingerprint    string                `json:"fingerprint"`
-	Count          int                   `json:"count"`
-	Members        []NearDuplicateMember `json:"members"`
+	// Count is the FULL membership count for this group — unchanged
+	// by per-group truncation so agents still see the real cluster
+	// size when Members has been capped via NearDupMembersLimit.
+	Count   int                   `json:"count"`
+	Members []NearDuplicateMember `json:"members"`
+	// MembersTotal mirrors Count when Members is unscaled; when the
+	// caller asked for NearDupMembersLimit ≥ 1 and the group had
+	// more members, MembersTotal carries the pre-truncation count so
+	// the caller knows there's more to drill into. Issue #279.
+	MembersTotal int `json:"members_total,omitempty"`
+	// MembersTruncated fires when Members was capped via the
+	// per-group limit input. Distinct from Count > len(Members)
+	// alone because zero-limit (default) leaves Members untouched
+	// and we want the boolean to be unambiguous on the wire.
+	MembersTruncated bool `json:"members_truncated,omitempty"`
 }
 
 // NearDuplicates is the aggregate result of FindNearDuplicates.
@@ -139,6 +152,7 @@ func FindNearDuplicates(ctx context.Context, opts Options, registry *content.Reg
 	if len(candidates) >= 2 {
 		out.Groups = groupNearDuplicates(candidates, threshold)
 		out.GroupCount = int64(len(out.Groups))
+		applyNearDupCaps(&out.Groups, opts.NearDupMembersLimit, opts.NearDupGroupLimit)
 	}
 
 	out.Cancelled, out.CancellationReason = classifyCancellation(walkErr, ctx)
@@ -345,4 +359,37 @@ func classifyCancellation(walkErr error, ctx context.Context) (bool, string) {
 		return true, "client_cancel"
 	}
 	return false, ""
+}
+
+// applyNearDupCaps applies the per-group member cap and the top-N
+// group cap requested by the caller. Mutates *groups in place because
+// the slice is a fresh allocation owned by FindNearDuplicates — no
+// aliasing risk.
+//
+// Member-cap semantics: when memberLimit > 0 AND a group has more
+// members than the cap, keep the first memberLimit (groupNearDuplicates
+// already sorts by similarity descending, so the survivors are the
+// strongest matches) and stamp MembersTotal + MembersTruncated. When
+// memberLimit ≤ 0 the cap is disabled and groups are returned
+// unchanged.
+//
+// Group-cap semantics: when groupLimit > 0 AND there are more groups
+// than the cap, truncate to the first groupLimit. groupNearDuplicates
+// already sorts groups by member count desc / representative size
+// desc so the kept groups are the largest / most-interesting clusters.
+// Issue #279.
+func applyNearDupCaps(groups *[]NearDuplicateGroup, memberLimit, groupLimit int) {
+	if memberLimit > 0 {
+		for i := range *groups {
+			g := &(*groups)[i]
+			if len(g.Members) > memberLimit {
+				g.MembersTotal = len(g.Members)
+				g.MembersTruncated = true
+				g.Members = g.Members[:memberLimit]
+			}
+		}
+	}
+	if groupLimit > 0 && len(*groups) > groupLimit {
+		*groups = (*groups)[:groupLimit]
+	}
 }

--- a/internal/search/near_duplicates_pagination_test.go
+++ b/internal/search/near_duplicates_pagination_test.go
@@ -1,0 +1,132 @@
+package search_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// seedNearDupGroup writes N markdown files with a 1-token-edit between
+// each so the SimHash similarity comfortably exceeds 0.85 (the prose
+// default). Returns the tmpdir path.
+func seedNearDupGroup(t *testing.T, n int) string {
+	t.Helper()
+	dir := t.TempDir()
+	base := strings.Repeat("The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. ", 60)
+	for i := range n {
+		// Each variant changes a small fraction of the text — enough to keep similarity high.
+		body := strings.Replace(base, "lazy", "sleepy", i+1)
+		if err := os.WriteFile(filepath.Join(dir, "file"+string(rune('a'+i))+".md"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	return dir
+}
+
+func TestFindNearDuplicates_MembersLimitPerGroup_Truncates(t *testing.T) {
+	dir := seedNearDupGroup(t, 6)
+	res, err := search.FindNearDuplicates(context.Background(), search.Options{
+		Root:                dir,
+		Expr:                `is_markdown`,
+		Workers:             1,
+		NearDupMembersLimit: 3,
+	}, content.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("FindNearDuplicates: %v", err)
+	}
+	if len(res.Groups) == 0 {
+		t.Fatal("expected at least one near-dup group")
+	}
+	g := res.Groups[0]
+	if len(g.Members) != 3 {
+		t.Errorf("Members size = %d, want 3", len(g.Members))
+	}
+	if g.MembersTotal != 6 {
+		t.Errorf("MembersTotal = %d, want 6", g.MembersTotal)
+	}
+	if !g.MembersTruncated {
+		t.Errorf("MembersTruncated should be true")
+	}
+	// Count carries the FULL group size, not the truncated Members length.
+	if g.Count != 6 {
+		t.Errorf("Count = %d, want 6 (unchanged by truncation)", g.Count)
+	}
+}
+
+func TestFindNearDuplicates_NoLimitLeavesGroupAsIs(t *testing.T) {
+	dir := seedNearDupGroup(t, 4)
+	res, err := search.FindNearDuplicates(context.Background(), search.Options{
+		Root:    dir,
+		Expr:    `is_markdown`,
+		Workers: 1,
+		// NearDupMembersLimit: 0 (default) → no truncation
+	}, content.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("FindNearDuplicates: %v", err)
+	}
+	if len(res.Groups) == 0 {
+		t.Fatal("expected at least one near-dup group")
+	}
+	g := res.Groups[0]
+	if g.MembersTruncated {
+		t.Errorf("MembersTruncated should be false when no cap was requested")
+	}
+	if g.MembersTotal != 0 {
+		t.Errorf("MembersTotal should be 0 when no cap was requested; got %d", g.MembersTotal)
+	}
+}
+
+func TestFindNearDuplicates_GroupLimit_CapsSlice(t *testing.T) {
+	// Two separate near-dup clusters.
+	dir := t.TempDir()
+	cluster1 := strings.Repeat("The quick brown fox jumps over the lazy dog. Pack my box with five dozen liquor jugs. ", 60)
+	cluster2 := strings.Repeat("Photosynthesis converts light into chemical energy via chlorophyll capturing photons. ", 60)
+	for i, body := range []string{cluster1, strings.Replace(cluster1, "lazy", "sleepy", 1), strings.Replace(cluster1, "fox", "cat", 1)} {
+		_ = i
+		if err := os.WriteFile(filepath.Join(dir, "c1_"+string(rune('a'+i))+".md"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	for i, body := range []string{cluster2, strings.Replace(cluster2, "chlorophyll", "carotenoid", 1)} {
+		_ = i
+		if err := os.WriteFile(filepath.Join(dir, "c2_"+string(rune('a'+i))+".md"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	// Without group limit — both clusters appear.
+	all, err := search.FindNearDuplicates(context.Background(), search.Options{
+		Root:    dir,
+		Expr:    `is_markdown`,
+		Workers: 1,
+	}, content.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("FindNearDuplicates: %v", err)
+	}
+	if len(all.Groups) < 2 {
+		t.Skipf("test environment didn't produce 2 distinct clusters; got %d", len(all.Groups))
+	}
+
+	// With group limit=1, only the largest cluster survives.
+	capped, err := search.FindNearDuplicates(context.Background(), search.Options{
+		Root:              dir,
+		Expr:              `is_markdown`,
+		Workers:           1,
+		NearDupGroupLimit: 1,
+	}, content.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("FindNearDuplicates capped: %v", err)
+	}
+	if len(capped.Groups) != 1 {
+		t.Errorf("Groups size = %d, want 1 (capped)", len(capped.Groups))
+	}
+	// GroupCount reports the unbounded original count.
+	if capped.GroupCount < 2 {
+		t.Errorf("GroupCount = %d, want >=2 (unchanged by truncation)", capped.GroupCount)
+	}
+}

--- a/internal/search/walker.go
+++ b/internal/search/walker.go
@@ -276,6 +276,20 @@ type Options struct {
 	// Walk path.
 	SimilarityThreshold float64
 
+	// NearDupMembersLimit caps the per-group members slice returned
+	// by FindNearDuplicates. 0 (default) returns every member. When
+	// truncated, the group reports MembersTotal + MembersTruncated
+	// so the caller knows there's more to drill into. Members are
+	// sorted by similarity descending before truncation so the
+	// survivors are the strongest matches. Issue #279.
+	NearDupMembersLimit int
+
+	// NearDupGroupLimit caps the number of groups returned by
+	// FindNearDuplicates. 0 (default) returns every group. Groups
+	// are sorted by member count desc / representative size desc
+	// before truncation. Issue #279.
+	NearDupGroupLimit int
+
 	// GroupBy controls the bucketing key used by ComputeStats. See
 	// stats.go ValidGroupBys for the recognised set. Ignored by
 	// Walk/WalkStream — it only affects ComputeStats's aggregation.


### PR DESCRIPTION
Closes #279.

## Summary

\`find_near_duplicates\` returns full group membership inline. After #274 cut the false-positive cluster sizes, groups are smaller but still unbounded — a 5-member cluster dumps 5 paths + similarities even when the caller just wants triage. Adds two pagination knobs:

| Input | Effect |
|---|---|
| \`members_limit_per_group\` | Cap the per-group members slice. Truncated groups stamp \`members_total\` + \`members_truncated\` so callers know there's more to drill into. \`Count\` still reports the full cluster size. |
| \`group_limit\` | Cap the number of groups returned. \`GroupCount\` still reports the unbounded original count (mirrors #273's section pagination). |

Both default \`0\` = today's behaviour (no truncation). Members are sorted similarity-desc before per-group truncation so the survivors are the strongest matches. Groups are sorted by member count desc / representative size desc before the group cap, so the largest / most-interesting clusters are kept.

## Dogfood

\`\`\`
$ /tmp/fso near-duplicates 'is_source && !is_test_file' \\
    --members-limit 2 --output json
{
  ...
  \"groups\": [
    {
      \"representative\": \"internal/gitmeta/gitmeta.go\",
      \"count\": 5,
      \"members\": [...top 2 by similarity...],
      \"members_total\": 5,
      \"members_truncated\": true
    },
    ...
  ]
}
\`\`\`

## Test plan

- [x] \`go test -race -timeout 180s ./...\` — all green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` idempotent
- [x] 3 new tests: 6-member group truncated to 3 (asserts \`members_total=6\`, \`members_truncated=true\`, \`Count=6\` unchanged); no-limit leaves group as-is; group_limit caps the slice while \`GroupCount\` reports the unbounded original count
- [x] Manual dogfood on this repo confirms the wire shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)