### PR TITLE
fix(content): detect WAV correctly and disambiguate the RIFF family (#322)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Prefer the command line? The same binary is a standalone CLI — `file-search-on
   | **Data** | JSON, YAML, TOML, CSV, TSV | json_kind, yaml_kind, yaml_document_count, column_count, csv_columns |
   | **Plain text** | TXT, log, … | line_count, word_count |
   | **Images** | JPEG, PNG, GIF, WebP, TIFF, BMP, SVG, HEIC, RAW (Canon CR2 / CR3, Nikon NEF, Sony ARW, Adobe DNG, Fujifilm RAF, Olympus ORF, Panasonic RW2) — predicates `is_raw_photo`, `is_cr2`, `is_cr3`, `is_nef`, `is_arw`, `is_dng`, `is_raf`, `is_orf`, `is_rw2`. HEIC + sibling MOV → Apple Live Photo pairing (`is_live_photo`, `is_live_photo_video`). | dimensions + EXIF: camera, lens, GPS, ISO, focal_length, taken_at; RAW adds `raw_kind`, `raw_vendor`; Live Photo adds `live_photo_video_path`, `live_photo_video_size`, `live_photo_image_path` |
-  | **Audio** | MP3, M4A, FLAC, OGG | tags (artist, album, genre, year, …) + duration, bitrate / nominal_bitrate, sample_rate, channels, bit_depth, ReplayGain |
+  | **Audio** | MP3, M4A, FLAC, OGG, WAV | tags (artist, album, genre, year, …) + duration, bitrate / nominal_bitrate, sample_rate, channels, bit_depth, ReplayGain |
   | **Video** | MP4, MOV, MKV, WebM, AVI | duration, bitrate / nominal_bitrate, video_codec, audio_codec, video_width/height, frame_rate, rotation, HDR / colour-space, subtitles |
   | **Office** | DOCX, XLSX, PPTX, ODT | title, author, language (Dublin Core) |
   | **Archives** | ZIP (incl. JAR / WAR / EAR), TAR, TAR.GZ, GZIP | entry_count, uncompressed_size, top_level_entries, has_root_dir |

--- a/examples/audio.md
+++ b/examples/audio.md
@@ -1,8 +1,8 @@
 # Recipes — Audio
 
-Audio content types: `audio/mpeg` (MP3), `audio/mp4` (M4A/AAC), `audio/flac`, `audio/ogg`. Umbrella boolean `is_audio`.
+Audio content types: `audio/mpeg` (MP3), `audio/mp4` (M4A/AAC), `audio/flac`, `audio/ogg`, `audio/wav` (`.wav`/`.wave`). Umbrella boolean `is_audio`.
 
-Tags are extracted via [`dhowden/tag`](https://github.com/dhowden/tag) — handles ID3v1/v2 (MP3), MP4 atoms (M4A), and Vorbis comments (FLAC, OGG) under one API. Playback metadata (duration, bitrate, sample rate, channels) is hand-rolled per format.
+Tags are extracted via [`dhowden/tag`](https://github.com/dhowden/tag) — handles ID3v1/v2 (MP3), MP4 atoms (M4A), and Vorbis comments (FLAC, OGG) under one API. Playback metadata (duration, bitrate, sample rate, channels, bit depth) is hand-rolled per format; WAV reads its `fmt `/`data` chunks directly. WAV / WebP / AVI all share the `RIFF` magic, so detection checks the form-type at bytes 8..11 (`WAVE`/`WEBP`/`AVI `) to disambiguate.
 
 ## Tags
 

--- a/internal/content/audio_wav.go
+++ b/internal/content/audio_wav.go
@@ -1,0 +1,95 @@
+package content
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+// readWAVInfo parses a RIFF/WAVE file's `fmt ` and `data` chunks to
+// recover sample rate, channels, bit depth, and (from the data-chunk
+// size / byte rate) duration. Bounded: it reads fixed-size chunk
+// headers and seeks over chunk bodies, with a hard cap on the number of
+// chunks walked so a malformed file can't loop forever.
+//
+// WAV layout: "RIFF"<u32 size>"WAVE" then a sequence of chunks, each
+// 4-byte id + little-endian u32 size + body (padded to an even length).
+// The `fmt ` body (PCM): audioFormat u16, channels u16, sampleRate u32,
+// byteRate u32, blockAlign u16, bitsPerSample u16.
+func readWAVInfo(r io.ReadSeeker) (audioInfo, error) {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return audioInfo{}, err
+	}
+	var hdr [12]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return audioInfo{}, err
+	}
+	if string(hdr[0:4]) != "RIFF" || string(hdr[8:12]) != "WAVE" {
+		return audioInfo{}, errors.New("not a RIFF/WAVE file")
+	}
+
+	var (
+		info       audioInfo
+		byteRate   int64
+		haveFmt    bool
+		dataSize   int64
+		haveData   bool
+	)
+	const maxChunks = 4096
+	var chunkHdr [8]byte
+	for range maxChunks {
+		if _, err := io.ReadFull(r, chunkHdr[:]); err != nil {
+			break // EOF / truncated — return whatever we gathered
+		}
+		id := string(chunkHdr[0:4])
+		size := int64(binary.LittleEndian.Uint32(chunkHdr[4:8]))
+		switch id {
+		case "fmt ":
+			body := make([]byte, min(size, 64))
+			if _, err := io.ReadFull(r, body); err != nil {
+				break
+			}
+			if len(body) >= 16 {
+				info.Channels = int64(binary.LittleEndian.Uint16(body[2:4]))
+				info.SampleRate = int64(binary.LittleEndian.Uint32(body[4:8]))
+				byteRate = int64(binary.LittleEndian.Uint32(body[8:12]))
+				info.BitDepth = int64(binary.LittleEndian.Uint16(body[14:16]))
+				haveFmt = true
+			}
+			// Skip any remaining fmt bytes (+ pad) we didn't read.
+			if rem := size - int64(len(body)); rem > 0 {
+				if _, err := r.Seek(rem+(size&1), io.SeekCurrent); err != nil {
+					break
+				}
+			} else if size&1 == 1 {
+				_, _ = r.Seek(1, io.SeekCurrent)
+			}
+		case "data":
+			dataSize = size
+			haveData = true
+			// Don't read the (potentially huge) sample body; seek past it.
+			if _, err := r.Seek(size+(size&1), io.SeekCurrent); err != nil {
+				break
+			}
+		default:
+			if _, err := r.Seek(size+(size&1), io.SeekCurrent); err != nil {
+				break
+			}
+		}
+	}
+
+	if !haveFmt {
+		return audioInfo{}, errors.New("no fmt chunk")
+	}
+	// Prefer the codec-stored byte rate; fall back to deriving it.
+	if byteRate == 0 && info.SampleRate > 0 && info.Channels > 0 && info.BitDepth > 0 {
+		byteRate = info.SampleRate * info.Channels * info.BitDepth / 8
+	}
+	if haveData && byteRate > 0 {
+		info.Duration = float64(dataSize) / float64(byteRate)
+	}
+	if byteRate > 0 {
+		info.NominalBitrate = byteRate * 8 / 1000
+	}
+	return info, nil
+}

--- a/internal/content/audio_wav.go
+++ b/internal/content/audio_wav.go
@@ -37,6 +37,7 @@ func readWAVInfo(r io.ReadSeeker) (audioInfo, error) {
 	)
 	const maxChunks = 4096
 	var chunkHdr [8]byte
+chunkLoop:
 	for range maxChunks {
 		if _, err := io.ReadFull(r, chunkHdr[:]); err != nil {
 			break // EOF / truncated — return whatever we gathered
@@ -47,7 +48,7 @@ func readWAVInfo(r io.ReadSeeker) (audioInfo, error) {
 		case "fmt ":
 			body := make([]byte, min(size, 64))
 			if _, err := io.ReadFull(r, body); err != nil {
-				break
+				break chunkLoop
 			}
 			if len(body) >= 16 {
 				info.Channels = int64(binary.LittleEndian.Uint16(body[2:4]))
@@ -59,21 +60,23 @@ func readWAVInfo(r io.ReadSeeker) (audioInfo, error) {
 			// Skip any remaining fmt bytes (+ pad) we didn't read.
 			if rem := size - int64(len(body)); rem > 0 {
 				if _, err := r.Seek(rem+(size&1), io.SeekCurrent); err != nil {
-					break
+					break chunkLoop
 				}
 			} else if size&1 == 1 {
-				_, _ = r.Seek(1, io.SeekCurrent)
+				if _, err := r.Seek(1, io.SeekCurrent); err != nil {
+					break chunkLoop
+				}
 			}
 		case "data":
 			dataSize = size
 			haveData = true
 			// Don't read the (potentially huge) sample body; seek past it.
 			if _, err := r.Seek(size+(size&1), io.SeekCurrent); err != nil {
-				break
+				break chunkLoop
 			}
 		default:
 			if _, err := r.Seek(size+(size&1), io.SeekCurrent); err != nil {
-				break
+				break chunkLoop
 			}
 		}
 	}

--- a/internal/content/audio_wav_test.go
+++ b/internal/content/audio_wav_test.go
@@ -1,0 +1,62 @@
+package content
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// buildWAV constructs a minimal valid PCM WAV (header + fmt + data) for
+// the given parameters, with dataBytes of (zeroed) sample data.
+func buildWAV(channels, bitsPerSample int, sampleRate, dataBytes uint32) []byte {
+	byteRate := sampleRate * uint32(channels) * uint32(bitsPerSample) / 8
+	blockAlign := uint16(channels * bitsPerSample / 8)
+	var b bytes.Buffer
+	b.WriteString("RIFF")
+	binary.Write(&b, binary.LittleEndian, uint32(36+dataBytes))
+	b.WriteString("WAVE")
+	b.WriteString("fmt ")
+	binary.Write(&b, binary.LittleEndian, uint32(16))
+	binary.Write(&b, binary.LittleEndian, uint16(1)) // PCM
+	binary.Write(&b, binary.LittleEndian, uint16(channels))
+	binary.Write(&b, binary.LittleEndian, sampleRate)
+	binary.Write(&b, binary.LittleEndian, byteRate)
+	binary.Write(&b, binary.LittleEndian, blockAlign)
+	binary.Write(&b, binary.LittleEndian, uint16(bitsPerSample))
+	b.WriteString("data")
+	binary.Write(&b, binary.LittleEndian, dataBytes)
+	b.Write(make([]byte, dataBytes))
+	return b.Bytes()
+}
+
+func TestReadWAVInfo(t *testing.T) {
+	// 2ch, 16-bit, 44100Hz, 1 second of data (byteRate bytes).
+	sr := uint32(44100)
+	byteRate := sr * 2 * 16 / 8
+	wav := buildWAV(2, 16, sr, byteRate) // 1.0s
+	info, err := readWAVInfo(bytes.NewReader(wav))
+	if err != nil {
+		t.Fatalf("readWAVInfo: %v", err)
+	}
+	if info.SampleRate != 44100 {
+		t.Errorf("SampleRate=%d want 44100", info.SampleRate)
+	}
+	if info.Channels != 2 {
+		t.Errorf("Channels=%d want 2", info.Channels)
+	}
+	if info.BitDepth != 16 {
+		t.Errorf("BitDepth=%d want 16", info.BitDepth)
+	}
+	if info.Duration < 0.99 || info.Duration > 1.01 {
+		t.Errorf("Duration=%v want ~1.0", info.Duration)
+	}
+	if info.NominalBitrate <= 0 {
+		t.Errorf("NominalBitrate=%d want > 0", info.NominalBitrate)
+	}
+}
+
+func TestReadWAVInfo_NotWAV(t *testing.T) {
+	if _, err := readWAVInfo(bytes.NewReader([]byte("RIFF\x00\x00\x00\x00WEBPxxxx"))); err == nil {
+		t.Error("expected error for non-WAVE RIFF input")
+	}
+}

--- a/internal/content/audio_wav_test.go
+++ b/internal/content/audio_wav_test.go
@@ -12,19 +12,20 @@ func buildWAV(channels, bitsPerSample int, sampleRate, dataBytes uint32) []byte 
 	byteRate := sampleRate * uint32(channels) * uint32(bitsPerSample) / 8
 	blockAlign := uint16(channels * bitsPerSample / 8)
 	var b bytes.Buffer
+	put := func(v any) { _ = binary.Write(&b, binary.LittleEndian, v) } // never errors on a bytes.Buffer
 	b.WriteString("RIFF")
-	binary.Write(&b, binary.LittleEndian, uint32(36+dataBytes))
+	put(uint32(36 + dataBytes))
 	b.WriteString("WAVE")
 	b.WriteString("fmt ")
-	binary.Write(&b, binary.LittleEndian, uint32(16))
-	binary.Write(&b, binary.LittleEndian, uint16(1)) // PCM
-	binary.Write(&b, binary.LittleEndian, uint16(channels))
-	binary.Write(&b, binary.LittleEndian, sampleRate)
-	binary.Write(&b, binary.LittleEndian, byteRate)
-	binary.Write(&b, binary.LittleEndian, blockAlign)
-	binary.Write(&b, binary.LittleEndian, uint16(bitsPerSample))
+	put(uint32(16))
+	put(uint16(1)) // PCM
+	put(uint16(channels))
+	put(sampleRate)
+	put(byteRate)
+	put(blockAlign)
+	put(uint16(bitsPerSample))
 	b.WriteString("data")
-	binary.Write(&b, binary.LittleEndian, dataBytes)
+	put(dataBytes)
 	b.Write(make([]byte, dataBytes))
 	return b.Bytes()
 }

--- a/internal/content/audiotype.go
+++ b/internal/content/audiotype.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -14,6 +15,9 @@ func init() {
 	Register(&audioType{name: "audio/mp4", exts: []string{".m4a", ".m4b", ".m4p", ".aac"}, magic: nil})
 	Register(&audioType{name: "audio/flac", exts: []string{".flac"}, magic: [][]byte{[]byte("fLaC")}})
 	Register(&audioType{name: "audio/ogg", exts: []string{".ogg", ".oga"}, magic: [][]byte{[]byte("OggS")}})
+	// WAV is a RIFF container ("RIFF"<size>"WAVE"); see MatchMagic for the
+	// form-type disambiguation against WebP / AVI (issue #322).
+	Register(&audioType{name: "audio/wav", exts: []string{".wav", ".wave"}, magic: [][]byte{[]byte("RIFF")}})
 }
 
 type audioType struct {
@@ -25,6 +29,22 @@ type audioType struct {
 func (a *audioType) Name() string         { return a.name }
 func (a *audioType) Extensions() []string { return a.exts }
 func (a *audioType) MagicBytes() [][]byte { return a.magic }
+
+// MatchMagic disambiguates WAV from the other RIFF-container formats
+// (WebP image, AVI video) sharing the bare "RIFF" prefix: a real WAV
+// carries "WAVE" at bytes 8..11 (issue #322). Non-RIFF audio types fall
+// back to the standard prefix match.
+func (a *audioType) MatchMagic(head []byte) bool {
+	if a.name == "audio/wav" {
+		return len(head) >= 12 && string(head[0:4]) == "RIFF" && string(head[8:12]) == "WAVE"
+	}
+	for _, m := range a.magic {
+		if bytes.HasPrefix(head, m) {
+			return true
+		}
+	}
+	return false
+}
 
 // Attributes reads audio tags via dhowden/tag. The library auto-detects the
 // container format (ID3v1/v2 for MP3, MP4 atoms for M4A, Vorbis comments for
@@ -125,6 +145,8 @@ func readAudioInfo(ctx context.Context, name string, r io.ReadSeeker, fileSize i
 		return readOGGInfo(r, fileSize)
 	case "audio/mp4":
 		return readMP4Info(ctx, r, fileSize)
+	case "audio/wav":
+		return readWAVInfo(r)
 	}
 	return audioInfo{}, errors.New("unsupported audio format")
 }

--- a/internal/content/detector.go
+++ b/internal/content/detector.go
@@ -39,6 +39,34 @@ type ContentDiscriminator interface {
 	MatchesContent(head []byte) bool
 }
 
+// MagicMatcher is an optional interface a ContentType can implement when
+// a simple byte-PREFIX (MagicBytes) can't disambiguate it from another
+// type — most notably the RIFF container family (WebP / AVI / WAV all
+// start with the literal "RIFF" but carry their real form-type at bytes
+// 8..11: "WEBP" / "AVI " / "WAVE"). When implemented, the magic-sniff
+// pass calls MatchMagic(head) instead of prefix-matching MagicBytes, so
+// an extensionless or mis-extensioned RIFF file resolves correctly
+// rather than to whichever RIFF type happens to be registered first
+// (issue #322).
+type MagicMatcher interface {
+	MatchMagic(head []byte) bool
+}
+
+// magicMatches reports whether ct claims head via the magic-byte pass —
+// MatchMagic when ct implements MagicMatcher, otherwise a prefix match
+// against any of ct.MagicBytes().
+func magicMatches(ct ContentType, head []byte) bool {
+	if mm, ok := ct.(MagicMatcher); ok {
+		return mm.MatchMagic(head)
+	}
+	for _, magic := range ct.MagicBytes() {
+		if bytes.HasPrefix(head, magic) {
+			return true
+		}
+	}
+	return false
+}
+
 // discriminatorReadCap bounds the head read for the content-discriminator
 // tier. Generous enough to contain the top-level keys of a realistic
 // chat export (guild / channel metadata precedes the messages array)
@@ -132,10 +160,8 @@ func (r *Registry) Detect(fsys fs.FS, p string) ContentType {
 	}
 	buf = buf[:n]
 	for _, ct := range types {
-		for _, magic := range ct.MagicBytes() {
-			if bytes.HasPrefix(buf, magic) {
-				return ct
-			}
+		if magicMatches(ct, buf) {
+			return ct
 		}
 	}
 	return nil
@@ -253,11 +279,9 @@ func (r *Registry) DetectBoth(fsys fs.FS, p string) (nameType, magicType Content
 	}
 	buf = buf[:n]
 	for _, ct := range types {
-		for _, magic := range ct.MagicBytes() {
-			if bytes.HasPrefix(buf, magic) {
-				magicType = ct
-				return nameType, magicType
-			}
+		if magicMatches(ct, buf) {
+			magicType = ct
+			return nameType, magicType
 		}
 	}
 	return nameType, nil

--- a/internal/content/imagetype.go
+++ b/internal/content/imagetype.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"bytes"
 	"context"
 	"image"
 	_ "image/gif"
@@ -37,6 +38,23 @@ type imageType struct {
 func (i *imageType) Name() string         { return i.name }
 func (i *imageType) Extensions() []string { return i.exts }
 func (i *imageType) MagicBytes() [][]byte { return i.magic }
+
+// MatchMagic disambiguates WebP from the other RIFF-container formats
+// (WAV audio, AVI video) that share the bare "RIFF" prefix: a real WebP
+// carries "WEBP" at bytes 8..11. Without this, any RIFF file (e.g. a
+// .wav) would magic-match image/webp (issue #322). Non-WebP image types
+// fall back to the standard prefix match.
+func (i *imageType) MatchMagic(head []byte) bool {
+	if i.name == "image/webp" {
+		return len(head) >= 12 && string(head[0:4]) == "RIFF" && string(head[8:12]) == "WEBP"
+	}
+	for _, m := range i.magic {
+		if bytes.HasPrefix(head, m) {
+			return true
+		}
+	}
+	return false
+}
 
 func (i *imageType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {
 	if err := ctx.Err(); err != nil {

--- a/internal/content/riff_disambiguation_test.go
+++ b/internal/content/riff_disambiguation_test.go
@@ -1,0 +1,44 @@
+package content_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDetect_RIFFFamilyDisambiguation is the regression for issue #322:
+// WebP, AVI, and WAV all start with the bare "RIFF" prefix, so the
+// magic-byte pass used to return whichever registered first (WebP) for
+// every RIFF file — a .wav detected as image/webp. The form-type at
+// bytes 8..11 ("WEBP"/"AVI "/"WAVE") now disambiguates them, even for
+// extensionless / mis-extensioned files.
+func TestDetect_RIFFFamilyDisambiguation(t *testing.T) {
+	dir := t.TempDir()
+	// 4-byte RIFF size is arbitrary for detection; form-type at 8..11 matters.
+	cases := []struct {
+		file string
+		body []byte
+		want string
+	}{
+		// Extensionless → forces the magic-byte pass.
+		{"riff_webp", append([]byte("RIFF\x00\x10\x00\x00WEBP"), []byte("VP8 ....")...), "image/webp"},
+		{"riff_wave", append([]byte("RIFF\x00\x10\x00\x00WAVE"), []byte("fmt ....")...), "audio/wav"},
+		{"riff_avi", append([]byte("RIFF\x00\x10\x00\x00AVI "), []byte("LIST....")...), "video/x-msvideo"},
+		// Correct extension also resolves (extension pass wins).
+		{"song.wav", append([]byte("RIFF\x00\x10\x00\x00WAVE"), []byte("fmt ....")...), "audio/wav"},
+	}
+	for _, tc := range cases {
+		p := filepath.Join(dir, tc.file)
+		if err := os.WriteFile(p, tc.body, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		ct := detectAt(p)
+		if ct == nil {
+			t.Errorf("%s: got nil, want %s", tc.file, tc.want)
+			continue
+		}
+		if ct.Name() != tc.want {
+			t.Errorf("%s: got %s, want %s", tc.file, ct.Name(), tc.want)
+		}
+	}
+}

--- a/internal/content/videotype.go
+++ b/internal/content/videotype.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -24,6 +25,22 @@ type videoType struct {
 func (v *videoType) Name() string         { return v.name }
 func (v *videoType) Extensions() []string { return v.exts }
 func (v *videoType) MagicBytes() [][]byte { return v.magic }
+
+// MatchMagic disambiguates AVI from the other RIFF-container formats
+// (WebP image, WAV audio) sharing the bare "RIFF" prefix: a real AVI
+// carries "AVI " at bytes 8..11 (issue #322). Other video types fall
+// back to the standard prefix match.
+func (v *videoType) MatchMagic(head []byte) bool {
+	if v.name == "video/x-msvideo" {
+		return len(head) >= 12 && string(head[0:4]) == "RIFF" && string(head[8:12]) == "AVI "
+	}
+	for _, m := range v.magic {
+		if bytes.HasPrefix(head, m) {
+			return true
+		}
+	}
+	return false
+}
 
 // Attributes dispatches to a per-format binary parser. Each parser is
 // header- + tail-bounded (sub-millisecond on real files); ctx is honoured


### PR DESCRIPTION
## Problem

WAV, WebP, and AVI are all RIFF containers starting with the literal `RIFF`. There was **no `audio/wav` type at all**, and the magic-byte pass is a plain byte-prefix match, so it returned whichever RIFF type registered first — a `.wav` detected as **`image/webp`** with `is_image=true` (found in the mixed-format dogfood).

```sh
file-search-on attrs tone.wav   # was: content_type image/webp, is_image
```

## Fix

- **`MagicMatcher` interface** (`content/detector.go`): when a type implements it, the magic-sniff pass calls `MatchMagic(head)` instead of prefix-matching `MagicBytes`. `image/webp`, `video/x-msvideo`, and the new `audio/wav` implement it to check the RIFF form-type at bytes 8..11 (`WEBP`/`AVI `/`WAVE`) — so even **extensionless / mis-extensioned** RIFF files resolve correctly.
- **Register `audio/wav`** (`.wav`/`.wave`). The extension pass already wins over magic, so the common `.wav` case is fixed regardless; `is_audio` fires via the `audio/` prefix rule.
- **`readWAVInfo`**: parse the `fmt `/`data` chunks → `sample_rate`, `channels`, `bit_depth`, `duration` (data size / byte rate) + derived `nominal_bitrate`. Bounded chunk walk (cap 4096) so malformed input can't loop.

## Tests
`internal/content`: RIFF-family disambiguation (webp/wav/avi, extensionless **and** by extension — fails on `main`) and `readWAVInfo` (sample rate / channels / bit depth / ~1 s duration; rejects non-WAVE RIFF). README + `examples/audio.md` updated.

`build`/`vet`/`go fix` clean; full `go test ./...` passes; content package `-race` clean.

## Verified live
```
file-search-on attrs tone.wav
  content_type audio/wav ; duration 5 ; sample_rate 44100 ; channels 1 ; bit_depth 16
# extensionless RIFF files: riff_wave->audio/wav, riff_webp->image/webp, riff_avi->video/x-msvideo
```

Closes #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)