### PR TITLE
fix(semantic): wrap similarity threshold in double() so whole-number thresholds compile (#307)

### DIFF
--- a/cmd/file-search-on/search_cmd.go
+++ b/cmd/file-search-on/search_cmd.go
@@ -163,11 +163,11 @@ func (s *SearchCmd) Run(ctx context.Context) error {
 			s.Sort = "similarity"
 			s.Order = "desc"
 		}
-		// Fold the similarity threshold into the CEL filter. Use
-		// CEL's fmt.Sprintf-friendly literal for the float so locale
-		// settings can't accidentally produce a comma. CEL parses
-		// scientific notation, so even very small thresholds work.
-		threshold := fmt.Sprintf("similarity >= %g", s.SimilarityThreshold)
+		// Fold the similarity threshold into the CEL filter. The literal
+		// is wrapped in double(...) so a whole-number threshold (0.0,
+		// 1.0) doesn't compile to an int literal and trip cel-go's
+		// missing double>=int overload (issue #307).
+		threshold := search.SimilarityThresholdExpr(s.SimilarityThreshold)
 		if s.Expr == "" {
 			s.Expr = threshold
 		} else {

--- a/internal/mcpserver/search_semantic_tool.go
+++ b/internal/mcpserver/search_semantic_tool.go
@@ -128,7 +128,10 @@ func (h *handlers) searchSemanticHandler(ctx context.Context, req *mcp.CallToolR
 
 	// Fold the threshold into the CEL filter. Pre-prune via in.Expr
 	// when set; otherwise just the threshold gate.
-	expr := fmt.Sprintf("similarity >= %g", threshold)
+	// Wrap the threshold literal in double(...) so a whole-number
+	// threshold (0.0, 1.0) doesn't compile to an int literal and trip
+	// cel-go's missing double>=int overload (issue #307).
+	expr := search.SimilarityThresholdExpr(threshold)
 	if in.Expr != "" {
 		expr = "(" + in.Expr + ") && " + expr
 	}

--- a/internal/search/semantic.go
+++ b/internal/search/semantic.go
@@ -1,0 +1,17 @@
+package search
+
+import "fmt"
+
+// SimilarityThresholdExpr builds the CEL clause that folds a semantic
+// similarity threshold into a search expression.
+//
+// The literal is wrapped in double(...) on purpose. The `similarity` CEL
+// variable is a double, and cel-go has no `double >= int` overload, so a
+// whole-number threshold like 0.0 or 1.0 — which fmt's %v/%g render as
+// the int literal "0" / "1" — would compile to `similarity >= 0` and
+// fail with "no matching overload for '_>=_' applied to '(double, int)'"
+// (issue #307). double(%v) yields double(0) / double(0.5) / double(1),
+// all valid doubles, while keeping full float precision via %v.
+func SimilarityThresholdExpr(threshold float64) string {
+	return fmt.Sprintf("similarity >= double(%v)", threshold)
+}

--- a/internal/search/semantic_test.go
+++ b/internal/search/semantic_test.go
@@ -1,0 +1,27 @@
+package search_test
+
+import (
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// TestSimilarityThresholdExpr_Compiles is the regression for issue #307:
+// a whole-number threshold (0.0, 1.0) must produce a CEL expression that
+// compiles. Before the double(...) wrapper, %g rendered 0.0 as the int
+// literal "0" and `similarity >= 0` failed with cel-go's missing
+// double>=int overload.
+func TestSimilarityThresholdExpr_Compiles(t *testing.T) {
+	for _, th := range []float64{0, 0.0, 1, 1.0, 0.5, 0.55, 0.7, 0.123456789, 1e-7} {
+		expr := search.SimilarityThresholdExpr(th)
+		if _, err := celexpr.New(expr); err != nil {
+			t.Errorf("threshold %v -> %q failed to compile: %v", th, expr, err)
+		}
+		// Also the AND-combined form the CLI / MCP build.
+		combined := "(is_epub) && " + expr
+		if _, err := celexpr.New(combined); err != nil {
+			t.Errorf("threshold %v combined -> %q failed to compile: %v", th, combined, err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`--similarity-threshold` (CLI) and the `search_semantic` `threshold` (MCP) were folded into the CEL filter as `fmt.Sprintf("similarity >= %g", threshold)`. `%g` renders a whole-number threshold (`0.0`, `1.0`) as the **int** literal `0` / `1`, and cel-go has no `double >= int` overload, so:

```
$ file-search-on search 'is_epub' --semantic-query x --embedding-model all-minilm --similarity-threshold 0.0 ...
Error: compiling CEL expression: ERROR: found no matching overload for '_>=_' applied to '(double, int)'
 | (is_epub) && similarity >= 0
```

(Surfaced in the dogfood and reproducible via `validate_expr("similarity >= 0")`.)

## Fix

Add a shared helper `search.SimilarityThresholdExpr(threshold)` that emits `similarity >= double(%v)` — valid CEL for any threshold (`double(0)`, `double(0.5)`, `double(1)`) while keeping full float precision via `%v` — and use it at both injection sites (`cmd/file-search-on/search_cmd.go` and `internal/mcpserver/search_semantic_tool.go`), replacing the duplicated `%g` formatting.

## Test

`internal/search/semantic_test.go` compiles the expression (and the AND-combined form the CLI/MCP build) across thresholds including `0.0` and `1.0`. It fails on the old `%g` formatting and passes with the fix.

`build` / `vet` / `go fix` clean; full `go test ./...` passes.

Closes #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)