### PR TITLE
fix(semantic): cap embed input + surface embed failures so book-length docs don't silently return nothing (#305)

### DIFF
--- a/cmd/file-search-on/search_cmd.go
+++ b/cmd/file-search-on/search_cmd.go
@@ -52,6 +52,7 @@ type SearchCmd struct {
 	SimilarityThreshold float64    `name:"similarity-threshold" default:"0.5" help:"Minimum similarity score (0..1) for a file to be returned when --semantic-query is set. Higher = stricter."`
 	EmbeddingServer  string        `name:"embedding-server" env:"OLLAMA_HOST" default:"http://localhost:11434" help:"Ollama base URL for embedding requests. Resolution order: --embedding-server flag > $OLLAMA_HOST env var > http://localhost:11434."`
 	EmbeddingModel   string        `name:"embedding-model" help:"Ollama embedding model name (e.g. nomic-embed-text, mxbai-embed-large). No default — user picks per-tree based on the model they've pulled. Required when --semantic-query is set."`
+	EmbedMaxBytes    int           `name:"embed-max-bytes" default:"0" help:"Cap on the body text handed to the embedding model when --semantic-query is set (bytes). 0 uses an 8 KiB default that fits common models' context windows. Embedding models truncate to their context anyway, and over-long input can be rejected outright by Ollama; raise only for large-context models (e.g. bge-m3)."`
 	Exclude          []string      `name:"exclude" help:"Glob pattern matched against the basename of each file/directory; matches are skipped (directories are pruned). Repeatable: --exclude node_modules --exclude '*.bak'."`
 	RespectGitignore bool          `name:"respect-gitignore" help:"Parse a .gitignore at the walk root (if present) and skip matching paths. Nested .gitignore files in subdirectories are NOT honoured in this version."`
 	FollowSymlinks   bool          `name:"follow-symlinks" help:"Descend through symbolic links to directories during the walk. Off by default — symlinks-to-dirs surface as leaf entries with is_symlink=true. The is_symlink / target_path / is_broken_symlink CEL attributes are populated regardless of this flag. No loop detection."`
@@ -199,6 +200,7 @@ func (s *SearchCmd) Run(ctx context.Context) error {
 		Denylist:          denylist,
 		Embedder:               embedder,
 		SemanticQueryEmbedding: queryVector,
+		EmbedInputMaxBytes:     s.EmbedMaxBytes,
 		Excludes:            s.Exclude,
 		RespectGitignore:    s.RespectGitignore,
 		FollowSymlinks:      s.FollowSymlinks,
@@ -238,6 +240,16 @@ func (s *SearchCmd) Run(ctx context.Context) error {
 		if st.BodyHits+st.BodyMisses+st.BodyPuts+st.BodyStales+st.BodyEvictions+st.BodyOversize+st.BodyErrors > 0 {
 			fmt.Fprintf(os.Stderr, "body cache: %d hits, %d misses, %d stored, %d stale, %d evicted, %d oversized, %d errors\n",
 				st.BodyHits, st.BodyMisses, st.BodyPuts, st.BodyStales, st.BodyEvictions, st.BodyOversize, st.BodyErrors)
+		}
+		// Embedding line only when a semantic query ran. A non-zero
+		// errors count is the signal that "0 results" means embedding
+		// failed, not that nothing matched (issue #305).
+		if st.EmbedHits+st.EmbedMisses+st.EmbedPuts+st.EmbedErrors+st.EmbedModelMismatches > 0 {
+			fmt.Fprintf(os.Stderr, "embeddings: %d hits, %d misses, %d stored, %d errors, %d model-mismatch\n",
+				st.EmbedHits, st.EmbedMisses, st.EmbedPuts, st.EmbedErrors, st.EmbedModelMismatches)
+			if st.EmbedErrors > 0 {
+				fmt.Fprintf(os.Stderr, "warning: %d file(s) failed to embed — results may be incomplete (is Ollama running and the model pulled? try a smaller --embed-max-bytes)\n", st.EmbedErrors)
+			}
 		}
 	}
 

--- a/internal/celexpr/body.go
+++ b/internal/celexpr/body.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/richardwooding/file-search-on/internal/content"
 	"github.com/richardwooding/file-search-on/internal/content/ocr"
@@ -150,7 +151,22 @@ func populateSimilarity(ctx context.Context, fsys fs.FS, fsPath, displayPath, ca
 	if opts.Index != nil && (cached == nil || len(cached.Vector) == 0) {
 		opts.Index.BumpEmbedStat("miss")
 	}
+	// Cap the text handed to the embedder. Embedding models truncate to
+	// their context window anyway, and some Ollama model/version combos
+	// reject over-long input with an HTTP error (which would surface as
+	// a silent "0 results") — see issue #305.
+	body = truncateForEmbed(body, opts.EmbedInputMaxBytes)
 	vec, err := opts.Embedder.Embed(ctx, body)
+	if err != nil && ctx.Err() == nil {
+		// Some models reject inputs whose TOKEN count exceeds their hard
+		// limit even after the byte cap — CJK / dense text packs far more
+		// tokens per byte than English prose. Retry once at a small,
+		// conservative size before giving up so a handful of multibyte
+		// documents don't silently drop out of the results (#305).
+		if retry := truncateForEmbed(body, embedRetryMaxBytes); len(retry) < len(body) {
+			vec, err = opts.Embedder.Embed(ctx, retry)
+		}
+	}
 	if err != nil || len(vec) == 0 {
 		if opts.Index != nil {
 			opts.Index.BumpEmbedStat("error")
@@ -179,6 +195,32 @@ func populateSimilarity(ctx context.Context, fsys fs.FS, fsPath, displayPath, ca
 		_ = opts.Index.Put(cacheKey, entry)
 		opts.Index.BumpEmbedStat("put")
 	}
+}
+
+// embedRetryMaxBytes is the conservative fallback size used when an
+// embed call fails on the primary (larger) input — small enough to stay
+// under common embedding models' hard token limits for any script
+// (≈2 KiB ≈ well under 2048 tokens even for single-byte-per-token text).
+const embedRetryMaxBytes = 2 << 10
+
+// truncateForEmbed caps text to maxBytes (0 → defaultEmbedInputMaxBytes)
+// on a UTF-8 rune boundary so the embedder never receives a split
+// multibyte character. Returns text unchanged when it's already within
+// the cap.
+func truncateForEmbed(text string, maxBytes int) string {
+	if maxBytes <= 0 {
+		maxBytes = defaultEmbedInputMaxBytes
+	}
+	if len(text) <= maxBytes {
+		return text
+	}
+	// Back off to the start of the rune that straddles the cut so we
+	// don't hand the embedder an invalid UTF-8 tail.
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(text[cut]) {
+		cut--
+	}
+	return text[:cut]
 }
 
 // applyKnownStatus checks the file's MD5 / SHA1 / SHA256 against

--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -329,6 +329,19 @@ type BuildOptions struct {
 	Embedder               embed.Embedder
 	SemanticQueryEmbedding []float32
 
+	// EmbedInputMaxBytes caps the body text handed to the Embedder
+	// (NOT the body read / cached for `body.contains` — that's
+	// BodyMaxBytes). Embedding models have small context windows
+	// (a few hundred to a few thousand tokens) and some Ollama
+	// model/version combinations return an HTTP error rather than
+	// silently truncating book-length input, which would otherwise
+	// surface as a silent "0 results" (issue #305). Capping the embed
+	// input avoids that AND saves bandwidth — the model truncates to
+	// its context window anyway, so bytes past the window never
+	// influence the vector. 0 → defaultEmbedInputMaxBytes. The cap is
+	// applied on a UTF-8 rune boundary.
+	EmbedInputMaxBytes int
+
 	// GitCache, when non-nil, drives population of the git_* fields on
 	// FileAttributes (last commit time/author/subject, first seen,
 	// commit count, is_tracked, is_ignored). The walker builds one
@@ -369,6 +382,16 @@ type BuildOptions struct {
 // is plenty for typical text files (markdown posts, source modules,
 // JSON manifests) and bounds the worst case on adversarial input.
 const defaultBodyMaxBytes = 1 << 20
+
+// defaultEmbedInputMaxBytes caps the text handed to the embedding
+// model when BuildOptions.EmbedInputMaxBytes is unset. 8 KiB comfortably
+// covers the context window of the common Ollama embedding models
+// (all-minilm ~256 tokens, nomic-embed-text ~2048 tokens ≈ 8 KiB) and
+// stays under the input size at which some model/version combinations
+// reject the request outright (issue #305). Larger-context models can
+// raise it via --embed-max-bytes / the search_semantic embed_max_bytes
+// input.
+const defaultEmbedInputMaxBytes = 8 << 10
 
 // BuildAttributes is the no-cache wrapper. New callers should use
 // BuildAttributesWith and pass an index.Index when caching is desired.

--- a/internal/celexpr/similarity_test.go
+++ b/internal/celexpr/similarity_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/richardwooding/file-search-on/internal/celexpr"
@@ -424,6 +426,120 @@ func mockEmbedServer(t *testing.T, vec []float32, calls *int) *httptest.Server {
 	}))
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+// TestBuildAttributesWith_Similarity_TruncatesEmbedInput is the
+// regression for issue #305: the body handed to the embedder must be
+// capped (default 8 KiB, or BuildOptions.EmbedInputMaxBytes) so
+// book-length input doesn't trip the over-long-input errors some
+// Ollama model/version combinations return.
+func TestBuildAttributesWith_Similarity_TruncatesEmbedInput(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.md")
+	// ~50 KiB of body text — well past any embed cap under test.
+	mustWrite(t, path, "# Big\n\n"+strings.Repeat("lorem ipsum dolor ", 3000)+"\n")
+
+	abs, _ := filepath.Abs(path)
+	base := filepath.Base(abs)
+	parent := filepath.Dir(abs)
+
+	var mu sync.Mutex
+	maxInput := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Input string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		if len(body.Input) > maxInput {
+			maxInput = len(body.Input)
+		}
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": [][]float32{{1, 0, 0}}})
+	}))
+	defer srv.Close()
+
+	run := func(cap, want int) {
+		idx := index.NewMemory()
+		defer func() { _ = idx.Close() }()
+		mu.Lock()
+		maxInput = 0
+		mu.Unlock()
+		_, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), celexpr.BuildOptions{
+			Index:                  idx,
+			Embedder:               embed.NewOllama(srv.URL, "mock"),
+			SemanticQueryEmbedding: []float32{1, 0, 0},
+			EmbedInputMaxBytes:     cap,
+		})
+		if err != nil {
+			t.Fatalf("cap=%d: %v", cap, err)
+		}
+		mu.Lock()
+		got := maxInput
+		mu.Unlock()
+		if got > want {
+			t.Errorf("cap=%d: embedder received %d bytes, want <= %d", cap, got, want)
+		}
+		if got == 0 {
+			t.Errorf("cap=%d: embedder never called", cap)
+		}
+	}
+
+	run(0, 8<<10)  // default 8 KiB
+	run(2048, 2048) // explicit smaller cap
+}
+
+// TestBuildAttributesWith_Similarity_RetriesSmallerOnError verifies the
+// #305 fallback: when the embedder rejects the (byte-capped) input
+// because its TOKEN count is still over the model's hard limit — as
+// dense / CJK text does — the walk retries once at a smaller size
+// instead of dropping the file with a silent embed error.
+func TestBuildAttributesWith_Similarity_RetriesSmallerOnError(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dense.md")
+	mustWrite(t, path, "# Dense\n\n"+strings.Repeat("token ", 20000)+"\n")
+
+	abs, _ := filepath.Abs(path)
+	base := filepath.Base(abs)
+	parent := filepath.Dir(abs)
+
+	// Mock rejects any input larger than 2 KiB (mimics a token-limit
+	// rejection at the default 8 KiB cap), succeeds at/below it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Input string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if len(body.Input) > 2<<10 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": [][]float32{{1, 0, 0}}})
+	}))
+	defer srv.Close()
+
+	idx := index.NewMemory()
+	defer func() { _ = idx.Close() }()
+	a, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), celexpr.BuildOptions{
+		Index:                  idx,
+		Embedder:               embed.NewOllama(srv.URL, "mock"),
+		SemanticQueryEmbedding: []float32{1, 0, 0},
+	})
+	if err != nil {
+		t.Fatalf("BuildAttributesWith: %v", err)
+	}
+	if a.Similarity < 0.99 {
+		t.Errorf("Similarity=%f want ~1.0 — retry should have embedded the file", a.Similarity)
+	}
+	st := idx.Stats()
+	if st.EmbedErrors != 0 {
+		t.Errorf("EmbedErrors=%d want 0 — the smaller-input retry should have succeeded; stats=%+v", st.EmbedErrors, st)
+	}
+	if st.EmbedPuts != 1 {
+		t.Errorf("EmbedPuts=%d want 1 (vector cached after retry); stats=%+v", st.EmbedPuts, st)
+	}
 }
 
 // TestBuildAttributesWith_Similarity_MissPathRetainsExtra is the

--- a/internal/mcpserver/search_semantic_cache_test.go
+++ b/internal/mcpserver/search_semantic_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -97,5 +98,72 @@ func TestSearchSemanticReusesCachedEmbeddings(t *testing.T) {
 	}
 	if stats.EmbedPuts != 1 {
 		t.Errorf("EmbedPuts=%d want 1 — the file should be embedded exactly once; stats=%+v", stats.EmbedPuts, stats)
+	}
+}
+
+// TestSearchSemanticSurfacesEmbedErrors is the MCP-level regression for
+// issue #305: when a file's embedding fails (here the mock Ollama 400s
+// on file embeds while the query embed succeeds), the tool must not
+// silently return "0 results" — it surfaces embed_errors > 0 and a
+// warning, without failing the call.
+func TestSearchSemanticSurfacesEmbedErrors(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "doc.md"), "# Doc\n\nsome body text to embed\n")
+
+	// First /api/embed call (the query) succeeds; every later call (the
+	// per-file embeds) returns 400, mimicking an over-long / rejected
+	// input.
+	var mu sync.Mutex
+	calls := 0
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/embed" {
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+			return
+		}
+		mu.Lock()
+		calls++
+		first := calls == 1
+		mu.Unlock()
+		if first {
+			_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": [][]float32{{1, 0, 0}}})
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	t.Cleanup(ollama.Close)
+
+	ctx := t.Context()
+	idx := index.NewMemory()
+	server := New("test", idx, 0, EmbedDefaults{Server: ollama.URL, Model: "mock"})
+	t1, t2 := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search_semantic",
+		Arguments: SearchSemanticInput{Query: "anything", Dir: dir, Threshold: 0.4, Limit: 10},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.GetError() != nil {
+		t.Fatalf("embed failure must not fail the tool call: %v", res.GetError())
+	}
+	var out SearchSemanticOutput
+	mustDecodeStructured(t, res, &out)
+	if out.EmbedErrors == 0 {
+		t.Errorf("EmbedErrors=0 want > 0 — a failed embed was swallowed silently (#305); out=%+v", out)
+	}
+	if out.Warning == "" {
+		t.Errorf("expected a warning when embeds fail; out=%+v", out)
 	}
 }

--- a/internal/mcpserver/search_semantic_tool.go
+++ b/internal/mcpserver/search_semantic_tool.go
@@ -31,6 +31,8 @@ type SearchSemanticInput struct {
 	RespectGitignore bool    `json:"respect_gitignore,omitempty" jsonschema:"When true, parse a .gitignore at the walk root and skip matching paths."`
 	FollowSymlinks   bool    `json:"follow_symlinks,omitempty" jsonschema:"When true, descend through symbolic links to directories."`
 	IncludeBody      bool    `json:"include_body,omitempty" jsonschema:"When true, the full file body is exposed to the CEL pre-filter as the 'body' string variable. Most semantic-search workflows leave this off — the similarity score already captures conceptual match — but it's available for cases like 'similar AND contains a specific term'."`
+	BodyMaxBytes     int      `json:"body_max_bytes,omitempty" jsonschema:"Cap on the body string read per file in bytes (default 1 MiB). Only relevant when include_body is set. Files larger than the cap are truncated; the prefix still participates in the CEL pre-filter."`
+	EmbedMaxBytes    int      `json:"embed_max_bytes,omitempty" jsonschema:"Cap on the body text handed to the embedding model in bytes. 0 uses an 8 KiB default that fits common models' context windows. Embedding models truncate to their context anyway, and over-long input can be rejected by Ollama; raise only for large-context models (e.g. bge-m3)."`
 	TimeoutSeconds  *float64 `json:"timeout_seconds,omitempty" jsonschema:"Per-call timeout in seconds. 0 disables; nil falls through to the server default. On timeout the partial ranked set is returned with cancelled=true; not an error."`
 	Workers         int      `json:"workers,omitempty" jsonschema:"Parallel walker workers. 0 = runtime.NumCPU()."`
 }
@@ -46,6 +48,12 @@ type SearchSemanticOutput struct {
 	ElapsedSeconds     float64        `json:"elapsed_seconds"`
 	EmbeddingModel     string         `json:"embedding_model"`
 	SimilarityThreshold float64       `json:"similarity_threshold"`
+	// EmbedErrors counts files whose embedding failed during this call
+	// (Ollama unreachable, model not pulled, input rejected, etc.).
+	// Non-zero with Count==0 means "embedding failed", not "nothing
+	// matched" — without it that failure is invisible (issue #305).
+	EmbedErrors        uint64         `json:"embed_errors,omitempty"`
+	Warning            string         `json:"warning,omitempty"`
 	Cancelled          bool           `json:"cancelled,omitempty"`
 	CancellationReason string         `json:"cancellation_reason,omitempty"`
 }
@@ -133,12 +141,19 @@ func (h *handlers) searchSemanticHandler(ctx context.Context, req *mcp.CallToolR
 		IncludeAttributes:      true,
 		Index:                  h.idx,
 		IncludeBody:            in.IncludeBody,
+		BodyMaxBytes:           in.BodyMaxBytes,
 		Embedder:               embedder,
 		SemanticQueryEmbedding: queryVec,
+		EmbedInputMaxBytes:     in.EmbedMaxBytes,
 		Excludes:               in.Excludes,
 		RespectGitignore:       in.RespectGitignore,
 		FollowSymlinks:         in.FollowSymlinks,
 	}
+
+	// Snapshot the embed-error counter so we can report how many files
+	// failed to embed during THIS call — a non-zero count with no
+	// matches means embedding failed, not that nothing matched (#305).
+	embedErrsBefore := h.idx.Stats().EmbedErrors
 
 	out := make(chan search.Result, 64)
 	var walkErr error
@@ -196,6 +211,10 @@ func (h *handlers) searchSemanticHandler(ctx context.Context, req *mcp.CallToolR
 		ElapsedSeconds:      elapsed,
 		EmbeddingModel:      model,
 		SimilarityThreshold: threshold,
+	}
+	if embedErrs := h.idx.Stats().EmbedErrors - embedErrsBefore; embedErrs > 0 {
+		output.EmbedErrors = embedErrs
+		output.Warning = fmt.Sprintf("%d file(s) failed to embed (model %q at %s) — results may be incomplete; check that Ollama is running, the model is pulled, and consider lowering embed_max_bytes", embedErrs, model, server)
 	}
 	if cancelled {
 		output.Cancelled = true

--- a/internal/search/walker.go
+++ b/internal/search/walker.go
@@ -198,6 +198,13 @@ type Options struct {
 	Embedder               embed.Embedder
 	SemanticQueryEmbedding []float32
 
+	// EmbedInputMaxBytes caps the body text handed to the embedder
+	// (distinct from BodyMaxBytes, which caps the body read for CEL
+	// `body.contains`). 0 → an 8 KiB default that fits common embedding
+	// models' context windows and avoids the over-long-input errors
+	// behind issue #305. Threaded into celexpr.BuildOptions.
+	EmbedInputMaxBytes int
+
 	// ResolveProjects, when true, makes BuildAttributesWith populate
 	// each match's `project_types` (list<string>) and `project_type`
 	// (string — first match) CEL variables by walking up from the
@@ -574,6 +581,7 @@ func WalkStream(ctx context.Context, opts Options, registry *content.Registry, o
 						Denylist:               opts.Denylist,
 						Embedder:               opts.Embedder,
 						SemanticQueryEmbedding: opts.SemanticQueryEmbedding,
+						EmbedInputMaxBytes:     opts.EmbedInputMaxBytes,
 						OCRImages:              opts.OCRImages,
 						OCRTimeout:             opts.OCRTimeout,
 						WithPHash:              opts.WithPHash,


### PR DESCRIPTION
## Problem

Semantic search embedded the **full body** (default 1 MiB). Embedding models have small context windows, and some Ollama model/version combinations **reject** over-long input with an HTTP error rather than truncating it. So a book-length file produced an embed error that was **swallowed**: the file dropped out, the query returned `0 results`, and nothing surfaced the failure except `index_stats.embed_errors` (which the CLI never printed). On a corpus of EPUBs, `nomic-embed-text` returned **nothing at all** and only worked with a manual `--body-max-bytes` workaround.

Empirically (against a live Ollama): a 118 KB input to nomic returns HTTP 400 deterministically; truncated to 8 KB it returns 200. The model truncates to its context window internally anyway, so bytes past the window never influence the vector.

## Changes

- **Cap the embed input** (`celexpr.BuildOptions.EmbedInputMaxBytes`, default **8 KiB**), applied on a UTF-8 rune boundary. Avoids the rejection and saves bandwidth with no ranking impact.
- **Retry once at 2 KiB on embed error.** Dense / CJK text packs far more tokens per byte than English and can exceed the model's hard *token* limit even after the byte cap; the smaller retry clears it. Only a genuine failure (Ollama down, model missing) is then counted as an error.
- **Surface embed failures:**
  - CLI prints an `embeddings:` footer line (hits / misses / stored / errors / model-mismatch) plus a warning when any embed errored.
  - `search_semantic` MCP tool returns `embed_errors` + a `warning`, so `0 results` is distinguishable from "embedding failed."
- **New knobs:** CLI `--embed-max-bytes`; `search_semantic` `embed_max_bytes` (and `body_max_bytes`, which it was missing).
- Threaded `EmbedInputMaxBytes` through `search.Options` → `celexpr.BuildOptions`.

## Tests

- `TruncatesEmbedInput` — embedder receives ≤ cap bytes (default + explicit).
- `RetriesSmallerOnError` — input rejected at 8 KiB embeds via the 2 KiB retry; no error counted.
- `SearchSemanticSurfacesEmbedErrors` — a failing embed yields `embed_errors > 0` + a warning without failing the call.

`build` / `vet` / `go fix` clean; full `go test ./...` passes; affected packages pass under `-race`.

## Verification (live, 291-EPUB Project Gutenberg corpus)

`nomic-embed-text` now embeds **all 293 files with 0 errors at default settings** (was `0 results`), ranking sensibly (Roger Ackroyd / Seven Dials / Sherlock Holmes for "detective murder mystery"). The dense/CJK books that fail at 8 KiB are caught by the 2 KiB retry. A genuine failure now shows up in the CLI footer and the MCP `embed_errors`/`warning` fields.

Closes #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)