### PR TITLE
fix(find_matches): surface truncated files when scanner buffer cap is hit

### DIFF
--- a/internal/mcpserver/find_matches_tool.go
+++ b/internal/mcpserver/find_matches_tool.go
@@ -38,14 +38,20 @@ type FindMatchesInput struct {
 // Cancelled / CancellationReason mirror search / stats / duplicates.
 type FindMatchesOutput struct {
 	CommonOutput
-	Matches            []LineMatch `json:"matches"`
-	Count              int         `json:"count"`
-	FilesScanned       int         `json:"files_scanned"`
-	FilesWithMatches   int         `json:"files_with_matches"`
-	Cancelled          bool        `json:"cancelled,omitempty"`
-	CancellationReason string      `json:"cancellation_reason,omitempty"`
-	ElapsedSeconds     float64     `json:"elapsed_seconds,omitempty"`
-	// Suggestions populated on cancellation. Issue #168 sub-feature C.
+	Matches          []LineMatch `json:"matches"`
+	Count            int         `json:"count"`
+	FilesScanned     int         `json:"files_scanned"`
+	FilesWithMatches int         `json:"files_with_matches"`
+	// TruncatedFiles names every file whose scanner hit the per-line
+	// buffer cap (64 KiB) on at least one line — the over-cap suffix
+	// wasn't scanned, so a regex match past the cap silently misses.
+	// Pair with the corresponding suggestion entry. Issue #283.
+	TruncatedFiles     []string `json:"truncated_files,omitempty"`
+	Cancelled          bool     `json:"cancelled,omitempty"`
+	CancellationReason string   `json:"cancellation_reason,omitempty"`
+	ElapsedSeconds     float64  `json:"elapsed_seconds,omitempty"`
+	// Suggestions populated on cancellation (#168 sub-feature C) AND
+	// on truncation (#283).
 	Suggestions []string `json:"suggestions,omitempty"`
 }
 
@@ -122,6 +128,7 @@ func (h *handlers) findMatchesHandler(ctx context.Context, _ *mcp.CallToolReques
 		out.Count = res.Count
 		out.FilesScanned = res.FilesScanned
 		out.FilesWithMatches = res.FilesWithMatches
+		out.TruncatedFiles = res.TruncatedFiles
 		out.Cancelled = res.Cancelled
 		out.CancellationReason = res.CancellationReason
 		out.ElapsedSeconds = res.ElapsedSeconds
@@ -154,6 +161,16 @@ func (h *handlers) findMatchesHandler(ctx context.Context, _ *mcp.CallToolReques
 				Excludes:         in.Excludes,
 				RespectGitignore: in.RespectGitignore,
 			}, synthMatches, out.ElapsedSeconds, out.CancellationReason)
+		}
+		// Truncation hint — independent of cancellation. When the
+		// scanner blew past the 64 KiB per-line cap on any file, the
+		// over-cap suffix didn't participate in the regex pass, so a
+		// match past the cap would silently miss. Surface the file
+		// count + a copy-pasteable suggestion. Issue #283.
+		if len(out.TruncatedFiles) > 0 {
+			out.Suggestions = append(out.Suggestions,
+				fmt.Sprintf("%d file(s) had lines exceeding the 64 KiB scanner cap; the over-cap suffix wasn't scanned. Pre-split the offending files (e.g. `sed 's/[delimiter]/\\n/g'`) or use external grep for them.",
+					len(out.TruncatedFiles)))
 		}
 	}
 	out.ServerVersion = h.version

--- a/internal/mcpserver/server_find_matches_test.go
+++ b/internal/mcpserver/server_find_matches_test.go
@@ -163,3 +163,39 @@ func equalStrSlice(a, b []string) bool {
 	}
 	return true
 }
+
+// TestFindMatchesTool_TruncationSurfacedInResponse confirms the #283
+// MCP wire shape: TruncatedFiles + Suggestions both populate when a
+// file's line exceeds the scanner cap.
+func TestFindMatchesTool_TruncationSurfacedInResponse(t *testing.T) {
+	dir := t.TempDir()
+	longLine := strings.Repeat("x", 70*1024) // 70 KiB — past the 64 KiB cap
+	mustWrite(t, filepath.Join(dir, "big.go"), longLine+"\n// TODO past the cap\n")
+
+	ctx, cs := newSession(t)
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "find_matches",
+		Arguments: FindMatchesInput{
+			Pattern: "TODO",
+			Dir:     dir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	var out FindMatchesOutput
+	mustDecodeStructured(t, res, &out)
+	if len(out.TruncatedFiles) != 1 {
+		t.Errorf("TruncatedFiles size = %d, want 1; got %v", len(out.TruncatedFiles), out.TruncatedFiles)
+	}
+	gotHint := false
+	for _, s := range out.Suggestions {
+		if strings.Contains(s, "exceeding the 64 KiB") {
+			gotHint = true
+			break
+		}
+	}
+	if !gotHint {
+		t.Errorf("Suggestions should include the truncation hint; got %v", out.Suggestions)
+	}
+}

--- a/internal/search/findmatches.go
+++ b/internal/search/findmatches.go
@@ -37,11 +37,17 @@ type LineMatch struct {
 // and line-scanned (after the CEL prune); FilesWithMatches counts
 // files that produced at least one match. Cancelled / CancellationReason
 // mirror the search / stats / duplicates partial-result contract.
+//
+// TruncatedFiles names every file whose scanner hit
+// findMatchesLineCap on at least one line — the over-cap suffix
+// wasn't searched, so a regex that would have matched past the cap
+// silently misses. Issue #283.
 type FindMatchesResult struct {
 	Matches            []LineMatch `json:"matches"`
 	Count              int         `json:"count"`
 	FilesScanned       int         `json:"files_scanned"`
 	FilesWithMatches   int         `json:"files_with_matches"`
+	TruncatedFiles     []string    `json:"truncated_files,omitempty"`
 	Cancelled          bool        `json:"cancelled,omitempty"`
 	CancellationReason string      `json:"cancellation_reason,omitempty"`
 	ElapsedSeconds     float64     `json:"elapsed_seconds,omitempty"`
@@ -174,6 +180,7 @@ func FindMatches(ctx context.Context, opts Options, registry *content.Registry) 
 		allMatches       []LineMatch
 		filesScanned     int
 		filesWithMatches int
+		truncatedFiles   []string
 		wg               sync.WaitGroup
 	)
 
@@ -183,12 +190,15 @@ func FindMatches(ctx context.Context, opts Options, registry *content.Registry) 
 				if ctx.Err() != nil {
 					return
 				}
-				hits := scanResultForMatches(ctx, opts.FS, r, re, opts.ContextBefore, opts.ContextAfter, opts.MaxMatchesPerFile, matchIn)
+				hits, truncated := scanResultForMatches(ctx, opts.FS, r, re, opts.ContextBefore, opts.ContextAfter, opts.MaxMatchesPerFile, matchIn)
 				mu.Lock()
 				filesScanned++
 				if len(hits) > 0 {
 					filesWithMatches++
 					allMatches = append(allMatches, hits...)
+				}
+				if truncated {
+					truncatedFiles = append(truncatedFiles, r.Path)
 				}
 				mu.Unlock()
 			}
@@ -214,10 +224,12 @@ func FindMatches(ctx context.Context, opts Options, registry *content.Registry) 
 		return allMatches[i].Line < allMatches[j].Line
 	})
 
+	sort.Strings(truncatedFiles)
 	out.Matches = allMatches
 	out.Count = len(allMatches)
 	out.FilesScanned = filesScanned
 	out.FilesWithMatches = filesWithMatches
+	out.TruncatedFiles = truncatedFiles
 	out.ElapsedSeconds = time.Since(start).Seconds()
 
 	// Cancellation: same precedence as duplicates / stats. Walk-stage
@@ -252,21 +264,21 @@ func FindMatches(ctx context.Context, opts Options, registry *content.Registry) 
 // drop that file silently — matches the broader "broken file doesn't
 // abort the walk" pattern. fsys is non-nil only in test paths that
 // pass Options.FS.
-func scanResultForMatches(ctx context.Context, fsys fs.FS, r Result, re *regexp.Regexp, ctxBefore, ctxAfter, maxPerFile int, matchIn matchInMode) []LineMatch {
+func scanResultForMatches(ctx context.Context, fsys fs.FS, r Result, re *regexp.Regexp, ctxBefore, ctxAfter, maxPerFile int, matchIn matchInMode) ([]LineMatch, bool) {
 	if err := ctx.Err(); err != nil {
-		return nil
+		return nil, false
 	}
 	var rd io.ReadCloser
 	if fsys != nil {
 		f, err := fsys.Open(r.Path)
 		if err != nil {
-			return nil
+			return nil, false
 		}
 		rd = f
 	} else {
 		f, err := os.Open(r.Path)
 		if err != nil {
-			return nil
+			return nil, false
 		}
 		rd = f
 	}
@@ -286,12 +298,12 @@ func scanResultForMatches(ctx context.Context, fsys fs.FS, r Result, re *regexp.
 		syntax, hasSyntax = commentSyntaxFor(languageFromContentType(r.ContentType))
 	}
 
-	hits := scanReaderForMatches(ctx, rd, re, ctxBefore, ctxAfter, maxPerFile, matchIn, syntax, hasSyntax)
+	hits, truncated := scanReaderForMatches(ctx, rd, re, ctxBefore, ctxAfter, maxPerFile, matchIn, syntax, hasSyntax)
 	for i := range hits {
 		hits[i].Path = r.Path
 		hits[i].ContentType = r.ContentType
 	}
-	return hits
+	return hits, truncated
 }
 
 // scanReaderForMatches is the pure scanner — given any io.Reader,
@@ -303,7 +315,7 @@ func scanResultForMatches(ctx context.Context, fsys fs.FS, r Result, re *regexp.
 // (without adding new matches) until every pending After window is
 // filled — otherwise the last few matches would carry truncated
 // After lines, which is surprising.
-func scanReaderForMatches(ctx context.Context, rd io.Reader, re *regexp.Regexp, ctxBefore, ctxAfter, maxPerFile int, matchIn matchInMode, syntax commentSyntax, hasSyntax bool) []LineMatch {
+func scanReaderForMatches(ctx context.Context, rd io.Reader, re *regexp.Regexp, ctxBefore, ctxAfter, maxPerFile int, matchIn matchInMode, syntax commentSyntax, hasSyntax bool) ([]LineMatch, bool) {
 	scanner := bufio.NewScanner(rd)
 	scanner.Buffer(make([]byte, 0, 4096), findMatchesLineCap)
 
@@ -321,7 +333,7 @@ func scanReaderForMatches(ctx context.Context, rd io.Reader, re *regexp.Regexp, 
 
 	for scanner.Scan() {
 		if err := ctx.Err(); err != nil {
-			return matches
+			return matches, false
 		}
 		lineNo++
 		// scanner.Bytes() is reused on next Scan(); copy.
@@ -375,9 +387,15 @@ func scanReaderForMatches(ctx context.Context, rd io.Reader, re *regexp.Regexp, 
 			}
 		}
 	}
-	// scanner.Err() deliberately ignored — pathological lines are
-	// truncated; matches the snippet / read_lines degradation pattern.
-	return matches
+	// Detect truncation: bufio.Scanner halts and stamps
+	// bufio.ErrTooLong on scanner.Err() when a single line exceeds
+	// the buffer cap. The matches we already collected stay; the
+	// over-cap line and everything after it didn't scan. Surface
+	// this to the caller via the second return so FindMatches can
+	// list the affected file path in TruncatedFiles and emit a hint
+	// in Suggestions. Issue #283.
+	truncated := errors.Is(scanner.Err(), bufio.ErrTooLong)
+	return matches, truncated
 }
 
 // roleMatches reports whether a line of role `r` survives the MatchIn

--- a/internal/search/findmatches_truncation_test.go
+++ b/internal/search/findmatches_truncation_test.go
@@ -1,0 +1,92 @@
+package search_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// TestFindMatches_TruncationSurfaced confirms the #283 contract:
+// when a file has a single line longer than the scanner's per-line
+// buffer cap (64 KiB), the file path lands in TruncatedFiles so the
+// caller knows the scan was incomplete. A regex match HIDDEN past
+// the cap silently misses (the documented limitation that motivated
+// the warning).
+func TestFindMatches_TruncationSurfaced(t *testing.T) {
+	dir := t.TempDir()
+
+	// Hand-craft a file with two lines:
+	//   line 1: 70 KiB of filler — exceeds the 64 KiB scanner cap.
+	//   line 2: a real "TODO" annotation that should be findable.
+	// Because line 1 trips bufio.ErrTooLong, line 2 never reaches the
+	// scanner and the TODO match is missed.
+	longLine := strings.Repeat("x", 70*1024)
+	body := longLine + "\n// TODO real annotation\n"
+	if err := os.WriteFile(filepath.Join(dir, "big.go"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// A second normal file with a real TODO — should match cleanly.
+	normal := "// TODO another one\n"
+	if err := os.WriteFile(filepath.Join(dir, "normal.go"), []byte(normal), 0o644); err != nil {
+		t.Fatalf("write normal: %v", err)
+	}
+
+	res, err := search.FindMatches(context.Background(), search.Options{
+		Root:    dir,
+		Expr:    `is_source && language == "go"`,
+		Pattern: "TODO",
+		Workers: 1,
+	}, content.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("FindMatches: %v", err)
+	}
+
+	// big.go's TODO sat past the truncated line → not matched.
+	// normal.go's TODO matched cleanly → exactly one result.
+	if res.Count != 1 {
+		t.Errorf("Count = %d, want 1 (big.go's TODO is past the cap; only normal.go matched)", res.Count)
+	}
+	// TruncatedFiles must include big.go.
+	gotTruncated := false
+	for _, p := range res.TruncatedFiles {
+		if strings.HasSuffix(p, "big.go") {
+			gotTruncated = true
+			break
+		}
+	}
+	if !gotTruncated {
+		t.Errorf("TruncatedFiles should include big.go; got %v", res.TruncatedFiles)
+	}
+	// normal.go MUST NOT appear in TruncatedFiles.
+	for _, p := range res.TruncatedFiles {
+		if strings.HasSuffix(p, "normal.go") {
+			t.Errorf("normal.go should NOT be in TruncatedFiles: %v", res.TruncatedFiles)
+		}
+	}
+}
+
+// TestFindMatches_NoTruncationWhenLinesFit confirms TruncatedFiles
+// stays empty on well-behaved input.
+func TestFindMatches_NoTruncationWhenLinesFit(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ok.go"), []byte("// TODO tiny\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	res, err := search.FindMatches(context.Background(), search.Options{
+		Root:    dir,
+		Pattern: "TODO",
+		Workers: 1,
+	}, content.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("FindMatches: %v", err)
+	}
+	if len(res.TruncatedFiles) != 0 {
+		t.Errorf("TruncatedFiles should be empty on well-behaved input; got %v", res.TruncatedFiles)
+	}
+}


### PR DESCRIPTION
Closes #283.

## Summary

\`bufio.Scanner\` halts and stamps \`bufio.ErrTooLong\` when any line in the input exceeds its buffer cap (64 KiB for find_matches). The matches that landed before the over-cap line stayed; the over-cap line AND EVERYTHING AFTER IT didn't scan. A regex hit past the cap silently missed — that's the silent-failure footgun #283 called out.

This adds detection + signal:

- \`scanReaderForMatches\` returns \`(matches, truncated bool)\`; the boolean fires when \`scanner.Err()\` is \`bufio.ErrTooLong\`.
- \`scanResultForMatches\` propagates it.
- \`FindMatches\` aggregates affected paths into \`res.TruncatedFiles\`.
- New \`FindMatchesResult.TruncatedFiles []string\` wire field — JSON output carries it via \`truncated_files\`.
- MCP \`FindMatchesOutput\` exposes the same field AND appends a suggestion explaining the truncation with a copy-pasteable workaround (pre-split offending files / external grep for them).

Existing partial-result behaviour (\`Cancelled\` + \`CancellationReason\` + the cancellation-time \`Suggestions\`) is untouched — truncation is a SCAN-stage concern independent of walk-stage cancellation.

## Test plan

- [x] \`go test -race -timeout 180s ./...\` — all green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` idempotent
- [x] \`TestFindMatches_TruncationSurfaced\`: a file with a 70 KiB single line + a TODO past the cap. The TODO is correctly missed; the file path lands in \`TruncatedFiles\`. A normal sibling matches cleanly and is NOT in \`TruncatedFiles\`.
- [x] \`TestFindMatches_NoTruncationWhenLinesFit\`: well-behaved input leaves \`TruncatedFiles\` empty (no false positives).
- [x] MCP integration: \`TestFindMatchesTool_TruncationSurfacedInResponse\` confirms wire shape carries \`truncated_files\` + \`suggestions\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)