### PR TITLE
fix(celexpr): stop embedding vector and attributes clobbering each other in the cache (#306, #308)

### DIFF
--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -717,16 +718,31 @@ func BuildAttributesWith(ctx context.Context, fsys fs.FS, fsPath, displayPath st
 	// we never wait for the write. Body is NOT included in the cached
 	// Extra — it's read on demand per call (see cache-hit branch
 	// above) and would otherwise bloat the index file.
+	//
+	// cacheEntry is the SINGLE entry the enrichment helpers below
+	// (populateHashes / populatePHash / populateSimilarity) merge into:
+	// they receive it as their `cached` argument and stamp their own
+	// fields onto it before re-Put-ing the same value. Without this,
+	// each helper Put a SEPARATE minimal entry to the same key and the
+	// last write clobbered the others — dropping the parsed Extra (the
+	// embedding-vs-attributes clobber behind issue #306 / Finding #5).
+	var cacheEntry *index.Entry
 	if opts.Index != nil && cacheKey != "" {
-		_ = opts.Index.Put(cacheKey, &index.Entry{
+		// Clone the parsed attributes: the helpers below re-Put
+		// cacheEntry after `extra` gains the on-demand body and the
+		// per-walk project context (neither of which belongs in the
+		// (size, mtime) cache), so the cached copy must be decoupled
+		// from later mutations to `extra`.
+		cacheEntry = &index.Entry{
 			Size:                 info.Size(),
 			ModTimeUnixNano:      info.ModTime().UnixNano(),
 			ContentType:          contentTypeName,
-			Extra:                map[string]any(extra),
+			Extra:                maps.Clone(map[string]any(extra)),
 			MagicContentType:     magicCT,
 			ExtensionContentType: extCT,
 			DisguiseChecked:      opts.CheckDisguised,
-		})
+		}
+		_ = opts.Index.Put(cacheKey, cacheEntry)
 	}
 
 	// Add body to the returned Extra (separately from the cached
@@ -795,7 +811,7 @@ func BuildAttributesWith(ctx context.Context, fsys fs.FS, fsPath, displayPath st
 	// so populateHashes always computes when ComputeHashes is set. The
 	// fresh values flow back into the cache so subsequent walks hit.
 	if opts.ComputeHashes {
-		populateHashes(ctx, displayPath, cacheKey, info, nil, attrs, opts.Index)
+		populateHashes(ctx, displayPath, cacheKey, info, cacheEntry, attrs, opts.Index)
 	}
 	// Perceptual image hash (issue #208). Cache-miss path: compute
 	// + Put back. Gated to image/* content types inside populatePHash.
@@ -803,13 +819,13 @@ func BuildAttributesWith(ctx context.Context, fsys fs.FS, fsPath, displayPath st
 		if attrs.Extra == nil {
 			attrs.Extra = content.Attributes{}
 		}
-		populatePHash(ctx, fsys, fsPath, displayPath, cacheKey, contentTypeName, info, nil, attrs.Extra, opts.Index)
+		populatePHash(ctx, fsys, fsPath, displayPath, cacheKey, contentTypeName, info, cacheEntry, attrs.Extra, opts.Index)
 	}
 	if opts.Allowlist != nil || opts.Denylist != nil {
 		applyKnownStatus(attrs, opts)
 	}
 	if opts.Embedder != nil && len(opts.SemanticQueryEmbedding) > 0 {
-		populateSimilarity(ctx, fsys, fsPath, displayPath, cacheKey, info, nil, attrs, opts)
+		populateSimilarity(ctx, fsys, fsPath, displayPath, cacheKey, info, cacheEntry, attrs, opts)
 	}
 	if opts.CheckDisguised {
 		applyDisguise(attrs, magicCT, extCT)

--- a/internal/celexpr/similarity_test.go
+++ b/internal/celexpr/similarity_test.go
@@ -412,3 +412,179 @@ func TestEmbedder_NoModel_Surfaces(t *testing.T) {
 		t.Errorf("Similarity=%f want 0 with no model", a.Similarity)
 	}
 }
+
+// mockEmbedServer returns an httptest Ollama mock that always answers
+// with the given vector, plus a counter of how many embed calls it
+// served. Shared by the cache-clobber regression tests below.
+func mockEmbedServer(t *testing.T, vec []float32, calls *int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		*calls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": [][]float32{vec}})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestBuildAttributesWith_Similarity_MissPathRetainsExtra is the
+// regression for the cache-entry clobber behind issue #306 and
+// Finding #5. On the cache-MISS path BuildAttributesWith used to Put
+// an attribute entry (with parsed Extra) and then populateSimilarity
+// Put a SEPARATE vector-only entry to the same key — last write wins,
+// so the cached entry lost its Extra. A second semantic walk then
+// served a vector-only cache hit with no title/word_count.
+//
+// Asserts that after one semantic walk the cached entry carries BOTH
+// the embedding Vector AND the parsed Extra, and that a second walk
+// reuses the vector (EmbedHits) while still surfacing word_count.
+func TestBuildAttributesWith_Similarity_MissPathRetainsExtra(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.md")
+	mustWrite(t, path, "# My Title\n\nalpha beta gamma delta epsilon\n")
+
+	abs, _ := filepath.Abs(path)
+	base := filepath.Base(abs)
+	parent := filepath.Dir(abs)
+
+	calls := 0
+	srv := mockEmbedServer(t, []float32{1, 0, 0}, &calls)
+	embedder := embed.NewOllama(srv.URL, "mock")
+	idx := index.NewMemory()
+	defer func() { _ = idx.Close() }()
+
+	opts := celexpr.BuildOptions{
+		Index:                  idx,
+		Embedder:               embedder,
+		SemanticQueryEmbedding: []float32{1, 0, 0},
+	}
+
+	// Walk 1: cache miss → parse attrs + embed + cache both.
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), opts); err != nil {
+		t.Fatalf("walk 1: %v", err)
+	}
+
+	// The single cached entry must carry both the vector and the Extra.
+	e, ok := idx.PeekAttrs(abs)
+	if !ok {
+		t.Fatalf("no cached entry for %s after walk 1", abs)
+	}
+	if len(e.Vector) == 0 {
+		t.Errorf("cached entry missing Vector after walk 1; entry=%+v", e)
+	}
+	if e.Extra == nil || e.Extra["word_count"] == nil {
+		t.Errorf("cached entry lost Extra (clobber bug): Extra=%v", e.Extra)
+	}
+
+	// Walk 2: cache hit → reuse the vector (no Ollama call) AND still
+	// surface the parsed attributes.
+	a2, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), opts)
+	if err != nil {
+		t.Fatalf("walk 2: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("walk 2 made %d total Ollama calls; want 1 (vector should be cached)", calls)
+	}
+	if idx.Stats().EmbedHits < 1 {
+		t.Errorf("walk 2: EmbedHits=%d want >= 1; stats=%+v", idx.Stats().EmbedHits, idx.Stats())
+	}
+	if a2.Extra == nil || a2.Extra["word_count"] == nil {
+		t.Errorf("walk 2: cache hit dropped word_count (Finding #5): Extra=%v", a2.Extra)
+	}
+}
+
+// TestBuildAttributesWith_Similarity_MixedTrafficCacheHit mirrors the
+// MCP server flow that issue #306 was filed against: the shared index
+// has already served a non-semantic query (so attributes are cached)
+// before any semantic query runs. A subsequent repeated semantic query
+// must reuse the cached embedding rather than re-embedding the file.
+func TestBuildAttributesWith_Similarity_MixedTrafficCacheHit(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.md")
+	mustWrite(t, path, "# Doc\n\nsome searchable body text here\n")
+
+	abs, _ := filepath.Abs(path)
+	base := filepath.Base(abs)
+	parent := filepath.Dir(abs)
+
+	calls := 0
+	srv := mockEmbedServer(t, []float32{1, 0, 0}, &calls)
+	embedder := embed.NewOllama(srv.URL, "mock")
+	idx := index.NewMemory()
+	defer func() { _ = idx.Close() }()
+
+	// Non-semantic walk first (no Embedder) — like a plain `search`.
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), celexpr.BuildOptions{Index: idx}); err != nil {
+		t.Fatalf("non-semantic walk: %v", err)
+	}
+
+	semOpts := celexpr.BuildOptions{
+		Index:                  idx,
+		Embedder:               embedder,
+		SemanticQueryEmbedding: []float32{1, 0, 0},
+	}
+	// First semantic walk embeds + caches the vector.
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), semOpts); err != nil {
+		t.Fatalf("semantic walk 1: %v", err)
+	}
+	// Second semantic walk must hit the cache.
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), semOpts); err != nil {
+		t.Fatalf("semantic walk 2: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 Ollama embed call across two semantic walks, got %d", calls)
+	}
+	if idx.Stats().EmbedHits < 1 {
+		t.Errorf("EmbedHits=%d want >= 1; stats=%+v", idx.Stats().EmbedHits, idx.Stats())
+	}
+}
+
+// TestBuildAttributesWith_Similarity_NonSemanticPreservesVector guards
+// the cross-tool race on the shared MCP index: once a file's embedding
+// is cached, a later non-semantic walk (plain search / stats) that
+// re-stat'd the file must NOT overwrite the cached entry with a
+// vector-less one. Re-running a non-semantic walk after a semantic
+// walk and then a third semantic walk must still hit the vector.
+func TestBuildAttributesWith_Similarity_NonSemanticPreservesVector(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.md")
+	mustWrite(t, path, "# Title\n\nbody text body text\n")
+
+	abs, _ := filepath.Abs(path)
+	base := filepath.Base(abs)
+	parent := filepath.Dir(abs)
+
+	calls := 0
+	srv := mockEmbedServer(t, []float32{1, 0, 0}, &calls)
+	embedder := embed.NewOllama(srv.URL, "mock")
+	idx := index.NewMemory()
+	defer func() { _ = idx.Close() }()
+
+	semOpts := celexpr.BuildOptions{
+		Index:                  idx,
+		Embedder:               embedder,
+		SemanticQueryEmbedding: []float32{1, 0, 0},
+	}
+
+	// Semantic walk caches the vector.
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), semOpts); err != nil {
+		t.Fatalf("semantic walk 1: %v", err)
+	}
+	// Non-semantic walk over the same file (no Embedder).
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), celexpr.BuildOptions{Index: idx}); err != nil {
+		t.Fatalf("non-semantic walk: %v", err)
+	}
+	// Vector must survive the non-semantic walk.
+	if e, ok := idx.PeekAttrs(abs); !ok || len(e.Vector) == 0 {
+		t.Fatalf("non-semantic walk wiped the cached vector; ok=%v entry=%+v", ok, e)
+	}
+	// Third walk: semantic again, must hit (no new Ollama call).
+	if _, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), semOpts); err != nil {
+		t.Fatalf("semantic walk 2: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 Ollama call; vector should have survived the non-semantic walk, got %d", calls)
+	}
+}

--- a/internal/mcpserver/search_semantic_cache_test.go
+++ b/internal/mcpserver/search_semantic_cache_test.go
@@ -1,0 +1,101 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+)
+
+// TestSearchSemanticReusesCachedEmbeddings is the MCP-level regression
+// for issue #306 (the server re-embedded the whole tree on every
+// search_semantic call) and Finding #5 (semantic matches dropped
+// title/author). A mock Ollama answers /api/embed with a fixed vector;
+// the same query is run twice against the same shared in-memory index.
+//
+// The second call must reuse the cached per-file embedding
+// (index_stats.embed_hits > 0, and the file is embedded exactly once)
+// and both calls must surface the file's title.
+func TestSearchSemanticReusesCachedEmbeddings(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "doc.md"), "# Neuromancer\n\ncyberspace console cowboy ICE\n")
+
+	// Mock Ollama: every embed (query + each file) returns [1,0,0], so
+	// cosine similarity is 1.0 and the file clears the threshold.
+	fileEmbeds := 0
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/embed" {
+			fileEmbeds++
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": [][]float32{{1, 0, 0}}})
+	}))
+	t.Cleanup(ollama.Close)
+
+	ctx := t.Context()
+	idx := index.NewMemory()
+	server := New("test", idx, 0, EmbedDefaults{Server: ollama.URL, Model: "mock"})
+
+	t1, t2 := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	semantic := func(label string) SearchSemanticOutput {
+		t.Helper()
+		res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "search_semantic",
+			Arguments: SearchSemanticInput{Query: "cyberpunk hacker", Dir: dir, Threshold: 0.4, Limit: 10},
+		})
+		if err != nil {
+			t.Fatalf("%s: CallTool: %v", label, err)
+		}
+		if res.GetError() != nil {
+			t.Fatalf("%s: tool error: %v", label, res.GetError())
+		}
+		var out SearchSemanticOutput
+		mustDecodeStructured(t, res, &out)
+		if out.Count != 1 || len(out.Matches) != 1 {
+			t.Fatalf("%s: Count=%d len(Matches)=%d want 1/1; out=%+v", label, out.Count, len(out.Matches), out)
+		}
+		return out
+	}
+
+	out1 := semantic("call 1")
+	if out1.Matches[0].Title != "Neuromancer" {
+		t.Errorf("call 1: Title=%q want %q", out1.Matches[0].Title, "Neuromancer")
+	}
+
+	out2 := semantic("call 2")
+	if out2.Matches[0].Title != "Neuromancer" {
+		t.Errorf("call 2 (cached): Title=%q want %q (Finding #5: cached semantic match dropped title)", out2.Matches[0].Title, "Neuromancer")
+	}
+
+	// The single file must have been embedded exactly once across both
+	// calls (the query is embedded each call, hence > 1 total /api/embed
+	// hits, but the file's vector must come from cache on call 2).
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "index_stats", Arguments: struct{}{}})
+	if err != nil {
+		t.Fatalf("index_stats: %v", err)
+	}
+	var stats IndexStatsOutput
+	mustDecodeStructured(t, res, &stats)
+	if stats.EmbedHits < 1 {
+		t.Errorf("EmbedHits=%d want >= 1 — the repeat semantic query re-embedded the tree (#306); stats=%+v", stats.EmbedHits, stats)
+	}
+	if stats.EmbedPuts != 1 {
+		t.Errorf("EmbedPuts=%d want 1 — the file should be embedded exactly once; stats=%+v", stats.EmbedPuts, stats)
+	}
+}


### PR DESCRIPTION
## Problem

On the cache-**miss** path, `BuildAttributesWith` wrote the attribute `Entry` (with parsed `Extra`) and then each enrichment helper — `populateSimilarity` / `populateHashes` / `populatePHash` — wrote a **separate, minimal `Entry`** to the same cache key with `cached=nil`. Last write won, so the embedding-vector entry **clobbered the parsed attributes** (and vice-versa).

Two reported issues, one root cause:

- **#308 (Finding #5):** semantic results served from cache dropped `title`/`author`/`language` — the cached entry was vector-only.
- **#306:** under the shared/concurrent MCP index, the vector-vs-attribute clobber degraded embedding reuse so `search_semantic` re-embedded the tree on repeat calls.

### On #306's "embed_hits: 0"

Reproducing deterministically (mock embedder, single thread) showed pure `embed_hits:0` does **not** occur — the live number from the dogfood was amplified by Ollama instability (the 3rd semantic call logged 210 embed *errors*) and a `find_near_duplicates` running concurrently on the shared in-memory index. The entry **clobber** is the reproducible root cause, and fixing it removes the vector-vs-attribute corruption that degraded #306 under concurrent MCP traffic.

## Fix

`internal/celexpr/evaluator.go`: build **one** `cacheEntry` per file on the miss path and pass it (instead of `nil`) to all three enrichment helpers, which already merge via `entry := cached`. `Extra` + `Vector` + hashes + phash now coexist in a single entry. `cacheEntry.Extra` is `maps.Clone`d so the on-demand body and per-walk project context (deliberately uncached) don't leak into the index via the helpers' re-`Put`.

## Tests

Each fails on `main`, passes with the fix:

- `internal/celexpr/similarity_test.go` — `MissPathRetainsExtra` (cached entry keeps Vector **and** Extra), `MixedTrafficCacheHit`, `NonSemanticPreservesVector`.
- `internal/mcpserver/search_semantic_cache_test.go` — MCP-level: `search_semantic` twice → `embed_hits >= 1`, `embed_puts == 1`, titles present on both calls.

## Verification

- `go build` / `go vet` / `go fix` clean; full `go test ./...` passes; affected packages pass under `-race`.
- Live (a 291-EPUB Project Gutenberg corpus, `all-minilm`): cold + warm semantic passes both return full titles/authors (closes #308), and the warm pass reuses the cache (293 hits, 0 misses, 3.5 s — no re-embedding).

Closes #306. Closes #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)