### PR TITLE
feat(safety): mcp/watch refuse to start outside $HOME unless opted out

### DIFF
--- a/.claude/skills/file-search-on-mcp/references/foot-guns.md
+++ b/.claude/skills/file-search-on-mcp/references/foot-guns.md
@@ -23,6 +23,10 @@ In **stdio** mode the MCP server inherits the launching process's cwd. Relative 
 
 `~` expansion happens in the server, not the agent — `"~/Pictures"` works even when the agent's shell isn't bash.
 
+## The server refuses to start outside your home directory
+
+By default `file-search-on mcp` won't start unless its working root(s) — the cwd plus any `--warm-dir` / `--watch-index-dir` / `--sandbox-dir` — are inside `$HOME`. This is a startup safety guard (it does NOT police per-call `dir` inputs — that's `--sandbox`). If you launch the server from a non-home location (another volume, `/opt`, or a container/CI runner with no `HOME`), startup is refused with a `home-guard:` error; pass `--allow-outside-home` to override. The `watch` subcommand has the same guard over its `-d` directories.
+
 ## `include_body` is the most expensive flag
 
 When `include_body: true`, the server reads every candidate file's body (up to `body_max_bytes`, default 1 MiB) so the `body` CEL variable is populated. On a tree of thousands of files this is gigabytes of I/O.

--- a/README.md
+++ b/README.md
@@ -429,6 +429,23 @@ file-search-on mcp --timeout 90s                         # raise the per-call de
 
 For HTTP and SSE, `--addr` (default `:8080`) is the bind address and `--path` (default `/`) is the URL prefix. `--timeout` (default `60s`) sets the per-tool-call deadline; per-call `timeout_seconds` on the `search` tool input overrides it.
 
+### Home-directory safety guard
+
+By default both long-running subcommands (`mcp` and `watch`) **refuse to start unless the directory they operate on is inside your home directory.** This stops an agent-driven server or a background watcher from being aimed — by an errant `cwd`, `--warm-dir`, or `-d` — at system paths or an entire volume.
+
+- For `mcp`, the guarded roots are the **cwd** (the default any tool call inherits when it omits `dir`) plus any explicit `--warm-dir` / `--watch-index-dir` / `--sandbox-dir`. So `cd /etc && file-search-on mcp` is refused.
+- For `watch`, every `-d` directory is checked.
+- `$HOME` itself and anything beneath it pass; symlinks are resolved on both sides before the check.
+
+Opt out with **`--allow-outside-home`** when you genuinely need to serve or watch a directory elsewhere:
+
+```sh
+cd /opt/data && file-search-on mcp --allow-outside-home     # serve a non-home root
+file-search-on watch -d /Volumes/Media --allow-outside-home  # watch another volume
+```
+
+The guard is **fail-closed**: if `$HOME` can't be determined (e.g. a container or CI runner with no `HOME` set), startup is refused until you set `HOME` or pass `--allow-outside-home`. It's independent of `--sandbox` — the guard is a startup check on the server's own root(s), while `--sandbox` governs the per-call `dir` inputs an agent supplies at runtime.
+
 Twenty tools are exposed, grouped by family:
 
 **Search & inspect**

--- a/cmd/file-search-on/homeguard.go
+++ b/cmd/file-search-on/homeguard.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/richardwooding/file-search-on/internal/pathguard"
+)
+
+// ensureUnderHome is the startup safety guard for the long-running
+// subcommands (mcp, watch): it refuses to proceed unless every monitored
+// directory resolves inside the user's home directory. This stops an
+// agent-driven server or a background watcher from being pointed at
+// system paths or an entire volume by an errant cwd / --warm-dir / -d.
+//
+// Semantics:
+//   - allowOutside short-circuits the guard (explicit operator opt-out
+//     via --allow-outside-home), printing a one-line stderr notice.
+//   - Fail-closed: an unresolvable $HOME is itself an error — the guard
+//     can't confine what it can't locate, so it refuses rather than
+//     silently passing. Container / CI runners with no $HOME must set
+//     HOME or pass --allow-outside-home.
+//   - Both the candidate dir and $HOME are canonicalised the same way
+//     (pathguard.Canonical: abs + clean + symlink-resolve) so a
+//     symlinked home or a macOS /tmp→/private/tmp quirk never causes a
+//     false reject. $HOME itself counts as inside (inclusive boundary).
+//
+// Empty dir entries are skipped; duplicates are only reported once.
+func ensureUnderHome(dirs []string, allowOutside bool) error {
+	if allowOutside {
+		fmt.Fprintln(os.Stderr, "home-guard: bypassed (--allow-outside-home)")
+		return nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("home-guard: cannot determine your home directory (%v); "+
+			"set HOME or pass --allow-outside-home to run anyway", err)
+	}
+	canonHome := pathguard.Canonical(home)
+
+	seen := make(map[string]bool)
+	for _, d := range dirs {
+		if d == "" {
+			continue
+		}
+		canon := pathguard.Canonical(d)
+		if seen[canon] {
+			continue
+		}
+		seen[canon] = true
+		if !pathguard.Under(canon, canonHome) {
+			return fmt.Errorf("home-guard: %q (%s) is not inside your home directory (%s); "+
+				"pass --allow-outside-home to run anyway", d, canon, canonHome)
+		}
+	}
+	return nil
+}

--- a/cmd/file-search-on/homeguard_test.go
+++ b/cmd/file-search-on/homeguard_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureUnderHome(t *testing.T) {
+	home := t.TempDir()
+	outside := t.TempDir() // sibling of home — not inside it
+	under := filepath.Join(home, "proj")
+	if err := os.MkdirAll(under, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("dir under home passes", func(t *testing.T) {
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		if err := ensureUnderHome([]string{under}, false); err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("home itself passes (inclusive)", func(t *testing.T) {
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		if err := ensureUnderHome([]string{home}, false); err != nil {
+			t.Errorf("expected nil for home itself, got %v", err)
+		}
+	})
+
+	t.Run("dir outside home is refused", func(t *testing.T) {
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		err := ensureUnderHome([]string{outside}, false)
+		if err == nil {
+			t.Fatal("expected refusal for dir outside home")
+		}
+		if !strings.Contains(err.Error(), "--allow-outside-home") {
+			t.Errorf("error should name the opt-out flag, got %v", err)
+		}
+	})
+
+	t.Run("opt-out allows outside dir", func(t *testing.T) {
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		if err := ensureUnderHome([]string{outside}, true); err != nil {
+			t.Errorf("opt-out should pass, got %v", err)
+		}
+	})
+
+	t.Run("one outside dir among several is refused", func(t *testing.T) {
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		if err := ensureUnderHome([]string{under, outside}, false); err == nil {
+			t.Fatal("expected refusal when any dir is outside home")
+		}
+	})
+
+	t.Run("empty dirs pass", func(t *testing.T) {
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		if err := ensureUnderHome([]string{"", ""}, false); err != nil {
+			t.Errorf("empty dirs should pass, got %v", err)
+		}
+	})
+}
+
+func TestEnsureUnderHome_NoHomeFailsClosed(t *testing.T) {
+	home := t.TempDir()
+	under := filepath.Join(home, "proj")
+	if err := os.MkdirAll(under, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Unset both so os.UserHomeDir errors on every platform.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+
+	if err := ensureUnderHome([]string{under}, false); err == nil {
+		t.Error("expected fail-closed error when $HOME is unresolvable")
+	}
+	// Opt-out still works without a resolvable home.
+	if err := ensureUnderHome([]string{under}, true); err != nil {
+		t.Errorf("opt-out should pass even without $HOME, got %v", err)
+	}
+}
+
+// TestWatchCmd_RefusesOutsideHome confirms the guard fires at Run entry,
+// before any index/watcher side effects, so an outside -d is rejected.
+func TestWatchCmd_RefusesOutsideHome(t *testing.T) {
+	home := t.TempDir()
+	outside := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	c := &WatchCmd{Dir: []string{outside}}
+	err := c.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected watch to refuse an outside -d directory")
+	}
+	if !strings.Contains(err.Error(), "home-guard") {
+		t.Errorf("expected a home-guard error, got %v", err)
+	}
+}
+
+// TestMCPCmd_RefusesOutsideHome confirms the mcp server refuses to start
+// when an explicit root is outside $HOME (the guard runs first, so the
+// server never binds).
+func TestMCPCmd_RefusesOutsideHome(t *testing.T) {
+	home := t.TempDir()
+	outside := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	m := &MCPCmd{WarmDir: outside}
+	err := m.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected mcp to refuse an outside --warm-dir")
+	}
+	if !strings.Contains(err.Error(), "home-guard") {
+		t.Errorf("expected a home-guard error, got %v", err)
+	}
+}

--- a/cmd/file-search-on/mcp_cmd.go
+++ b/cmd/file-search-on/mcp_cmd.go
@@ -38,9 +38,26 @@ type MCPCmd struct {
 	WatchIndexDir     string        `name:"watch-index-dir" help:"Directory the index watcher monitors. Defaults to --warm-dir, then the cwd at server start. Implies --watch-index."`
 	Sandbox           bool          `name:"sandbox" help:"Restrict agent filesystem access to the cwd at server startup. Path-accepting MCP tool inputs (dir / dirs / path / tree_a / tree_b / hash_allowlist_path / hash_denylist_path) that resolve outside the sandbox are rejected with a clear error. Off by default; opt in when running file-search-on as an MCP server for an agent you want to scope to a single project. Combine with --sandbox-dir to specify explicit roots."`
 	SandboxDir        []string      `name:"sandbox-dir" help:"Sandbox root directory. Repeatable for multiple roots (e.g. --sandbox-dir ~/Code/foo --sandbox-dir ~/Code/bar). Implies --sandbox. Symlinks pointing outside the sandbox are rejected; follow_symlinks=true is rejected entirely when the sandbox is active (the walker doesn't yet enforce sandbox per-entry)."`
+	AllowOutsideHome  bool          `name:"allow-outside-home" help:"Bypass the home-directory safety guard. By default the mcp server refuses to start unless its working root(s) — the cwd plus any --warm-dir / --watch-index-dir / --sandbox-dir — are inside your home directory, to avoid serving an agent system paths or an entire volume. Pass this to serve a directory elsewhere (other volumes, /opt, /srv) or in a container/CI runner where HOME isn't set. Independent of --sandbox, which governs per-call tool inputs."`
 }
 
 func (m *MCPCmd) Run(ctx context.Context) error {
+	// Safety guard: refuse to start unless the server's working root(s)
+	// are inside $HOME. The implicit root is the cwd (the default for
+	// tool calls that omit a dir); any explicit warm / watch-index /
+	// sandbox roots are checked too. Runs before any side effects. A
+	// failing os.Getwd is itself a guard failure (fail-closed).
+	guardDirs := append([]string(nil), m.WarmDir, m.WatchIndexDir)
+	guardDirs = append(guardDirs, m.SandboxDir...)
+	if cwd, err := os.Getwd(); err == nil {
+		guardDirs = append(guardDirs, cwd)
+	} else if !m.AllowOutsideHome {
+		return fmt.Errorf("home-guard: cannot determine the working directory (%v); pass --allow-outside-home to run anyway", err)
+	}
+	if err := ensureUnderHome(guardDirs, m.AllowOutsideHome); err != nil {
+		return err
+	}
+
 	idx, backend, err := openIndex(m.IndexPath, m.NoIndex, index.BodyCacheCap{MaxBytes: int64(m.BodyCacheMaxBytes), Disable: m.NoBodyCache})
 	if err != nil {
 		return err

--- a/cmd/file-search-on/watch_cmd.go
+++ b/cmd/file-search-on/watch_cmd.go
@@ -38,9 +38,16 @@ type WatchCmd struct {
 	Monitor          bool          `name:"monitor" help:"No-op — the monitoring dashboard is on by default since v0.65.0. Kept for back-compat with pre-existing scripts. Use --no-monitor to opt out, --monitor-addr to pin a fixed port."`
 	NoMonitor        bool          `name:"no-monitor" help:"Disable the read-only monitoring dashboard for this run. Useful for hermetic CI / sandboxed environments where binding a localhost port is undesirable. (Watch mode has no MCP tools, so the dashboard cannot be re-enabled mid-session.)"`
 	MonitorAddr      string        `name:"monitor-addr" help:"Bind the monitoring dashboard on this fixed port (e.g. ':9090') instead of an OS-assigned dynamic port. Binds 127.0.0.1 only. Overrides the default dynamic-port behaviour. Shows index cache stats + capabilities + a peer switcher at http://localhost:<port>/ (no MCP activity panel in watch mode)."`
+	AllowOutsideHome bool          `name:"allow-outside-home" help:"Bypass the home-directory safety guard. By default watch refuses to start unless every -d directory is inside your home directory, to avoid a long-running watcher over system paths or an entire volume. Pass this to watch a directory elsewhere (other volumes, /opt, /srv) or in a container/CI runner where HOME isn't set."`
 }
 
 func (c *WatchCmd) Run(ctx context.Context) error {
+	// Safety guard: refuse to watch a directory outside $HOME unless the
+	// operator explicitly opts out. Runs before any side effects.
+	if err := ensureUnderHome(c.Dir, c.AllowOutsideHome); err != nil {
+		return err
+	}
+
 	var tmpl *template.Template
 	if c.Format != "" {
 		t, err := parseFormatTemplate(c.Format)

--- a/examples/watch.md
+++ b/examples/watch.md
@@ -46,6 +46,16 @@ file-search-on watch -d ./incoming -o bare
 
 Flags mirror `search` where they make sense: `--body` / `--body-max-bytes`, `--ocr` / `--ocr-timeout`, `--with-hashes`, `--with-phash`, `--with-xattrs`, `--exclude`, `--respect-gitignore`, `--index-path`. Ranking, semantic embedding, and project resolution are omitted — they're walk-collection concerns, not single-file-event concerns.
 
+### Home-directory safety guard
+
+`watch` refuses to start unless every `-d` directory is inside your home directory — a guard against accidentally aiming a long-running watcher at system paths or an entire volume. To watch elsewhere (another volume, `/opt`, `/srv`, or in a container where `HOME` isn't set), pass `--allow-outside-home`:
+
+```sh
+file-search-on watch 'is_video' -d /Volumes/Media --allow-outside-home
+```
+
+`$HOME` itself and anything under it pass. The guard is fail-closed: if `$HOME` can't be determined it refuses until you set `HOME` or opt out. The `mcp` server has the same guard (covering its cwd + `--warm-dir` / `--watch-index-dir` / `--sandbox-dir`).
+
 NDJSON output is the same wire shape as `search -o json`, so the same `jq` recipes work:
 
 ```sh

--- a/internal/mcpserver/sandbox.go
+++ b/internal/mcpserver/sandbox.go
@@ -4,7 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
+
+	"github.com/richardwooding/file-search-on/internal/pathguard"
 )
 
 // errSandboxFollowSymlinksUnsupported is returned when a walk tool is
@@ -89,44 +90,13 @@ func (h *handlers) validatePath(p string) (string, error) {
 		return "", fmt.Errorf("sandbox: resolve %q: %w", p, err)
 	}
 	abs = filepath.Clean(abs)
-	resolved := resolveDeepest(abs)
+	resolved := pathguard.ResolveDeepest(abs)
 	for _, root := range h.sandbox {
-		if pathUnder(resolved, root) {
+		if pathguard.Under(resolved, root) {
 			return abs, nil
 		}
 	}
 	return "", fmt.Errorf("sandbox: %q is outside the allowed roots %v", p, h.sandbox)
-}
-
-// resolveDeepest walks up p until filepath.EvalSymlinks succeeds, then
-// reattaches the non-existent suffix. This canonicalises symlinked
-// ancestors (e.g. /tmp → /private/tmp on macOS) for paths that don't
-// fully exist yet — important so the sandbox check sees the same
-// canonical form for both existing and not-yet-existing inputs.
-// Returns abs unchanged when no ancestor resolves.
-func resolveDeepest(abs string) string {
-	suffix := ""
-	cur := abs
-	for {
-		if r, err := filepath.EvalSymlinks(cur); err == nil {
-			if suffix == "" {
-				return filepath.Clean(r)
-			}
-			return filepath.Clean(filepath.Join(r, suffix))
-		}
-		parent := filepath.Dir(cur)
-		if parent == cur {
-			// Reached the root without finding a resolvable ancestor.
-			return abs
-		}
-		base := filepath.Base(cur)
-		if suffix == "" {
-			suffix = base
-		} else {
-			suffix = filepath.Join(base, suffix)
-		}
-		cur = parent
-	}
 }
 
 // validatePaths is the slice variant for tools that take `dirs` /
@@ -157,16 +127,4 @@ func (h *handlers) checkFollowSymlinks(follow bool) error {
 		return errSandboxFollowSymlinksUnsupported
 	}
 	return nil
-}
-
-// pathUnder is a separator-aware "is p inside root?" prefix check.
-// Returns true when p == root (the root itself is a valid input) or
-// when p starts with root + the path separator (so "/home/foo-bar"
-// doesn't sneak through when root is "/home/foo"). Both inputs are
-// expected to be canonical (filepath.Clean + Abs) before being passed.
-func pathUnder(p, root string) bool {
-	if p == root {
-		return true
-	}
-	return strings.HasPrefix(p, root+string(filepath.Separator))
 }

--- a/internal/mcpserver/sandbox_test.go
+++ b/internal/mcpserver/sandbox_test.go
@@ -270,17 +270,7 @@ func TestWithSandbox_NilLeavesSandboxEmpty(t *testing.T) {
 	}
 }
 
-func TestPathUnder_ExactMatch(t *testing.T) {
-	if !pathUnder("/a/b", "/a/b") {
-		t.Errorf("exact match should be 'under'")
-	}
-}
-
-func TestPathUnder_SeparatorAware(t *testing.T) {
-	if pathUnder("/a/foo-bar", "/a/foo") {
-		t.Errorf("/a/foo-bar should NOT be under /a/foo (prefix collision)")
-	}
-	if !pathUnder("/a/foo/x", "/a/foo") {
-		t.Errorf("/a/foo/x should be under /a/foo")
-	}
-}
+// The separator-aware containment check moved to internal/pathguard;
+// its exact-match and prefix-collision behaviour is covered by
+// pathguard.TestUnder. The sandbox tests above exercise it end-to-end
+// through validatePath.

--- a/internal/pathguard/pathguard.go
+++ b/internal/pathguard/pathguard.go
@@ -1,0 +1,71 @@
+// Package pathguard provides separator-aware path-containment checks and
+// symlink-aware canonicalization shared by the MCP sandbox (per-call
+// tool-input validation) and the CLI home guard (startup confinement of
+// the monitored directory to $HOME).
+//
+// Both inputs to Under are expected to be canonical (see Canonical) so
+// the prefix comparison is meaningful. The logic here was extracted from
+// the original internal/mcpserver/sandbox.go so the two features can't
+// drift in how they decide "is this path inside that directory?".
+package pathguard
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Under is a separator-aware "is p inside root?" prefix check. Returns
+// true when p == root (the root itself counts as inside) or when p
+// starts with root + the path separator — so "/home/foo-bar" doesn't
+// sneak through when root is "/home/foo". Both inputs are expected to be
+// canonical (Canonical) before being passed.
+func Under(p, root string) bool {
+	if p == root {
+		return true
+	}
+	return strings.HasPrefix(p, root+string(filepath.Separator))
+}
+
+// ResolveDeepest walks up abs until filepath.EvalSymlinks succeeds, then
+// reattaches the non-existent suffix. This canonicalises symlinked
+// ancestors (e.g. /tmp → /private/tmp on macOS) for paths that don't
+// fully exist yet — important so containment checks see the same
+// canonical form for both existing and not-yet-existing inputs. Returns
+// abs unchanged when no ancestor resolves.
+func ResolveDeepest(abs string) string {
+	suffix := ""
+	cur := abs
+	for {
+		if r, err := filepath.EvalSymlinks(cur); err == nil {
+			if suffix == "" {
+				return filepath.Clean(r)
+			}
+			return filepath.Clean(filepath.Join(r, suffix))
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached the root without finding a resolvable ancestor.
+			return abs
+		}
+		base := filepath.Base(cur)
+		if suffix == "" {
+			suffix = base
+		} else {
+			suffix = filepath.Join(base, suffix)
+		}
+		cur = parent
+	}
+}
+
+// Canonical resolves path to an absolute, symlink-aware canonical form:
+// filepath.Abs → filepath.Clean → ResolveDeepest. Falls back to a
+// lexical filepath.Clean when Abs fails (e.g. the cwd is unavailable).
+// Use it on BOTH sides of an Under check so a symlinked $HOME or a macOS
+// /tmp quirk doesn't cause a false mismatch.
+func Canonical(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return ResolveDeepest(filepath.Clean(abs))
+}

--- a/internal/pathguard/pathguard_test.go
+++ b/internal/pathguard/pathguard_test.go
@@ -1,0 +1,72 @@
+package pathguard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUnder(t *testing.T) {
+	sep := string(filepath.Separator)
+	root := filepath.Join(sep+"home", "foo")
+	cases := []struct {
+		name string
+		p    string
+		want bool
+	}{
+		{"exact match", root, true},
+		{"direct child", filepath.Join(root, "proj"), true},
+		{"deep child", filepath.Join(root, "a", "b", "c"), true},
+		{"sibling prefix not under", filepath.Join(sep+"home", "foo-bar"), false},
+		{"parent not under", filepath.Join(sep + "home"), false},
+		{"unrelated", filepath.Join(sep+"etc", "passwd"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Under(tc.p, root); got != tc.want {
+				t.Errorf("Under(%q, %q) = %v, want %v", tc.p, root, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonical_RelativeBecomesAbsolute(t *testing.T) {
+	got := Canonical(".")
+	if !filepath.IsAbs(got) {
+		t.Errorf("Canonical(\".\") = %q, want an absolute path", got)
+	}
+}
+
+func TestCanonical_ResolvesSymlinkedAncestor(t *testing.T) {
+	// real/sub exists; link → real. Canonical(link/sub/new) should
+	// resolve through the symlink to real/sub/new even though "new"
+	// doesn't exist.
+	tmp := t.TempDir()
+	real := filepath.Join(tmp, "real")
+	if err := os.MkdirAll(filepath.Join(real, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(tmp, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+	got := Canonical(filepath.Join(link, "sub", "new"))
+	want := Canonical(filepath.Join(real, "sub", "new"))
+	if got != want {
+		t.Errorf("Canonical via symlink = %q, want %q", got, want)
+	}
+	// And the resolved path is genuinely under the real dir.
+	if !Under(got, Canonical(real)) {
+		t.Errorf("resolved %q not under %q", got, Canonical(real))
+	}
+}
+
+func TestCanonical_NonExistentFallsBackLexically(t *testing.T) {
+	// A fully non-existent absolute path with no resolvable ancestor
+	// (other than the filesystem root) should clean to itself.
+	p := filepath.Join(string(filepath.Separator), "nonexistent-xyz-123", "deep", "leaf")
+	got := Canonical(p)
+	if got != filepath.Clean(p) {
+		t.Errorf("Canonical(%q) = %q, want %q", p, got, filepath.Clean(p))
+	}
+}


### PR DESCRIPTION
## What

Both long-running subcommands (`mcp` and `watch`) now **refuse to start unless the directory they operate on is inside your home directory** — a guard against an agent-driven server or a background watcher being aimed (by an errant cwd, `--warm-dir`, or `-d`) at system paths or an entire volume.

| Command | Guarded roots |
|---|---|
| `mcp` | the **cwd** (the default any tool call inherits when it omits `dir`) **plus** any explicit `--warm-dir` / `--watch-index-dir` / `--sandbox-dir` |
| `watch` | every `-d` directory |

- `$HOME` itself and anything under it pass. Both sides are canonicalised (abs + clean + symlink-resolve), so a symlinked `$HOME` or macOS `/tmp → /private/tmp` never causes a false reject.
- **Fail-closed:** an unresolvable `$HOME` (a container / CI runner with no `HOME`) is itself a refusal.

Opt out with **`--allow-outside-home`** (on both commands):

```
$ cd /tmp && file-search-on watch -d /tmp
Error: home-guard: "/tmp" (/private/tmp) is not inside your home directory (/Users/me); pass --allow-outside-home to run anyway
```

The guard is a **startup** check on the server's own root(s) — it's independent of `--sandbox`, which governs the per-call `dir` inputs an agent supplies at runtime.

## Implementation

- **New `internal/pathguard` package** holds the separator-aware containment (`Under`) and symlink-aware canonicalisation (`ResolveDeepest`, `Canonical`), **extracted verbatim from the mcpserver sandbox** so the two features can't drift. `sandbox.go` now delegates to it — behaviour-preserving, guarded by the existing `sandbox_test.go`.
- **New `cmd/file-search-on/homeguard.go`**: `ensureUnderHome(dirs, allowOutside)`, called as the first statement in each `Run` before any side effects.
- `--allow-outside-home` flag added to `MCPCmd` and `WatchCmd`.

## ⚠️ Breaking change

Anyone running `mcp`/`watch` from outside `$HOME` (other volumes, `/opt`, `/srv`, or a **container without `HOME` set**) must now pass `--allow-outside-home`. Documented in the README MCP section, `examples/watch.md`, and the skill foot-guns reference.

## Tests / verification

- `internal/pathguard/pathguard_test.go` (Under, Canonical incl. symlinked ancestor + non-existent fallback).
- `cmd/file-search-on/homeguard_test.go` — fake `$HOME` via `t.Setenv`: under-home passes, home itself passes, outside refused (error names the flag), opt-out passes, no-`$HOME` fail-closed; plus Run-level refusal tests for both `mcp` and `watch`.
- Existing `sandbox_test.go` passes unchanged (guards the extraction).
- `go build ./...`, `go test -race ./...` (all green), `go vet`, `golangci-lint` (0 issues), `go fix -diff` (empty). Manual smoke confirmed all four paths (refuse outside / opt-out / no-HOME / allow under-home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)