### PR TITLE
fix(walk): degrade instead of dropping files whose Attributes() errors (#321)

### DIFF
--- a/examples/presets.md
+++ b/examples/presets.md
@@ -34,6 +34,17 @@ file-search-on preset
 
 Each preset bakes a fresh timestamp at invocation time, so `recent_changes` always means "last 7 days from NOW".
 
+### EPUB / ebook-library presets
+
+EPUB metadata is Dublin Core only (`title` / `author` / `language`) with no page or word count, so these lean on `size` (the practical length proxy), `mod_time`, and the metadata fields.
+
+| Preset | What it finds | Defaults |
+|---|---|---|
+| `large_ebooks` | The largest EPUBs (size proxies length) | sort=size desc, limit=20 |
+| `recent_ebooks` | EPUBs added/changed in the last 30 days | sort=mod_time desc, limit=50 |
+| `untagged_ebooks` | EPUBs missing a Dublin Core title or author — the "fix this book's metadata" list | sort=name asc |
+| `non_english_ebooks` | EPUBs whose language is set and not `en` | sort=name asc |
+
 ## Running a preset
 
 ```sh

--- a/internal/celexpr/degrade_test.go
+++ b/internal/celexpr/degrade_test.go
@@ -1,0 +1,50 @@
+package celexpr_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+	"github.com/richardwooding/file-search-on/internal/content"
+)
+
+// TestBuildAttributesWith_MalformedFileDegrades is the regression for
+// issue #321: a file that detects as a parseable type (by extension)
+// but whose ContentType.Attributes() errors (truncated PDF, non-zip
+// docx, garbage with a valid extension) must NOT propagate the error —
+// that drops the file from the walk entirely and hard-errors `attrs`.
+// It should degrade to a basic record: detected content_type + stat,
+// no type-specific attributes.
+func TestBuildAttributesWith_MalformedFileDegrades(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	cases := []struct {
+		name, body, wantCT string
+	}{
+		{"broken.pdf", "this is not a pdf at all\n", "pdf"},                 // pdfBody/pagecount errors
+		{"empty.pdf", "", "pdf"},                                           // "invalid header"
+		{"notreally.docx", "this is plainly not a zip archive\n", "office/docx"}, // zip open errors
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := filepath.Join(dir, tc.name)
+			mustWrite(t, p, tc.body)
+			abs, _ := filepath.Abs(p)
+			a, err := celexpr.BuildAttributesWith(ctx, os.DirFS(dir), tc.name, abs, content.DefaultRegistry(), celexpr.BuildOptions{})
+			if err != nil {
+				t.Fatalf("malformed %s must not error (#321): %v", tc.name, err)
+			}
+			if a == nil {
+				t.Fatalf("%s: nil attrs", tc.name)
+			}
+			if a.ContentType != tc.wantCT {
+				t.Errorf("%s: content_type = %q, want %q (detected by extension; parse failed but file still surfaced)", tc.name, a.ContentType, tc.wantCT)
+			}
+			if a.Path != abs {
+				t.Errorf("%s: Path = %q, want %q", tc.name, a.Path, abs)
+			}
+		})
+	}
+}

--- a/internal/celexpr/evaluator.go
+++ b/internal/celexpr/evaluator.go
@@ -656,10 +656,25 @@ func BuildAttributesWith(ctx context.Context, fsys fs.FS, fsPath, displayPath st
 		}
 		if !opts.SkipAttributesParse && !skipForProfile {
 			a, err := ct.Attributes(ctx, fsys, fsPath)
-			if err != nil {
+			switch {
+			case err != nil && ctx.Err() != nil:
+				// Cancellation (timeout / Ctrl-C) — the whole walk is
+				// stopping; propagate so the caller surfaces it.
 				return nil, err
+			case err != nil:
+				// A parse error on a malformed / corrupt file (truncated
+				// PDF, non-zip docx, garbage with a valid extension, ...)
+				// must NOT drop the file from results — that silently
+				// hides exactly the suspicious files a forensic /
+				// inventory "match everything" is looking for (#321).
+				// Degrade to a basic record: the detected content_type +
+				// stat, with no type-specific attributes. Clear cacheKey
+				// so the empty parse isn't cached — a later valid version
+				// re-parses on its next (size, mtime) change.
+				cacheKey = ""
+			default:
+				extra = a
 			}
-			extra = a
 			// Curated SQLite app-name lookup (issue #177). Lives here
 			// rather than inside ContentType.Attributes because the
 			// path-based registry dimensions (PathContains: "Chrome",

--- a/internal/search/degrade_test.go
+++ b/internal/search/degrade_test.go
@@ -1,0 +1,43 @@
+package search_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// TestWalk_MalformedFilesNotDropped is the search-level regression for
+// issue #321: a malformed PDF / docx sitting among good files must still
+// appear in `search 'true'` results, not silently vanish.
+func TestWalk_MalformedFilesNotDropped(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("good.md", "# Title\n\nbody\n")
+	write("broken.pdf", "this is not a pdf\n") // detects pdf by ext; Attributes errors
+	write("empty.pdf", "")
+	write("notreally.docx", "not a zip\n")
+
+	results, err := search.Walk(t.Context(), search.Options{
+		Roots: []string{dir},
+		Expr:  "true",
+	}, content.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	got := map[string]bool{}
+	for _, r := range results {
+		got[filepath.Base(r.Path)] = true
+	}
+	for _, name := range []string{"good.md", "broken.pdf", "empty.pdf", "notreally.docx"} {
+		if !got[name] {
+			t.Errorf("%s missing from results — malformed files must not be dropped (#321); got %v", name, got)
+		}
+	}
+}

--- a/internal/search/presets.go
+++ b/internal/search/presets.go
@@ -245,6 +245,53 @@ var presets = []Preset{
 			}
 		},
 	},
+	{
+		Name:        "large_ebooks",
+		Description: "The 20 largest EPUBs, biggest first. EPUB carries no page/word count, so file size is the practical length proxy.",
+		Build: func() PresetOptions {
+			return PresetOptions{
+				Expr:  `is_epub`,
+				Sort:  "size",
+				Order: "desc",
+				Limit: 20,
+			}
+		},
+	},
+	{
+		Name:        "recent_ebooks",
+		Description: "EPUBs added or changed in the last 30 days, newest first — what landed in the library lately.",
+		Build: func() PresetOptions {
+			cutoff := time.Now().Add(-30 * 24 * time.Hour).Format(time.RFC3339)
+			return PresetOptions{
+				Expr:  fmt.Sprintf(`is_epub && mod_time > timestamp(%q)`, cutoff),
+				Sort:  "mod_time",
+				Order: "desc",
+				Limit: 50,
+			}
+		},
+	},
+	{
+		Name:        "untagged_ebooks",
+		Description: "EPUBs missing a Dublin Core title or author — the actionable 'fix this book's metadata' list.",
+		Build: func() PresetOptions {
+			return PresetOptions{
+				Expr:  `is_epub && (title == "" || author == "")`,
+				Sort:  "name",
+				Order: "asc",
+			}
+		},
+	},
+	{
+		Name:        "non_english_ebooks",
+		Description: "EPUBs whose Dublin Core language is set and not English — slice the library by language.",
+		Build: func() PresetOptions {
+			return PresetOptions{
+				Expr:  `is_epub && language != "" && language != "en"`,
+				Sort:  "name",
+				Order: "asc",
+			}
+		},
+	},
 }
 
 // Presets returns the catalog sorted alphabetically by Name. Safe to

--- a/internal/search/presets_test.go
+++ b/internal/search/presets_test.go
@@ -236,3 +236,32 @@ var marker = "FIXME: this is data"
 		})
 	}
 }
+
+// TestPresets_EbookSet asserts the EPUB-oriented presets exist, are
+// scoped to is_epub, and sort on a key meaningful for ebooks (EPUB has
+// no word_count/page_count, so size/name/mod_time only).
+func TestPresets_EbookSet(t *testing.T) {
+	want := map[string]string{
+		"large_ebooks":       "size",
+		"recent_ebooks":      "mod_time",
+		"untagged_ebooks":    "name",
+		"non_english_ebooks": "name",
+	}
+	for name, sortKey := range want {
+		p := search.PresetByName(name)
+		if p == nil {
+			t.Errorf("preset %q not found", name)
+			continue
+		}
+		opts := p.Build()
+		if !strings.Contains(opts.Expr, "is_epub") {
+			t.Errorf("preset %q expr %q is not scoped to is_epub", name, opts.Expr)
+		}
+		if opts.Sort != sortKey {
+			t.Errorf("preset %q sort = %q, want %q", name, opts.Sort, sortKey)
+		}
+		if _, err := celexpr.New(opts.Expr); err != nil {
+			t.Errorf("preset %q expr %q failed to compile: %v", name, opts.Expr, err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

A file that detects as a parseable type but whose `ContentType.Attributes()` errors — truncated PDF (`invalid header` / `missing %%EOF`), non-zip docx (`zip: not a valid zip file`), garbage with a valid extension — was **dropped from the walk entirely**, and `attrs <file>` hard-errored.

```sh
# ~/mixed-corpus/torture has 12 files; 5 are malformed PDFs/docx
file-search-on search 'true' -d ~/mixed-corpus/torture -o bare | wc -l   # was 7, not 12
file-search-on attrs truncated.pdf                                       # was: Error: not a PDF file: missing %%EOF
```

A corrupt PDF/office doc among good files silently vanished from `search 'true'` — exactly backwards for a forensic / inventory "match everything" pass (it hides the suspicious files). Surfaced in the mixed-format dogfood.

## Fix

`BuildAttributesWith` (internal/celexpr/evaluator.go) now degrades on a parse error instead of returning it: the file surfaces as a basic record — detected `content_type` + stat + `is_X` type flags, with no type-specific attributes. Cancellation (`ctx.Err() != nil`) still propagates. The empty parse isn't cached (cacheKey cleared) so a later valid version re-parses on its next `(size, mtime)` change.

```sh
# after:
file-search-on search 'true' -d ~/mixed-corpus/torture -o bare | wc -l   # 12
file-search-on attrs truncated.pdf                                       # content_type pdf; size 2048
```

## Tests (both fail on `main`)
- `internal/celexpr` — `BuildAttributesWith` on `broken.pdf` / `empty.pdf` / `notreally.docx` returns a record (content_type detected, no error).
- `internal/search` — `Walk 'true'` over a dir with a malformed pdf/docx still includes them (previously only the good file survived).

`build` / `vet` / `go fix` clean; full `go test ./...` passes; `celexpr` + `search` pass under `-race`.

Closes #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)