### PR TITLE
feat(mcp): --watch-index keeps the index cache fresh while serving

### DIFF
--- a/.claude/skills/file-search-on-mcp/references/tools.md
+++ b/.claude/skills/file-search-on-mcp/references/tools.md
@@ -570,7 +570,7 @@ Example:
 
 Cumulative attribute-cache counters for the running MCP server. Counters reset on restart.
 
-Output: `hits`, `misses`, `puts`, `stales`, `errors`, plus `body_*` and `embed_*` analogues (body cache, embedding cache).
+Output: `hits`, `misses`, `puts`, `stales`, `errors`, plus `body_*` and `embed_*` analogues (body cache, embedding cache). When the server was launched with `--watch-index` (the background cache maintainer; auto-on under `--warm`), also reports `watch_refreshed` (cached files re-parsed after an edit), `watch_evicted` (entries dropped for deleted files), and `watch_errors`. Zero on a server without the watcher.
 
 Useful for diagnosing cache effectiveness when a search feels slower than expected.
 

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Twenty tools are exposed, grouped by family:
 | `list_attributes` | The full canonical schema (`common`, `type_specific`, `frontmatter`, `functions`) plus registered content types. |
 | `list_presets` | Discover the eight built-in named search recipes (`recent_changes`, `recent_photos`, `old_drafts`, `large_files`, `large_binaries`, `suspicious_files`, `failed_tests`, `system_metadata`). |
 | `query_preset` | Run a named preset; per-call overrides for `dir`, `limit`, `excludes`, etc. |
-| `index_stats` | Cache counters for the running server (hits, misses, puts, stales, errors; same for body + embedding caches). |
+| `index_stats` | Cache counters for the running server (hits, misses, puts, stales, errors; same for body + embedding caches). When `--watch-index` is on, also reports `watch_refreshed` / `watch_evicted` / `watch_errors`. |
 | `monitor_info` | This server's monitoring-dashboard URL + the registry of sibling instances. Pass `enable: true` to start the dashboard on demand if it isn't already running. |
 
 Every walking tool (`search`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `find_projects`, `diff_trees`) honours the same partial-result contract: on timeout the call returns `cancelled=true` with the results gathered so far, never an error. Agents inspect the flag rather than catching exceptions.
@@ -491,6 +491,17 @@ file-search-on mcp --index-path /var/lib/fso.db                          # expli
 file-search-on mcp --no-index                                            # in-memory only (process lifetime)
 file-search-on mcp --transport http --addr :8080
 ```
+
+**Keeping the cache fresh while it runs — `--watch-index`.** The index is validated lazily by `(size, mtime)`, so a changed file is always re-parsed on its next lookup — results are never stale. `--watch-index` adds a background fsnotify watcher that proactively (1) **re-parses already-cached files when they change** so the *next* query is a warm hit instead of a cold parse, and (2) **evicts cache entries for deleted files** — the one bit of hygiene lazy validation never does (dead paths otherwise accumulate in the bbolt file forever). It's a latency/hygiene optimisation, **not** a correctness fix. Auto-enabled when you `--warm` a root ("warm once, then keep it warm"); off otherwise because watching a huge tree (e.g. `$HOME`) exhausts the OS per-directory watch limit. The watcher honours `.gitignore` and prunes build-artefact dirs (`node_modules`, `target`, …) so churny output doesn't thrash the cache.
+
+```sh
+file-search-on mcp --warm                                                # warm cwd, then keep it warm (watcher auto-on)
+file-search-on mcp --warm-dir ~/Code/myproj --watch-index                # warm + watch a specific root
+file-search-on mcp --watch-index-dir ~/Code/myproj                       # watch a root without a startup warm pass
+file-search-on mcp --warm --no-watch-index                               # warm once, but don't keep watching
+```
+
+The watcher's activity is reported by the `index_stats` MCP tool as `watch_refreshed` / `watch_evicted` / `watch_errors`; evictions also show as a shrinking attribute-entry count on the monitor dashboard.
 
 ### Registering with Claude Code
 

--- a/cmd/file-search-on/mcp_cmd.go
+++ b/cmd/file-search-on/mcp_cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/richardwooding/file-search-on/internal/index"
 	"github.com/richardwooding/file-search-on/internal/mcpserver"
 	"github.com/richardwooding/file-search-on/internal/monitor"
+	"github.com/richardwooding/file-search-on/internal/search"
 )
 
 type MCPCmd struct {
@@ -32,6 +33,9 @@ type MCPCmd struct {
 	WarmWorkers       int           `name:"warm-workers" help:"Worker count for the warmer. Defaults to max(1, NumCPU/4) — a quarter of the cores so the MCP server, the agent driving it, and the rest of the box keep their headroom. Pass 1 for minimum CPU; ignored when --warm is off."`
 	WarmTimeout       time.Duration `name:"warm-timeout" default:"10m" help:"Hard deadline on the warmer (Go duration: 30s, 5m). The MCP server keeps running if the warmer is killed by the deadline. Ignored when --warm is off."`
 	WarmEmbeddings    bool          `name:"warm-embeddings" help:"At startup, walk the warm root in the background and pre-populate the search_semantic embeddings cache. Requires --embedding-model to be set. Reads every walked file's body and calls Ollama once per file (expensive: ~1s/file on localhost) — appropriate as a pre-flight to interactive use. Walks concurrently with the MCP server, so clients connect immediately. Combine with --warm to populate both caches in one walk."`
+	WatchIndex        bool          `name:"watch-index" help:"After warming, keep the warm root's index cache fresh in the background: re-parse already-cached files when they change so the NEXT query is a warm hit, and evict cache entries for deleted files (which lazy validation never does). Auto-enabled when --warm/--warm-dir is set; use --no-watch-index to opt out. A latency/hygiene optimisation, NOT a correctness fix — lazy (size,mtime) validation already re-parses stale files on the next query. Off by default outside --warm because watching a huge tree (e.g. $HOME) exhausts the OS per-directory watch limit."`
+	NoWatchIndex      bool          `name:"no-watch-index" help:"Disable the background index watcher even when --warm/--warm-dir is set."`
+	WatchIndexDir     string        `name:"watch-index-dir" help:"Directory the index watcher monitors. Defaults to --warm-dir, then the cwd at server start. Implies --watch-index."`
 	Sandbox           bool          `name:"sandbox" help:"Restrict agent filesystem access to the cwd at server startup. Path-accepting MCP tool inputs (dir / dirs / path / tree_a / tree_b / hash_allowlist_path / hash_denylist_path) that resolve outside the sandbox are rejected with a clear error. Off by default; opt in when running file-search-on as an MCP server for an agent you want to scope to a single project. Combine with --sandbox-dir to specify explicit roots."`
 	SandboxDir        []string      `name:"sandbox-dir" help:"Sandbox root directory. Repeatable for multiple roots (e.g. --sandbox-dir ~/Code/foo --sandbox-dir ~/Code/bar). Implies --sandbox. Symlinks pointing outside the sandbox are rejected; follow_symlinks=true is rejected entirely when the sandbox is active (the walker doesn't yet enforce sandbox per-entry)."`
 }
@@ -193,10 +197,57 @@ func (m *MCPCmd) Run(ctx context.Context) error {
 		}
 	}
 
+	// Background index maintainer. Auto-enabled when the operator opted
+	// into warming a specific root ("warm once, then keep it warm");
+	// --watch-index / --watch-index-dir force it on without warming;
+	// --no-watch-index forces it off. Off otherwise — the implicit root
+	// is the cwd, and watching a huge tree (e.g. $HOME) exhausts the OS
+	// per-directory watch limit.
+	watchStats := &search.IndexWatchStats{}
+	watchEnabled := (m.WatchIndex || m.WatchIndexDir != "" || m.Warm || m.WarmDir != "") && !m.NoWatchIndex
+	if watchEnabled {
+		watchRoot := m.WatchIndexDir
+		if watchRoot == "" {
+			watchRoot = m.WarmDir
+		}
+		if watchRoot == "" {
+			if cwd, err := os.Getwd(); err == nil {
+				watchRoot = cwd
+			}
+		}
+		if watchRoot == "" {
+			fmt.Fprintln(os.Stderr, "watch-index: could not resolve directory to watch; skipping")
+		} else {
+			// Dedicated child ctx + done channel. The join defer cancels
+			// its own ctx and waits for the watcher (including any
+			// in-flight debounced re-parse) to drain. Registered AFTER
+			// idx.Close() above, so by LIFO it runs BEFORE idx.Close —
+			// no maintenance call can hit a closed index. Self-cancelling
+			// means it doesn't depend on cancelMonitor's ordering.
+			watchCtx, cancelWatch := context.WithCancel(ctx)
+			watchDone := make(chan struct{})
+			go func() {
+				defer close(watchDone)
+				opts := search.Options{
+					Roots:               []string{watchRoot},
+					RespectGitignore:    true,
+					PruneBuildArtefacts: true,
+					Index:               idx,
+				}
+				if err := search.WatchIndex(watchCtx, opts, nil, idx, watchStats); err != nil {
+					fmt.Fprintf(os.Stderr, "watch-index: %v\n", err)
+				}
+			}()
+			defer func() { cancelWatch(); <-watchDone }()
+			fmt.Fprintf(os.Stderr, "watch-index: maintaining cache for %s\n", watchRoot)
+		}
+	}
+
 	mcpOpts := []mcpserver.Option{
 		mcpserver.WithCollector(collector),
 		mcpserver.WithMonitor(controller),
 		mcpserver.WithGitPool(gitPool),
+		mcpserver.WithIndexWatchStats(watchStats),
 	}
 
 	sandboxRoots := append([]string(nil), m.SandboxDir...)

--- a/examples/indexing.md
+++ b/examples/indexing.md
@@ -110,6 +110,21 @@ Hit/miss counters are exposed via the `index_stats` MCP tool (no input, returns 
 { "name": "index_stats", "arguments": {} }
 ```
 
+### Keeping the cache warm under churn — `--watch-index`
+
+`--warm` (or `--warm-dir <root>`) pre-populates the cache at startup so the first tool call lands on a hot index. But once warm, edits silently make those entries stale — the next query pays a cold re-parse. `--watch-index` closes that gap with a background fsnotify watcher on the warm root:
+
+```sh
+file-search-on mcp --warm                             # warm cwd + keep it warm (watcher auto-on)
+file-search-on mcp --warm-dir ~/Code/proj --watch-index
+file-search-on mcp --watch-index-dir ~/Code/proj      # watch without a startup warm pass
+file-search-on mcp --warm --no-watch-index            # warm once, don't keep watching
+```
+
+On a create/write to an **already-cached** file it re-parses in the background (next query is warm, not cold); on a delete/rename it evicts the entry — the GC that lazy `(size, mtime)` validation never performs, so dead paths don't pile up in the bbolt file. It honours `.gitignore` and prunes build-artefact dirs so a churny `node_modules`/`target` can't thrash the cache. This is a **latency + hygiene** optimisation: results are already correct without it (stale entries re-parse on lookup), so leave it off for one-shot runs and turn it on for long-lived MCP sessions over an active project.
+
+It's deliberately off by default outside `--warm`: the watcher registers one OS watch per directory, so pointing it at a giant tree like `$HOME` can exhaust the kernel watch limit. The `index_stats` tool reports its work as `watch_refreshed` / `watch_evicted` / `watch_errors`.
+
 ## When NOT to use it
 
 - **One-shot scripts** in a hermetic CI where any disk side effect is unwanted — pass `--no-index`.

--- a/internal/mcpserver/index_stats_tool.go
+++ b/internal/mcpserver/index_stats_tool.go
@@ -34,6 +34,14 @@ type IndexStatsOutput struct {
 	EmbedPuts            uint64 `json:"embed_puts"`
 	EmbedErrors          uint64 `json:"embed_errors"`
 	EmbedModelMismatches uint64 `json:"embed_model_mismatches"`
+
+	// Watch* report the background index maintainer (mcp --watch-index).
+	// WatchRefreshed: cached files re-parsed after an edit so the next
+	// query is warm. WatchEvicted: entries dropped for deleted files
+	// (the GC lazy validation never does). Zero when no watcher is wired.
+	WatchRefreshed uint64 `json:"watch_refreshed"`
+	WatchEvicted   uint64 `json:"watch_evicted"`
+	WatchErrors    uint64 `json:"watch_errors"`
 }
 
 func (h *handlers) indexStatsHandler(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, IndexStatsOutput, error) {
@@ -41,6 +49,7 @@ func (h *handlers) indexStatsHandler(_ context.Context, _ *mcp.CallToolRequest, 
 		return nil, IndexStatsOutput{CommonOutput: CommonOutput{ServerVersion: h.version}}, nil
 	}
 	st := h.idx.Stats()
+	ws := h.indexWatch.Snapshot() // nil-safe: zeros when no watcher wired
 	return nil, IndexStatsOutput{
 		CommonOutput:  CommonOutput{ServerVersion: h.version},
 		Hits:          st.Hits,
@@ -60,5 +69,8 @@ func (h *handlers) indexStatsHandler(_ context.Context, _ *mcp.CallToolRequest, 
 		EmbedPuts:            st.EmbedPuts,
 		EmbedErrors:          st.EmbedErrors,
 		EmbedModelMismatches: st.EmbedModelMismatches,
+		WatchRefreshed:       ws.Refreshed,
+		WatchEvicted:         ws.Evicted,
+		WatchErrors:          ws.Errors,
 	}, nil
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/richardwooding/file-search-on/internal/gitmeta"
 	"github.com/richardwooding/file-search-on/internal/index"
 	"github.com/richardwooding/file-search-on/internal/monitor"
+	"github.com/richardwooding/file-search-on/internal/search"
 )
 
 // handlers wraps tool handlers so they can share an index reference
@@ -47,6 +48,11 @@ type handlers struct {
 	// between calls invalidate naturally. Primed at startup by the
 	// MCP command's --warm goroutine. Issue #271 follow-up.
 	gitPool *gitmeta.Pool
+	// indexWatch, when non-nil, holds the counters for the background
+	// index maintainer (the mcp --watch-index goroutine). Surfaced by
+	// the index_stats tool. nil when no watcher is wired (tests, or a
+	// server started without --watch-index) → reported as zeros.
+	indexWatch *search.IndexWatchStats
 }
 
 // Option configures the MCP server at construction. Used to attach
@@ -77,6 +83,18 @@ func WithGitPool(p *gitmeta.Pool) Option {
 	return func(h *handlers) {
 		if p != nil {
 			h.gitPool = p
+		}
+	}
+}
+
+// WithIndexWatchStats attaches the background index maintainer's
+// counters so the index_stats tool can report watch_refreshed /
+// watch_evicted / watch_errors. Passing nil is a no-op; the tool then
+// reports zeros for those fields.
+func WithIndexWatchStats(s *search.IndexWatchStats) Option {
+	return func(h *handlers) {
+		if s != nil {
+			h.indexWatch = s
 		}
 	}
 }

--- a/internal/mcpserver/server_index_test.go
+++ b/internal/mcpserver/server_index_test.go
@@ -79,4 +79,10 @@ func TestIndexStatsTool(t *testing.T) {
 	if stats.Puts != 1 {
 		t.Errorf("Puts=%d want 1 (full stats: %+v)", stats.Puts, stats)
 	}
+	// No --watch-index watcher wired on this server, so the watch
+	// counters must report zero (nil-safe Snapshot), not be absent.
+	if stats.WatchRefreshed != 0 || stats.WatchEvicted != 0 || stats.WatchErrors != 0 {
+		t.Errorf("watch counters should be zero without a watcher: refreshed=%d evicted=%d errors=%d",
+			stats.WatchRefreshed, stats.WatchEvicted, stats.WatchErrors)
+	}
 }

--- a/internal/search/watch.go
+++ b/internal/search/watch.go
@@ -29,7 +29,8 @@ const watchDebounce = 300 * time.Millisecond
 // The per-file evaluation mirrors the Walk path exactly — same
 // BuildAttributesWith + Evaluate, so OCR / hashes / phash / body /
 // xattrs / index caching all compose identically. Only create + write
-// events are considered (deletes are out of scope per issue #211).
+// events are considered (deletes have no match to emit, so they're
+// skipped here — see WatchIndex for the delete-aware consumer).
 //
 // fsnotify is not recursive: every existing directory under each root
 // is registered up front, and any directory created during the watch
@@ -52,31 +53,7 @@ func Watch(ctx context.Context, opts Options, registry *content.Registry, onMatc
 		return fmt.Errorf("compiling CEL expression: %w", err)
 	}
 
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return fmt.Errorf("creating watcher: %w", err)
-	}
-	defer func() { _ = watcher.Close() }()
-
-	for _, root := range opts.Roots {
-		if err := addDirsRecursive(watcher, root, opts.Excludes, opts.RespectGitignore); err != nil {
-			return err
-		}
-	}
-
 	buildOpts := opts.watchBuildOptions()
-
-	// Per-path debounce timers. Stopped on exit so a pending timer
-	// can't call onMatch after Watch returns.
-	var mu sync.Mutex
-	timers := make(map[string]*time.Timer)
-	defer func() {
-		mu.Lock()
-		for _, t := range timers {
-			t.Stop()
-		}
-		mu.Unlock()
-	}()
 
 	evalPath := func(path string) {
 		if ctx.Err() != nil {
@@ -103,6 +80,103 @@ func Watch(ctx context.Context, opts Options, registry *content.Registry, onMatc
 		onMatch(r)
 	}
 
+	return watchLoop(ctx, opts.Roots, opts.Excludes, opts.RespectGitignore, func(path string, op fsnotify.Op) {
+		// The match tool only surfaces new/changed files; a removed or
+		// renamed-away path has no match to emit.
+		if op.Has(fsnotify.Remove) || op.Has(fsnotify.Rename) {
+			return
+		}
+		evalPath(path)
+	})
+}
+
+// watchLoop is the shared fsnotify event engine behind Watch and
+// WatchIndex. It registers every existing directory under each root
+// (honouring globs + .gitignore), auto-registers directories created
+// during the watch, and invokes onEvent once per debounced file event.
+// It blocks until ctx is cancelled, then stops cleanly — all pending
+// debounce timers are stopped so onEvent can't fire after watchLoop
+// returns.
+//
+// onEvent receives the file path and the latest fsnotify.Op observed
+// for it within the debounce window. Create/Write/Remove/Rename are all
+// forwarded; directory creation is handled internally (recursive
+// registration) and never forwarded. Consumers inspect op to decide
+// what to do (Watch ignores Remove/Rename; WatchIndex evicts on them).
+//
+// Op coalescing is latest-wins: a quick create-then-remove resolves to
+// Remove (don't act on a vanished file), and a write following a remove
+// (a rename destination reusing a name) re-arms with the newer op.
+func watchLoop(ctx context.Context, roots, globs []string, respectGitignore bool, onEvent func(path string, op fsnotify.Op)) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("creating watcher: %w", err)
+	}
+	defer func() { _ = watcher.Close() }()
+
+	for _, root := range roots {
+		if err := addDirsRecursive(watcher, root, globs, respectGitignore); err != nil {
+			return err
+		}
+	}
+
+	// Per-path debounce state. Each entry holds the latest op and its
+	// timer. A WaitGroup tracks scheduled-but-not-yet-finished timer
+	// callbacks so the exit defer can DRAIN any in-flight onEvent before
+	// watchLoop returns — otherwise a timer that fired just before
+	// cancellation could run onEvent (touching a since-closed index)
+	// after the caller believes the watcher has stopped.
+	type pending struct {
+		timer *time.Timer
+		op    fsnotify.Op
+	}
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	timers := make(map[string]*pending)
+	defer func() {
+		mu.Lock()
+		for _, p := range timers {
+			if p.timer.Stop() {
+				// Stopped before firing: its callback won't run, so
+				// balance the Add we made when scheduling it.
+				wg.Done()
+			}
+			// Stop()==false means the callback already ran or is running
+			// (blocked on mu) — it will call wg.Done itself.
+		}
+		mu.Unlock()
+		wg.Wait() // block until in-flight onEvent callbacks finish
+	}()
+
+	schedule := func(name string, op fsnotify.Op) {
+		mu.Lock()
+		defer mu.Unlock()
+		if old, ok := timers[name]; ok {
+			if old.timer.Stop() { // latest op wins; supersede prior timer
+				wg.Done()
+			}
+		}
+		wg.Add(1)
+		p := &pending{op: op}
+		p.timer = time.AfterFunc(watchDebounce, func() {
+			defer wg.Done()
+			mu.Lock()
+			cur, ok := timers[name]
+			// Only the most-recently-scheduled timer acts. A timer that
+			// already fired but was superseded finds cur != p and bails,
+			// so onEvent fires exactly once per debounce window.
+			act := ok && cur == p
+			if act {
+				delete(timers, name)
+			}
+			mu.Unlock()
+			if act {
+				onEvent(name, p.op)
+			}
+		})
+		timers[name] = p
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -112,26 +186,16 @@ func Watch(ctx context.Context, opts Options, registry *content.Registry, onMatc
 				return nil
 			}
 			// A newly-created directory must be watched too (fsnotify
-			// isn't recursive). Register it and skip evaluation.
+			// isn't recursive). Register it and don't forward the event.
 			if event.Has(fsnotify.Create) {
 				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
-					_ = addDirsRecursive(watcher, event.Name, opts.Excludes, opts.RespectGitignore)
+					_ = addDirsRecursive(watcher, event.Name, globs, respectGitignore)
 					continue
 				}
 			}
-			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
-				name := event.Name
-				mu.Lock()
-				if t, ok := timers[name]; ok {
-					t.Stop()
-				}
-				timers[name] = time.AfterFunc(watchDebounce, func() {
-					mu.Lock()
-					delete(timers, name)
-					mu.Unlock()
-					evalPath(name)
-				})
-				mu.Unlock()
+			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) ||
+				event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+				schedule(event.Name, event.Op)
 			}
 		case _, ok := <-watcher.Errors:
 			if !ok {

--- a/internal/search/watch_index.go
+++ b/internal/search/watch_index.go
@@ -1,0 +1,164 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/projecttype"
+)
+
+// IndexWatchStats counts the work a background WatchIndex maintainer
+// performs over its lifetime. All counters are monotonic-since-start;
+// read a consistent snapshot via Snapshot. The zero value is ready to
+// use and safe for concurrent updates.
+type IndexWatchStats struct {
+	Refreshed atomic.Uint64 // cached entries re-parsed after a create/write
+	Evicted   atomic.Uint64 // entries dropped after a remove/rename
+	Errors    atomic.Uint64 // re-parse failures
+}
+
+// IndexWatchSnapshot is a plain-value snapshot of IndexWatchStats for
+// reporting (MCP index_stats tool, dashboard).
+type IndexWatchSnapshot struct {
+	Refreshed uint64
+	Evicted   uint64
+	Errors    uint64
+}
+
+// Snapshot returns the current counters as plain values.
+func (s *IndexWatchStats) Snapshot() IndexWatchSnapshot {
+	if s == nil {
+		return IndexWatchSnapshot{}
+	}
+	return IndexWatchSnapshot{
+		Refreshed: s.Refreshed.Load(),
+		Evicted:   s.Evicted.Load(),
+		Errors:    s.Errors.Load(),
+	}
+}
+
+// WatchIndex keeps the on-disk index cache fresh for the lifetime of a
+// long-running server. It watches opts.Roots and, per debounced event:
+//
+//   - remove / rename → idx.Delete(path) (the one thing lazy
+//     (size, mtime) validation never does — it leaves dead paths in the
+//     bbolt file forever);
+//   - create / write → re-parse the file via the standard
+//     BuildAttributesWith path so the refreshed attributes land back in
+//     the cache, BUT only when the path is ALREADY cached. The
+//     conservative gate (idx.PeekAttrs) means we restore warmth to
+//     entries an edit just staled rather than speculatively parsing
+//     every transient new file (editor temp files, downloads-in-flight,
+//     build output) under a churny tree.
+//
+// This is a latency / hygiene optimisation, NOT a correctness fix: lazy
+// validation already re-parses a stale entry on the next lookup, so
+// search results are always correct without the watcher. WatchIndex
+// just keeps a warmed cache warm under churn and garbage-collects
+// entries for deleted files.
+//
+// It blocks until ctx is cancelled, then returns cleanly. opts.Index
+// must be non-nil; opts.Excludes / RespectGitignore / PruneBuildArtefacts
+// are honoured so watched build-artefact dirs (node_modules, target, …)
+// don't thrash the cache. stats may be nil.
+func WatchIndex(ctx context.Context, opts Options, registry *content.Registry, idx index.Index, stats *IndexWatchStats) error {
+	if idx == nil {
+		return fmt.Errorf("WatchIndex: nil index")
+	}
+	if registry == nil {
+		registry = content.DefaultRegistry()
+	}
+
+	// addDirsRecursive honours globs + .gitignore but NOT
+	// PruneBuildArtefacts — unlike WalkStream, which unions the build-
+	// excludes in. Resolve them once up front and merge so both the
+	// directory registration and the per-event excluder skip build
+	// artefacts. Mirrors walker.go's PruneBuildArtefacts handling.
+	excludes := opts.Excludes
+	if opts.PruneBuildArtefacts {
+		for _, root := range opts.Roots {
+			if extra, err := projecttype.CollectBuildExcludes(ctx, root); err == nil {
+				excludes = append(excludes, extra...)
+			}
+		}
+	}
+
+	buildOpts := opts.watchBuildOptions()
+
+	// Per-event excluder keyed off the first root. fsnotify still fires
+	// events for files inside watched dirs even if a specific basename
+	// would be pruned, so we re-check each path's basename here.
+	var excl *excluder
+	if len(opts.Roots) > 0 {
+		excl = newExcluder(os.DirFS(opts.Roots[0]), excludes, opts.RespectGitignore)
+	}
+
+	maintain := func(path string, op fsnotify.Op) {
+		if ctx.Err() != nil {
+			return
+		}
+		// Cache keys are absolute, cleaned paths (see celexpr's
+		// BuildAttributesWith). Normalise the event path the same way so
+		// PeekAttrs / Delete address the same entry BuildAttributesWith
+		// would Put under.
+		key := path
+		if abs, err := filepath.Abs(path); err == nil {
+			key = filepath.Clean(abs)
+		}
+		if op.Has(fsnotify.Remove) || op.Has(fsnotify.Rename) {
+			// The path is gone (rename source included — the destination
+			// arrives as a separate create). Drop its cache entry.
+			if err := idx.Delete(key); err == nil && stats != nil {
+				stats.Evicted.Add(1)
+			}
+			return
+		}
+		// Create / Write. Skip excluded paths so a churny build dir
+		// can't thrash the cache. Match against the root-relative path
+		// (forward slashes) so gitignore path-patterns work, not just
+		// basename globs.
+		if excl != nil {
+			rel := filepath.Base(path)
+			if len(opts.Roots) > 0 {
+				if r, err := filepath.Rel(opts.Roots[0], path); err == nil {
+					rel = filepath.ToSlash(r)
+				}
+			}
+			if excl.Match(rel, false) {
+				return
+			}
+		}
+		// Conservative gate: only refresh paths already in the cache.
+		if _, ok := idx.PeekAttrs(key); !ok {
+			return
+		}
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			return // vanished between event and stat, or a directory
+		}
+		dir := filepath.Dir(path)
+		base := filepath.Base(path)
+		// The miss (the entry is now stale) makes BuildAttributesWith
+		// re-parse and Put the fresh entry back itself — same side
+		// effect warmIndex relies on. No explicit Put needed.
+		if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(dir), base, path, registry, buildOpts); err != nil {
+			if stats != nil {
+				stats.Errors.Add(1)
+			}
+			return
+		}
+		if stats != nil {
+			stats.Refreshed.Add(1)
+		}
+	}
+
+	return watchLoop(ctx, opts.Roots, excludes, opts.RespectGitignore, maintain)
+}

--- a/internal/search/watch_index_test.go
+++ b/internal/search/watch_index_test.go
@@ -1,0 +1,258 @@
+package search
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/index"
+)
+
+// startWatchIndex runs WatchIndex in a goroutine and returns its stats
+// plus a cancel func that blocks until the watcher has fully drained.
+func startWatchIndex(t *testing.T, opts Options, idx index.Index) (stats *IndexWatchStats, cancel func()) {
+	t.Helper()
+	ctx, cancelFn := context.WithCancel(context.Background())
+	stats = &IndexWatchStats{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = WatchIndex(ctx, opts, content.DefaultRegistry(), idx, stats)
+	}()
+	// Let the watcher register the initial directories before the test
+	// starts mutating files.
+	time.Sleep(150 * time.Millisecond)
+	return stats, func() {
+		cancelFn()
+		<-done
+	}
+}
+
+// seedIndex parses path through the standard attribute path so it lands
+// in idx (the same side-effect warmIndex relies on), and asserts the
+// entry is now cached. Returns the cache key (abs, cleaned).
+func seedIndex(t *testing.T, idx index.Index, path string) string {
+	t.Helper()
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	if _, err := celexpr.BuildAttributesWith(
+		context.Background(), os.DirFS(dir), base, path,
+		content.DefaultRegistry(), celexpr.BuildOptions{Index: idx},
+	); err != nil {
+		t.Fatalf("seed BuildAttributesWith: %v", err)
+	}
+	key := path
+	if abs, err := filepath.Abs(path); err == nil {
+		key = filepath.Clean(abs)
+	}
+	if _, ok := idx.PeekAttrs(key); !ok {
+		t.Fatalf("seed failed: %s not cached under key %s", path, key)
+	}
+	return key
+}
+
+func TestWatchIndexRefreshesStaleEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "note.md")
+	if err := os.WriteFile(path, []byte("# hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idx := index.NewMemory()
+	key := seedIndex(t, idx, path)
+	before, _ := idx.PeekAttrs(key)
+
+	stats, cancel := startWatchIndex(t, Options{Roots: []string{dir}, Index: idx}, idx)
+	defer cancel()
+
+	// Grow the file. Sleep first so the mtime is observably newer (some
+	// filesystems have coarse mtime granularity).
+	time.Sleep(1100 * time.Millisecond)
+	if err := os.WriteFile(path, []byte("# hello\n\nmuch more content here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !waitFor(func() bool { return stats.Refreshed.Load() >= 1 }, 3*time.Second) {
+		t.Fatalf("WatchIndex did not refresh; stats=%+v", stats.Snapshot())
+	}
+	after, ok := idx.PeekAttrs(key)
+	if !ok {
+		t.Fatal("entry vanished after refresh")
+	}
+	if after.Size <= before.Size {
+		t.Errorf("expected refreshed size > %d, got %d", before.Size, after.Size)
+	}
+}
+
+func TestWatchIndexEvictsDeletedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doomed.md")
+	if err := os.WriteFile(path, []byte("# bye\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idx := index.NewMemory()
+	key := seedIndex(t, idx, path)
+
+	stats, cancel := startWatchIndex(t, Options{Roots: []string{dir}, Index: idx}, idx)
+	defer cancel()
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	if !waitFor(func() bool {
+		_, ok := idx.PeekAttrs(key)
+		return !ok
+	}, 3*time.Second) {
+		t.Fatalf("WatchIndex did not evict deleted file; stats=%+v", stats.Snapshot())
+	}
+	if stats.Evicted.Load() < 1 {
+		t.Errorf("expected Evicted >= 1, got %d", stats.Evicted.Load())
+	}
+}
+
+func TestWatchIndexSkipsUncachedCreate(t *testing.T) {
+	dir := t.TempDir()
+	idx := index.NewMemory()
+
+	stats, cancel := startWatchIndex(t, Options{Roots: []string{dir}, Index: idx}, idx)
+	defer cancel()
+
+	// Brand-new file that was never cached: the conservative gate must
+	// skip it (no speculative warming of transient files).
+	path := filepath.Join(dir, "fresh.md")
+	if err := os.WriteFile(path, []byte("# fresh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait past the debounce window plus margin, then assert no refresh.
+	time.Sleep(900 * time.Millisecond)
+	if got := stats.Refreshed.Load(); got != 0 {
+		t.Errorf("expected no refresh for uncached new file, got Refreshed=%d", got)
+	}
+	key := path
+	if abs, err := filepath.Abs(path); err == nil {
+		key = filepath.Clean(abs)
+	}
+	if _, ok := idx.PeekAttrs(key); ok {
+		t.Errorf("uncached new file should not have been added to the index")
+	}
+}
+
+func TestWatchIndexRenameEvictsOldPath(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "before.md")
+	if err := os.WriteFile(oldPath, []byte("# before\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idx := index.NewMemory()
+	oldKey := seedIndex(t, idx, oldPath)
+
+	stats, cancel := startWatchIndex(t, Options{Roots: []string{dir}, Index: idx}, idx)
+	defer cancel()
+
+	newPath := filepath.Join(dir, "after.md")
+	if err := os.Rename(oldPath, newPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if !waitFor(func() bool {
+		_, ok := idx.PeekAttrs(oldKey)
+		return !ok
+	}, 3*time.Second) {
+		t.Fatalf("WatchIndex did not evict renamed-away path; stats=%+v", stats.Snapshot())
+	}
+}
+
+func TestWatchIndexRespectsExcludes(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "node_modules")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sub, "pkg.md")
+	if err := os.WriteFile(path, []byte("# vendored\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idx := index.NewMemory()
+	// Even if somehow cached, an excluded path must not be refreshed.
+	key := seedIndex(t, idx, path)
+
+	stats, cancel := startWatchIndex(t, Options{
+		Roots:    []string{dir},
+		Index:    idx,
+		Excludes: []string{"node_modules"},
+	}, idx)
+	defer cancel()
+
+	if err := os.WriteFile(path, []byte("# vendored\n\nmore\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(900 * time.Millisecond)
+	if got := stats.Refreshed.Load(); got != 0 {
+		t.Errorf("expected no refresh for excluded path, got Refreshed=%d", got)
+	}
+	_ = key
+}
+
+// TestWatchLoopDebounceCoalesces verifies the shared event loop collapses
+// a rapid write burst into a single onEvent and that a create-then-remove
+// within the window resolves to the final (remove) op.
+func TestWatchLoopDebounceCoalesces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "burst.txt")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var mu sync.Mutex
+	var events []string // "op:base"
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = watchLoop(ctx, []string{dir}, nil, false, func(p string, op fsnotify.Op) {
+			mu.Lock()
+			defer mu.Unlock()
+			tag := "write"
+			if op.Has(fsnotify.Remove) || op.Has(fsnotify.Rename) {
+				tag = "gone"
+			}
+			events = append(events, tag+":"+filepath.Base(p))
+		})
+	}()
+	defer func() { cancel(); <-done }()
+	time.Sleep(150 * time.Millisecond)
+
+	// Rapid create-then-remove inside the debounce window.
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("xy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	if !waitFor(func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) >= 1
+	}, 3*time.Second) {
+		t.Fatal("watchLoop emitted no event")
+	}
+	// Allow any stragglers to land.
+	time.Sleep(400 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 coalesced event, got %d: %v", len(events), events)
+	}
+	if events[0] != "gone:burst.txt" {
+		t.Errorf("expected final op to be the remove (gone:burst.txt), got %q", events[0])
+	}
+}


### PR DESCRIPTION
## Context

Answers *"In MCP mode, can we proactively watch the filesystem for changes?"* — server-internal direction (the chosen one from planning).

**Why not push-to-agent?** Claude Code doesn't support MCP resource subscriptions, and its only push mechanism (the research-preview Channels feature) is opt-in per session and blocked by the pinned go-sdk v1.6.1 having no public custom-notification API. The existing `watch_search` tool already covers the *pull* case. So this PR does the useful server-internal thing instead.

## What it does

The on-disk index is validated lazily by `(size, mtime)`, so results are **always correct** — a changed file re-parses on its next lookup. But:
- after `--warm` pre-populates the cache, edits silently **stale** those entries (next query pays a cold re-parse), and
- lazy validation never **removes** entries for deleted files, so the bbolt file accumulates dead paths forever.

`--watch-index` adds a background fsnotify watcher on the warm root that:
1. **re-parses an already-cached file when it changes** → the *next* query is a warm hit (conservative gate: only refreshes paths already cached, so a churny tree of transient files isn't speculatively parsed);
2. **evicts the cache entry on delete/rename** → the GC nothing else in the system does.

> **Honest framing:** this is a **latency + hygiene** optimisation, **not** a correctness fix.

## Flags

| Flag | Effect |
|---|---|
| `--watch-index` | enable the maintainer (auto-on when `--warm`/`--warm-dir` is set) |
| `--no-watch-index` | opt out even under `--warm` |
| `--watch-index-dir <dir>` | watch a root without a startup warm pass |

Off by default outside `--warm`: the watcher registers one OS watch per directory, so pointing it at `$HOME` exhausts the kernel watch limit. Honours `.gitignore` and prunes build-artefact dirs (`node_modules`, `target`, …).

## Implementation

- **`internal/search/watch.go`** — extracted a shared `watchLoop` primitive (fsnotify + recursive registration + debounce), now used by both `Watch` and the new maintainer. It forwards `Remove`/`Rename` (which `Watch` ignored), coalesces latest-op-wins per path, and **drains in-flight debounced callbacks before returning** so `onEvent` can't touch a closed index.
- **`internal/search/watch_index.go`** (new) — `WatchIndex` + `IndexWatchStats`.
- **`cmd/file-search-on/mcp_cmd.go`** — three flags, root resolution, watcher goroutine under the server-lifetime ctx, self-cancelling join defer ordered before `idx.Close()`.
- **`index_stats` tool** — reports `watch_refreshed` / `watch_evicted` / `watch_errors` (zero when no watcher wired), via a new `WithIndexWatchStats` option.
- Docs: README MCP section, `examples/indexing.md`, the `file-search-on-mcp` skill.

## Tests

`internal/search/watch_index_test.go` covers refresh-stale, evict-deleted, skip-uncached-create, rename eviction, exclude pruning, and the debounce create-then-delete race. Existing `watch_test.go` passes unchanged. `index_stats` test asserts the new fields default to zero without a watcher.

## Verification

- `go build ./...`, `go test -race ./...` (all packages green), `go vet ./...`, `golangci-lint run` (0 issues), `go fix -diff ./...` (empty).
- Manual smoke: `file-search-on mcp --warm-dir <tmp> --watch-index` logs `watch-index: maintaining cache for <tmp>`, starts the watcher, and shuts down cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)