### PR TITLE
fix(presets): failed_tests filters to comment-line annotations

### DIFF
--- a/internal/search/presets.go
+++ b/internal/search/presets.go
@@ -132,10 +132,24 @@ var presets = []Preset{
 	},
 	{
 		Name:        "failed_tests",
-		Description: "Source-code test files mentioning FAIL / FIXME / XXX in the body — code-review prompt.",
+		Description: "Source-code test files with FAIL / FIXME / XXX / TODO in COMMENTS — code-review prompt.",
 		Build: func() PresetOptions {
+			// Issue #280: the original `body.matches("FAIL|FIXME|XXX")`
+			// fired on every test-fixture string literal containing
+			// those tokens (the headline #2 dogfood pain). Anchor the
+			// match on a line that BEGINS with a common comment
+			// marker (// for C-family, # for hash-family, -- for
+			// Lua/SQL/Haskell, ; for Clojure/asm) followed by the
+			// keyword. Uses RE2's (?m) flag so `^` matches each
+			// line boundary against the full file body.
+			//
+			// Mixed-content lines like `assert(x == 1) // FIXME` are
+			// NOT picked up — same shape as find_matches's
+			// match_in=comments (issue #272). Acceptable: the
+			// targeted reviewer signal is "comment-line annotation",
+			// not trailing inline comments.
 			return PresetOptions{
-				Expr:        `is_source && is_test_file && body.matches("FAIL|FIXME|XXX")`,
+				Expr:        `is_source && is_test_file && body.matches("(?m)^\\s*(//|#|--|;)\\s*\\b(FAIL|FIXME|XXX|TODO)\\b")`,
 				IncludeBody: true,
 			}
 		},

--- a/internal/search/presets_test.go
+++ b/internal/search/presets_test.go
@@ -100,3 +100,69 @@ func TestPresets_TimeRelativeExpressionsBakeNow(t *testing.T) {
 		t.Fatalf("recent_changes expr doesn't include a timestamp literal: %s", first.Expr)
 	}
 }
+
+// TestPreset_FailedTests_OnlyFiresOnCommentLines is the #280
+// regression guard: the preset's body.matches() pattern must NOT fire
+// on raw-content occurrences of FIXME / XXX / FAIL / TODO (test
+// fixtures, string literals, fuzz seeds). Drives the actual CEL
+// expression baked into the preset rather than re-implementing it.
+func TestPreset_FailedTests_OnlyFiresOnCommentLines(t *testing.T) {
+	p := search.PresetByName("failed_tests")
+	if p == nil {
+		t.Fatal("failed_tests preset missing")
+	}
+	opts := p.Build()
+	ev, err := celexpr.New(opts.Expr)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	// Helper to build the attrs payload the evaluator wants. Only
+	// the four fields the failed_tests filter touches are populated;
+	// everything else stays at zero.
+	type fixture struct {
+		name        string
+		body        string
+		wantMatched bool
+	}
+	for _, fx := range []fixture{
+		// REAL comment annotations — should fire.
+		{"go line comment FIXME", "// FIXME: rewrite this\npackage foo\n", true},
+		{"indented go FIXME", "    // FIXME: indented\n", true},
+		{"python comment XXX", "# XXX needs proper test\n", true},
+		{"shell comment TODO", "# TODO: handle eof\n", true},
+		{"lua comment FAIL", "-- FAIL expected\n", true},
+		{"clojure comment FIXME", "; FIXME later\n", true},
+
+		// NOISE — should NOT fire under the comment-only preset.
+		{"string literal containing FIXME", `package foo
+var marker = "FIXME: this is data"
+`, false},
+		{"test fixture line", `mustWrite(t, p, "// FIXME inside string")`, false},
+		{"identifier substring", "func FailTestRunner() {}\n", false},
+		{"trailing comment after code", "assert(x == 1) // FIXME later\n", false},
+		{"FIXME word in normal prose", "// This package fixes the missing case (see issue).\n", false},
+
+		// Edge: bare FIXME with no comment prefix at all.
+		{"bare FIXME on its own line", "FIXME\n", false},
+	} {
+		t.Run(fx.name, func(t *testing.T) {
+			attrs := &celexpr.FileAttributes{
+				ContentType: "source/go",
+				IsSource:    true,
+				Extra: map[string]any{
+					"body":         fx.body,
+					"language":     "go",
+					"is_test_file": true,
+				},
+			}
+			matched, err := ev.Evaluate(attrs)
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if matched != fx.wantMatched {
+				t.Errorf("body %q: got matched=%v, want %v", fx.body, matched, fx.wantMatched)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #280.

## Summary

The original \`failed_tests\` preset (\`body.matches(\"FAIL|FIXME|XXX\")\`) fired on every test-fixture string literal containing those tokens — the headline #2 dogfood noise. Rewrite the regex with RE2's \`(?m)\` flag so it anchors on lines that START with a comment marker:

\`\`\`re2
(?m)^\\s*(//|#|--|;)\\s*\\b(FAIL|FIXME|XXX|TODO)\\b
\`\`\`

Covers // (C-family), # (hash-family), -- (Lua/SQL/Haskell), ; (Clojure/asm) — the languages where the preset would realistically fire. Same line-granular contract as find_matches's match_in=comments from #272: mixed-content lines like \`assert(x == 1) // FIXME\` are NOT picked up, but the targeted signal is comment-line annotations, not trailing inline comments.

Description updated to advertise the new \"in COMMENTS\" semantics. TODO added to the keyword set per the original issue.

## Dogfood

Before: lots of test files with FIXME/XXX/FAIL anywhere in their content (incl. string literals + identifiers + prose) — noise-heavy.

After (on this repo): **1 match** — a #272 fixture whose Go raw-string starts with \`// TODO ...\`. That's the documented line-granular limit (raw-string content read as plain text has \"comment-shaped\" lines); acceptable tail for the precision gain.

## Test plan

- [x] \`go test -race -timeout 180s ./...\` — all green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` idempotent
- [x] Existing \`TestPresets_AllCompile\` covers the regex compiles cleanly
- [x] New \`TestPreset_FailedTests_OnlyFiresOnCommentLines\` — 11 sub-cases:
  - Real comment annotations FIRE: Go //, indented Go, Python #, shell #, Lua --, Clojure ;
  - Noise DROPS: string literals containing FIXME, test fixture lines with embedded //, identifier substrings, trailing comments after code, prose mentions, bare FIXME-on-own-line

Why a regex change instead of full \`match_in: \"comments\"\` integration: the preset framework returns FILES (search-shaped), not LINE MATCHES (find_matches-shaped). Adopting \`match_in\` would require a new preset shape. Anchoring the regex with \`(?m)^\\s*<comment-marker>\` is the cheaper fix that ships #2's value without the framework churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)