### PR TITLE
feat(mcp): validate_expr tool

### DIFF
--- a/internal/celexpr/validate.go
+++ b/internal/celexpr/validate.go
@@ -1,0 +1,197 @@
+package celexpr
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// ValidationResult is what ValidateExpr returns. OK reports whether
+// the expression compiles; on failure, Error carries the cel-go
+// message and (when the failure is an unknown-identifier) Suggestion
+// carries a "did you mean 'X'?" hint computed by levenshtein against
+// the known CEL surface (all declared variables + all built-in
+// functions). ReferencedVariables / ReferencedFunctions are populated
+// regardless of OK — the agent gets to see which names the expression
+// REFERENCED (even if it didn't compile) so they can correlate against
+// the schema. Issue #282.
+type ValidationResult struct {
+	OK                  bool
+	Error               string
+	ReferencedVariables []string
+	ReferencedFunctions []string
+	Suggestion          string
+}
+
+// ValidateExpr compiles expr through the same env New uses (so every
+// declared CEL variable + every built-in function is in scope) and
+// returns a structured validation outcome. No program is built — this
+// is the pure compile-time check, an order of magnitude cheaper than
+// a full search call.
+//
+// Used by the MCP validate_expr tool so agents can iterate on CEL
+// without paying a walk's cost on every typo. Issue #282.
+func ValidateExpr(expr string) ValidationResult {
+	res := ValidationResult{}
+
+	// Reference extraction runs independently of compile success — we
+	// want to populate the lists even when the expression has typos.
+	// Strip string literals first so a `body.contains("size")` doesn't
+	// falsely surface "size" as a referenced variable.
+	stripped := stripCELStringLiterals(expr)
+	known := knownNames()
+	idents := extractIdentifiers(stripped)
+	for _, name := range idents {
+		switch known[name] {
+		case nameKindVar:
+			res.ReferencedVariables = append(res.ReferencedVariables, name)
+		case nameKindFunc:
+			res.ReferencedFunctions = append(res.ReferencedFunctions, name)
+		}
+	}
+	sort.Strings(res.ReferencedVariables)
+	sort.Strings(res.ReferencedFunctions)
+
+	// Compile via the same path New() uses. New returns a wrapped
+	// error on compile failure; on success we still pay the env build
+	// cost but skip the env.Program step entirely. The trade is one
+	// extra env construction per validate call — fine for a CLI/MCP
+	// validate tool that isn't on a hot path.
+	_, err := New(expr)
+	if err == nil {
+		res.OK = true
+		return res
+	}
+	res.Error = err.Error()
+	if unknown := extractUnknownIdentifier(res.Error); unknown != "" {
+		res.Suggestion = closestKnownName(unknown, known)
+	}
+	return res
+}
+
+// nameKind tags an identifier as a declared CEL variable or a
+// registered function, to support partitioning during reference
+// extraction.
+type nameKind uint8
+
+const (
+	nameKindUnknown nameKind = iota
+	nameKindVar
+	nameKindFunc
+)
+
+// knownNames returns the union of every declared variable + every
+// registered function, mapped to its kind. Built fresh per call —
+// this is invoked only inside ValidateExpr (not a hot path).
+func knownNames() map[string]nameKind {
+	schema := Schema()
+	out := make(map[string]nameKind, len(schema.Common)+len(schema.TypeSpecific)+len(schema.Frontmatter)+len(schema.Functions))
+	for _, a := range schema.Common {
+		out[a.Name] = nameKindVar
+	}
+	for _, a := range schema.TypeSpecific {
+		out[a.Name] = nameKindVar
+	}
+	for _, a := range schema.Frontmatter {
+		out[a.Name] = nameKindVar
+	}
+	for _, f := range schema.Functions {
+		out[f.Name] = nameKindFunc
+	}
+	return out
+}
+
+// reCELIdent matches identifier-shaped tokens (`[A-Za-z_][A-Za-z0-9_]*`).
+// Run against the literal-stripped expression so identifiers inside
+// string literals don't survive as false positives.
+var reCELIdent = regexp.MustCompile(`\b([a-zA-Z_][a-zA-Z0-9_]*)\b`)
+
+func extractIdentifiers(s string) []string {
+	matches := reCELIdent.FindAllStringSubmatch(s, -1)
+	seen := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		seen[m[1]] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	return out
+}
+
+// stripCELStringLiterals zeros out the content of every "..." and
+// '...' literal in expr so identifier extraction doesn't pick up
+// names that happen to appear inside string content (e.g.
+// `body.contains("size")` should NOT count "size" as a referenced
+// variable). Naive: doesn't handle CEL's escape sequences perfectly
+// (`\"` inside a string), but the failure mode is over-inclusion of
+// identifiers — same shape as the body.contains hint in #281.
+func stripCELStringLiterals(expr string) string {
+	var b strings.Builder
+	b.Grow(len(expr))
+	i := 0
+	for i < len(expr) {
+		c := expr[i]
+		if c == '"' || c == '\'' {
+			b.WriteByte(c)
+			quote := c
+			i++
+			for i < len(expr) && expr[i] != quote {
+				// Skip escape sequences without copying.
+				if expr[i] == '\\' && i+1 < len(expr) {
+					i += 2
+					continue
+				}
+				i++
+			}
+			b.WriteByte(quote)
+			if i < len(expr) {
+				i++ // consume closing quote
+			}
+			continue
+		}
+		b.WriteByte(c)
+		i++
+	}
+	return b.String()
+}
+
+// reCELUnknownIdent matches the cel-go error shape for an undeclared
+// reference. cel-go's message reads roughly:
+//
+//	ERROR: <input>:1:42: undeclared reference to 'imprts' (in container '')
+//
+// We capture the bad identifier so closestKnownName can levenshtein-
+// suggest the canonical spelling.
+var reCELUnknownIdent = regexp.MustCompile(`undeclared reference to '([^']+)'`)
+
+func extractUnknownIdentifier(errMsg string) string {
+	m := reCELUnknownIdent.FindStringSubmatch(errMsg)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// closestKnownName returns a "did you mean 'X'?" suggestion when the
+// unknown identifier is within levenshtein distance 2 of a known
+// variable or function. Distance > 2 returns "" — at that point the
+// suggestion is more confusing than helpful.
+func closestKnownName(unknown string, known map[string]nameKind) string {
+	if unknown == "" {
+		return ""
+	}
+	bestDist := 3 // strictly < 3, so distance ≤ 2 wins
+	best := ""
+	for name := range known {
+		d := Levenshtein(unknown, name)
+		if d < bestDist {
+			bestDist = d
+			best = name
+		}
+	}
+	if best == "" {
+		return ""
+	}
+	return "did you mean '" + best + "'?"
+}

--- a/internal/celexpr/validate_test.go
+++ b/internal/celexpr/validate_test.go
@@ -1,0 +1,86 @@
+package celexpr_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+)
+
+func TestValidateExpr_HappyPath(t *testing.T) {
+	res := celexpr.ValidateExpr(`is_source && language == "go" && loc > 100`)
+	if !res.OK {
+		t.Fatalf("expected ok=true, got error: %s", res.Error)
+	}
+	wantVars := []string{"is_source", "language", "loc"}
+	for _, v := range wantVars {
+		if !slices.Contains(res.ReferencedVariables, v) {
+			t.Errorf("ReferencedVariables missing %q; got %v", v, res.ReferencedVariables)
+		}
+	}
+	if len(res.ReferencedFunctions) != 0 {
+		t.Errorf("ReferencedFunctions should be empty for this expr; got %v", res.ReferencedFunctions)
+	}
+}
+
+func TestValidateExpr_TyposReturnError_AndSuggestion(t *testing.T) {
+	res := celexpr.ValidateExpr(`is_source && imprts.size() > 0`)
+	if res.OK {
+		t.Fatal("expected ok=false for typo")
+	}
+	if res.Error == "" {
+		t.Error("expected non-empty Error")
+	}
+	if !strings.Contains(res.Suggestion, "imports") {
+		t.Errorf("expected suggestion to include 'imports'; got %q", res.Suggestion)
+	}
+}
+
+func TestValidateExpr_ReferencedFunctions(t *testing.T) {
+	res := celexpr.ValidateExpr(`is_source && levenshtein(author, "Alice") < 3`)
+	if !res.OK {
+		t.Fatalf("expected ok=true, got: %s", res.Error)
+	}
+	if !slices.Contains(res.ReferencedFunctions, "levenshtein") {
+		t.Errorf("ReferencedFunctions should include levenshtein; got %v", res.ReferencedFunctions)
+	}
+	for _, v := range []string{"is_source", "author"} {
+		if !slices.Contains(res.ReferencedVariables, v) {
+			t.Errorf("ReferencedVariables missing %q; got %v", v, res.ReferencedVariables)
+		}
+	}
+}
+
+func TestValidateExpr_StringLiteralsDontPolluteRefs(t *testing.T) {
+	// "size" appears inside a string literal — it should NOT count
+	// as a referenced variable even though "size" is a real var.
+	res := celexpr.ValidateExpr(`is_source && body.contains("size")`)
+	if !res.OK {
+		t.Fatalf("expected ok=true, got: %s", res.Error)
+	}
+	for _, v := range res.ReferencedVariables {
+		if v == "size" {
+			t.Errorf("size appearing inside string literal should not surface as a ReferencedVariable; got %v", res.ReferencedVariables)
+		}
+	}
+}
+
+func TestValidateExpr_EmptyExprErrors(t *testing.T) {
+	res := celexpr.ValidateExpr("")
+	// cel-go errors on empty expr; that's fine — we just expect not-ok.
+	if res.OK {
+		t.Error("expected ok=false for empty expr")
+	}
+}
+
+func TestValidateExpr_DistantTypoNoSuggestion(t *testing.T) {
+	// Distance > 2 from any known name — no suggestion offered.
+	res := celexpr.ValidateExpr(`is_source && completelyMadeUpThing > 0`)
+	if res.OK {
+		t.Fatal("expected ok=false")
+	}
+	if res.Suggestion != "" {
+		t.Errorf("distant typo should NOT trigger a suggestion; got %q", res.Suggestion)
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -343,6 +343,11 @@ func New(version string, idx index.Index, defaultTimeout time.Duration, embedDef
 	}, instrument(h.metrics, "list_attributes", h.listAttributesHandler))
 
 	mcp.AddTool(s, &mcp.Tool{
+		Name:        "validate_expr",
+		Description: "Validate a CEL expression without running a walk. Compiles via the same env the search tool uses (every declared variable + every built-in function in scope) and returns ok / error / referenced_variables / referenced_functions / suggestion. On compile failure, surfaces the cel-go error message AND (when the failure was an unknown identifier within Levenshtein distance 2 of a known name) a 'did you mean X?' suggestion. The referenced_* lists populate regardless of ok so the caller can correlate against list_attributes even when their typo blocks compilation. Cheap — no file IO, no walk. Use during iterative CEL refinement to avoid burning a search call on every typo. Issue #282.",
+	}, instrument(h.metrics, "validate_expr", h.validateExprHandler))
+
+	mcp.AddTool(s, &mcp.Tool{
 		Name:        "read_attributes",
 		Description: "Extract content-type-specific attributes for a single file path. Use when the agent already knows the path and wants metadata without running a CEL filter or walking a directory. Returns the same Match shape as the search tool — title, author, EXIF, audio tags, video codec, frontmatter, etc., depending on the detected content type.",
 	}, instrument(h.metrics, "read_attributes", h.readAttributesHandler))

--- a/internal/mcpserver/validate_expr_tool.go
+++ b/internal/mcpserver/validate_expr_tool.go
@@ -1,0 +1,42 @@
+package mcpserver
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+)
+
+// ValidateExprInput is the JSON-schema input for the `validate_expr` tool.
+type ValidateExprInput struct {
+	Expr string `json:"expr" jsonschema:"CEL expression to validate. Same surface as the search tool — every declared CEL variable plus every built-in function is in scope. Required."`
+}
+
+// ValidateExprOutput reports whether expr compiles AND which names
+// it references. On failure, Error carries the cel-go message and
+// (when the failure was an unknown identifier within levenshtein
+// distance 2 of a known name) Suggestion carries a 'did you mean'
+// hint. ReferencedVariables / ReferencedFunctions are populated
+// regardless of OK so the agent can correlate against the schema
+// even when their typo blocks compilation. Issue #282.
+type ValidateExprOutput struct {
+	CommonOutput
+	OK                  bool     `json:"ok"`
+	Error               string   `json:"error,omitempty"`
+	ReferencedVariables []string `json:"referenced_variables,omitempty"`
+	ReferencedFunctions []string `json:"referenced_functions,omitempty"`
+	Suggestion          string   `json:"suggestion,omitempty"`
+}
+
+func (h *handlers) validateExprHandler(_ context.Context, _ *mcp.CallToolRequest, in ValidateExprInput) (*mcp.CallToolResult, ValidateExprOutput, error) {
+	res := celexpr.ValidateExpr(in.Expr)
+	return nil, ValidateExprOutput{
+		CommonOutput:        CommonOutput{ServerVersion: h.version},
+		OK:                  res.OK,
+		Error:               res.Error,
+		ReferencedVariables: res.ReferencedVariables,
+		ReferencedFunctions: res.ReferencedFunctions,
+		Suggestion:          res.Suggestion,
+	}, nil
+}

--- a/internal/mcpserver/validate_expr_tool_test.go
+++ b/internal/mcpserver/validate_expr_tool_test.go
@@ -1,0 +1,53 @@
+package mcpserver
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestValidateExprTool_HappyPath(t *testing.T) {
+	ctx, cs := newSession(t)
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "validate_expr",
+		Arguments: ValidateExprInput{Expr: `is_source && language == "go"`},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	var out ValidateExprOutput
+	mustDecodeStructured(t, res, &out)
+	if !out.OK {
+		t.Errorf("expected OK=true, got error: %s", out.Error)
+	}
+	if !slices.Contains(out.ReferencedVariables, "is_source") {
+		t.Errorf("ReferencedVariables missing is_source; got %v", out.ReferencedVariables)
+	}
+	if !slices.Contains(out.ReferencedVariables, "language") {
+		t.Errorf("ReferencedVariables missing language; got %v", out.ReferencedVariables)
+	}
+}
+
+func TestValidateExprTool_TypoSurfacesSuggestion(t *testing.T) {
+	ctx, cs := newSession(t)
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "validate_expr",
+		Arguments: ValidateExprInput{Expr: `is_source && imprts.size() > 0`},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	var out ValidateExprOutput
+	mustDecodeStructured(t, res, &out)
+	if out.OK {
+		t.Fatal("expected OK=false for typo")
+	}
+	if !strings.Contains(out.Suggestion, "imports") {
+		t.Errorf("expected suggestion containing 'imports'; got %q", out.Suggestion)
+	}
+	if out.Error == "" {
+		t.Error("expected non-empty Error")
+	}
+}


### PR DESCRIPTION
Closes #282.

## Summary

Agents iterating on CEL discover bad expressions only by running a full \`search\` call — the typo doesn't show up until after the walk has burned latency. This adds a pure compile-time validator:

\`\`\`json
{ \"tool\": \"validate_expr\", \"arguments\": { \"expr\": \"is_source && imprts.size() > 0\" } }
\`\`\`

Returns:

\`\`\`json
{
  \"ok\": false,
  \"error\": \"ERROR: <input>:1:18: undeclared reference to 'imprts' ...\",
  \"referenced_variables\": [\"is_source\"],
  \"suggestion\": \"did you mean 'imports'?\"
}
\`\`\`

## How it works

1. **Strip string literals** so identifiers inside quoted content (e.g. \`body.contains(\"size\")\`) don't pollute the \`referenced_variables\` list.
2. **Extract identifier-shaped tokens** from the stripped expression, partition into known variables vs known functions vs unknown.
3. **Compile** via the same env \`celexpr.New()\` uses (every declared variable + every built-in function in scope). No program is built — pure compile-time check, dramatically cheaper than a walk.
4. **On compile failure**, parse \`undeclared reference to 'X'\` from cel-go's error message and Levenshtein-suggest the closest known name (distance ≤ 2 to avoid noisy guesses on totally unrelated typos).

\`referenced_variables\` / \`referenced_functions\` are populated even on failure so the agent can correlate against \`list_attributes\` while debugging.

## Test plan

- [x] \`go test -race -timeout 180s ./...\` — all green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` idempotent
- [x] 6 unit tests on \`ValidateExpr\`: happy-path returns refs, typo returns error + 'did you mean' suggestion, function refs partition correctly, string literals don't pollute refs, empty expr errors cleanly, distant typo (> 2 Levenshtein) suppresses suggestion
- [x] 2 MCP integration tests via in-memory transport: happy-path + typo-with-suggestion both round-trip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)