### PR TITLE
feat(presets): add EPUB / ebook-library presets

### DIFF
--- a/examples/presets.md
+++ b/examples/presets.md
@@ -34,6 +34,17 @@ file-search-on preset
 
 Each preset bakes a fresh timestamp at invocation time, so `recent_changes` always means "last 7 days from NOW".
 
+### EPUB / ebook-library presets
+
+EPUB metadata is Dublin Core only (`title` / `author` / `language`) with no page or word count, so these lean on `size` (the practical length proxy), `mod_time`, and the metadata fields.
+
+| Preset | What it finds | Defaults |
+|---|---|---|
+| `large_ebooks` | The largest EPUBs (size proxies length) | sort=size desc, limit=20 |
+| `recent_ebooks` | EPUBs added/changed in the last 30 days | sort=mod_time desc, limit=50 |
+| `untagged_ebooks` | EPUBs missing a Dublin Core title or author — the "fix this book's metadata" list | sort=name asc |
+| `non_english_ebooks` | EPUBs whose language is set and not `en` | sort=name asc |
+
 ## Running a preset
 
 ```sh

--- a/internal/search/presets.go
+++ b/internal/search/presets.go
@@ -245,6 +245,53 @@ var presets = []Preset{
 			}
 		},
 	},
+	{
+		Name:        "large_ebooks",
+		Description: "The 20 largest EPUBs, biggest first. EPUB carries no page/word count, so file size is the practical length proxy.",
+		Build: func() PresetOptions {
+			return PresetOptions{
+				Expr:  `is_epub`,
+				Sort:  "size",
+				Order: "desc",
+				Limit: 20,
+			}
+		},
+	},
+	{
+		Name:        "recent_ebooks",
+		Description: "EPUBs added or changed in the last 30 days, newest first — what landed in the library lately.",
+		Build: func() PresetOptions {
+			cutoff := time.Now().Add(-30 * 24 * time.Hour).Format(time.RFC3339)
+			return PresetOptions{
+				Expr:  fmt.Sprintf(`is_epub && mod_time > timestamp(%q)`, cutoff),
+				Sort:  "mod_time",
+				Order: "desc",
+				Limit: 50,
+			}
+		},
+	},
+	{
+		Name:        "untagged_ebooks",
+		Description: "EPUBs missing a Dublin Core title or author — the actionable 'fix this book's metadata' list.",
+		Build: func() PresetOptions {
+			return PresetOptions{
+				Expr:  `is_epub && (title == "" || author == "")`,
+				Sort:  "name",
+				Order: "asc",
+			}
+		},
+	},
+	{
+		Name:        "non_english_ebooks",
+		Description: "EPUBs whose Dublin Core language is set and not English — slice the library by language.",
+		Build: func() PresetOptions {
+			return PresetOptions{
+				Expr:  `is_epub && language != "" && language != "en"`,
+				Sort:  "name",
+				Order: "asc",
+			}
+		},
+	},
 }
 
 // Presets returns the catalog sorted alphabetically by Name. Safe to

--- a/internal/search/presets_test.go
+++ b/internal/search/presets_test.go
@@ -236,3 +236,32 @@ var marker = "FIXME: this is data"
 		})
 	}
 }
+
+// TestPresets_EbookSet asserts the EPUB-oriented presets exist, are
+// scoped to is_epub, and sort on a key meaningful for ebooks (EPUB has
+// no word_count/page_count, so size/name/mod_time only).
+func TestPresets_EbookSet(t *testing.T) {
+	want := map[string]string{
+		"large_ebooks":       "size",
+		"recent_ebooks":      "mod_time",
+		"untagged_ebooks":    "name",
+		"non_english_ebooks": "name",
+	}
+	for name, sortKey := range want {
+		p := search.PresetByName(name)
+		if p == nil {
+			t.Errorf("preset %q not found", name)
+			continue
+		}
+		opts := p.Build()
+		if !strings.Contains(opts.Expr, "is_epub") {
+			t.Errorf("preset %q expr %q is not scoped to is_epub", name, opts.Expr)
+		}
+		if opts.Sort != sortKey {
+			t.Errorf("preset %q sort = %q, want %q", name, opts.Sort, sortKey)
+		}
+		if _, err := celexpr.New(opts.Expr); err != nil {
+			t.Errorf("preset %q expr %q failed to compile: %v", name, opts.Expr, err)
+		}
+	}
+}


### PR DESCRIPTION
Four canned `preset` recipes for ebook collections, designed around the real EPUB attribute surface — Dublin Core `title`/`author`/`language` plus `size`/`mod_time`; EPUB carries **no page or word count**, so `size` is the practical length proxy.

| Preset | CEL filter | Sort / limit | Why |
|---|---|---|---|
| `large_ebooks` | `is_epub` | size desc, 20 | biggest/longest books |
| `recent_ebooks` | `is_epub && mod_time > <30d>` | mod_time desc, 50 | what landed in the library lately |
| `untagged_ebooks` | `is_epub && (title == "" \|\| author == "")` | name asc | Dublin Core gaps — the actionable "fix this book's metadata" list |
| `non_english_ebooks` | `is_epub && language != "" && language != "en"` | name asc | slice the library by language |

Catalog-only change in `internal/search/presets.go` — the CLI `preset`, MCP `list_presets` / `query_preset`, and docs pick them up automatically. Metadata-only (no body extraction).

## Tests
`TestPresets_AllCompile` / `_NamesUnique` cover them automatically; added `TestPresets_EbookSet` (each is scoped to `is_epub`, sorts on an ebook-valid key, and compiles). Row block added to `examples/presets.md`.

## Verified live (291-EPUB Gutenberg corpus, released v0.77.0 binary)
- `large_ebooks` → CIA World Factbooks, Complete Shakespeare, Pepys' Diary
- `untagged_ebooks` → the 9 anthologies/dictionaries with an empty `dc:creator`
- `non_english_ebooks` → French / Middle-English (`enm`) / Dutch titles

`build` / `vet` / `go fix` clean; full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)