### PR TITLE
fix(search): git_* attrs projectable via fields (parity follow-up to #271)

### DIFF
--- a/internal/search/match.go
+++ b/internal/search/match.go
@@ -563,6 +563,23 @@ type Match struct {
 	MetadataChangedAt string `json:"metadata_changed_at,omitempty"`
 	IsBtimeAnomaly    bool   `json:"is_btime_anomaly,omitempty"`
 
+	// Git-aware metadata (issue #271). Populated when the caller sets
+	// with_git: true (MCP) / --with-git (CLI), AND the walk root is
+	// inside a git working tree, AND the file is tracked. Surfaces
+	// the CEL git_* variables in the wire format so callers can
+	// project via fields: ["git_last_commit_time", ...], render in
+	// JSON output, and decide based on the values without burning a
+	// follow-up call. Time fields are RFC3339 strings (matching
+	// CreatedAt / MetadataChangedAt). Empty / zero when the file
+	// isn't tracked or with_git was off.
+	GitLastCommitTime    string `json:"git_last_commit_time,omitempty"`
+	GitLastCommitAuthor  string `json:"git_last_commit_author,omitempty"`
+	GitLastCommitSubject string `json:"git_last_commit_subject,omitempty"`
+	GitFirstSeen         string `json:"git_first_seen,omitempty"`
+	GitCommitCount       int64  `json:"git_commit_count,omitempty"`
+	IsGitTracked         bool   `json:"is_git_tracked,omitempty"`
+	IsGitIgnored         bool   `json:"is_git_ignored,omitempty"`
+
 	// Disguise detection (PR #145). Populated when the caller sets
 	// `check_disguised: true` (MCP) or `--check-disguised` (CLI).
 	// MagicContentType is what the file's first 512 bytes look

--- a/internal/search/match_from.go
+++ b/internal/search/match_from.go
@@ -138,6 +138,22 @@ func applyComputedAttrs(m *Match, a *celexpr.FileAttributes) {
 	m.IsDisguised = a.IsDisguised
 	m.IsKnownGood = a.IsKnownGood
 	m.IsKnownBad = a.IsKnownBad
+	// Git-aware metadata (issue #271 wire-format follow-up). The CEL
+	// variables were already declared + queryable; this surfaces the
+	// typed FileAttributes fields on Match so fields: ["git_*"]
+	// projection works and JSON output carries them. Same pattern as
+	// CreatedAt / MetadataChangedAt above (RFC3339 string).
+	if !a.GitLastCommitTime.IsZero() {
+		m.GitLastCommitTime = a.GitLastCommitTime.Format(time.RFC3339)
+	}
+	if !a.GitFirstSeen.IsZero() {
+		m.GitFirstSeen = a.GitFirstSeen.Format(time.RFC3339)
+	}
+	m.GitLastCommitAuthor = a.GitLastCommitAuthor
+	m.GitLastCommitSubject = a.GitLastCommitSubject
+	m.GitCommitCount = a.GitCommitCount
+	m.IsGitTracked = a.IsGitTracked
+	m.IsGitIgnored = a.IsGitIgnored
 }
 
 // applyCommonAttrs covers the cross-family scalars (title/author/language/counts), manifest module fields, and project context.

--- a/internal/search/match_project_test.go
+++ b/internal/search/match_project_test.go
@@ -181,6 +181,51 @@ func TestValidateFields_FunctionsAndTypeNamesAccepted(t *testing.T) {
 	}
 }
 
+// TestValidateFields_GitAttrsAccepted confirms the seven git_* /
+// is_git_* attributes round-trip through fields-projection. Same
+// shape fix as #275 (imports) and #278 (functions / type_names) but
+// for the git-aware attributes added in #271.
+func TestValidateFields_GitAttrsAccepted(t *testing.T) {
+	if err := search.ValidateFields([]string{
+		"path",
+		"git_last_commit_time",
+		"git_last_commit_author",
+		"git_last_commit_subject",
+		"git_first_seen",
+		"git_commit_count",
+		"is_git_tracked",
+		"is_git_ignored",
+	}); err != nil {
+		t.Errorf("git_* fields should be valid projection targets: %v", err)
+	}
+}
+
+func TestProjectMatch_GitAttrs_Preserved(t *testing.T) {
+	m := search.Match{
+		Path:                 "/a.go",
+		ContentType:          "source/go",
+		GitLastCommitTime:    "2026-06-02T17:35:15Z",
+		GitLastCommitAuthor:  "Alice",
+		GitLastCommitSubject: "feat: bar",
+		GitFirstSeen:         "2026-05-21T11:53:43Z",
+		GitCommitCount:       11,
+		IsGitTracked:         true,
+	}
+	kept := search.ProjectMatch(m, []string{"git_commit_count", "git_last_commit_author"})
+	if kept.GitCommitCount != 11 {
+		t.Errorf("projection keeping git_commit_count zeroed it: %d", kept.GitCommitCount)
+	}
+	if kept.GitLastCommitAuthor != "Alice" {
+		t.Errorf("projection keeping git_last_commit_author zeroed it: %q", kept.GitLastCommitAuthor)
+	}
+	if kept.GitLastCommitSubject != "" {
+		t.Errorf("projection NOT including git_last_commit_subject should zero it; got %q", kept.GitLastCommitSubject)
+	}
+	if kept.IsGitTracked {
+		t.Errorf("projection NOT including is_git_tracked should zero it")
+	}
+}
+
 // TestProjectMatch_FunctionsAndTypeNames_Preserved confirms projection
 // keeps the typed source-symbol fields when requested, zeroes when not.
 func TestProjectMatch_FunctionsAndTypeNames_Preserved(t *testing.T) {


### PR DESCRIPTION
## Summary

Parity follow-up to #271 (git-aware CEL attrs) closing the same wire-format gap that #275 closed for \`imports\` and #278 closed for \`functions\` / \`type_names\`.

The CEL variables were already queryable + sortable + auto-enabled via expression detection. But the typed \`FileAttributes\` fields never landed on \`search.Match\`, so:

- \`fields: [\"git_commit_count\", \"git_last_commit_time\"]\` errored at request validation
- The JSON / MCP search response carried no git data even when \`with_git: true\`

## Change

Add 7 typed Match fields with json:\"git_*\" tags + RFC3339 string formatting for the timestamps (matching the existing \`CreatedAt\` / \`MetadataChangedAt\` shape):

\`\`\`go
GitLastCommitTime    string  `json:\"git_last_commit_time,omitempty\"`
GitLastCommitAuthor  string  `json:\"git_last_commit_author,omitempty\"`
GitLastCommitSubject string  `json:\"git_last_commit_subject,omitempty\"`
GitFirstSeen         string  `json:\"git_first_seen,omitempty\"`
GitCommitCount       int64   `json:\"git_commit_count,omitempty\"`
IsGitTracked         bool    `json:\"is_git_tracked,omitempty\"`
IsGitIgnored         bool    `json:\"is_git_ignored,omitempty\"`
\`\`\`

\`MatchFrom\` copies directly from the typed \`FileAttributes\` fields — no Extra-map indirection (git_* are typed fields, unlike imports/functions/type_names which sit on Extra).

## Dogfood

\`\`\`
$ /tmp/fso 'is_source && language == \"go\" && git_commit_count > 5' \\
    --sort git_commit_count --order desc --limit 1 --output json
{
  \"path\": \"...cmd/file-search-on/main.go\",
  \"git_last_commit_time\": \"2026-05-30T12:00:59Z\",
  \"git_last_commit_author\": \"Richard Wooding\",
  \"git_last_commit_subject\": \"feat(embed): expose + pull Ollama embedding models via MCP and CLI (#251)\",
  \"git_first_seen\": \"2026-05-03T15:46:58Z\",
  \"git_commit_count\": 41,
  \"is_git_tracked\": true,
  ...
}
\`\`\`

## Test plan

- [x] \`go test -race -timeout 180s ./...\` — all green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go fix ./...\` idempotent
- [x] 2 new tests: \`ValidateFields\` accepts all 7 git_* names; \`ProjectMatch\` preserves git_* when listed in projection, zeroes when not
- [x] Manual dogfood confirms git_* fields land in JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)