### PR TITLE
fix(content): detect fat/universal Mach-O instead of bytecode/jvm (#324)

### DIFF
--- a/internal/content/binary_macho.go
+++ b/internal/content/binary_macho.go
@@ -3,10 +3,42 @@ package content
 import (
 	"context"
 	"debug/macho"
+	"encoding/binary"
 	"io"
 	"io/fs"
 	"maps"
 )
+
+// machoFatCPUTypes is the set of Mach-O CPU types seen as the first
+// fat_arch.cputype in a universal binary. Used to disambiguate a
+// fat-Mach-O header from a Java .class file — both start with the
+// big-endian magic 0xCAFEBABE (issue #324).
+var machoFatCPUTypes = map[uint32]bool{
+	0x00000007: true, // x86
+	0x01000007: true, // x86_64
+	0x0000000C: true, // arm
+	0x0100000C: true, // arm64
+	0x0200000C: true, // arm64_32
+	0x00000012: true, // ppc
+	0x01000012: true, // ppc64
+}
+
+// isMachoFatHeader reports whether head begins a fat/universal Mach-O
+// binary. Fat Mach-O and Java .class both start with 0xCAFEBABE; they
+// differ in what follows — a fat header has a small nfat_arch count and
+// a recognised CPU type in the first fat_arch entry, whereas a class
+// file carries its minor/major version + constant pool there. Without
+// this check every universal binary (the macOS norm) misdetects as
+// bytecode/jvm. Issue #324.
+func isMachoFatHeader(head []byte) bool {
+	if len(head) < 12 || binary.BigEndian.Uint32(head[0:4]) != 0xCAFEBABE {
+		return false
+	}
+	if n := binary.BigEndian.Uint32(head[4:8]); n == 0 || n > 64 {
+		return false
+	}
+	return machoFatCPUTypes[binary.BigEndian.Uint32(head[8:12])]
+}
 
 // readMachoInfo parses a Mach-O binary's headers and returns the unified
 // binary attribute surface. Tries fat first via NewFatFile (handles the

--- a/internal/content/binarytype.go
+++ b/internal/content/binarytype.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io/fs"
@@ -38,6 +39,23 @@ type binaryType struct {
 func (b *binaryType) Name() string         { return b.name }
 func (b *binaryType) Extensions() []string { return b.exts }
 func (b *binaryType) MagicBytes() [][]byte { return b.magic }
+
+// MatchMagic claims fat/universal Mach-O binaries (magic 0xCAFEBABE),
+// which share that magic with Java .class and would otherwise detect as
+// bytecode/jvm — the thin Mach-O magics are registered but the fat one
+// isn't expressible as a fixed byte prefix (issue #324). Other binary
+// types (ELF, PE) fall back to the standard prefix match.
+func (b *binaryType) MatchMagic(head []byte) bool {
+	if b.name == "binary/mach-o" && isMachoFatHeader(head) {
+		return true
+	}
+	for _, m := range b.magic {
+		if bytes.HasPrefix(head, m) {
+			return true
+		}
+	}
+	return false
+}
 
 // Attributes dispatches to a per-format binary parser. All parsers
 // return the same surface — architectures, bitness, binary_format,

--- a/internal/content/bytecodetype.go
+++ b/internal/content/bytecodetype.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io/fs"
@@ -39,6 +40,22 @@ type bytecodeType struct {
 func (b *bytecodeType) Name() string         { return b.name }
 func (b *bytecodeType) Extensions() []string { return b.exts }
 func (b *bytecodeType) MagicBytes() [][]byte { return b.magic }
+
+// MatchMagic disambiguates Java .class from fat/universal Mach-O — both
+// start with 0xCAFEBABE. The jvm type only claims the magic when the
+// bytes that follow are NOT a fat-Mach-O header (issue #324). Other
+// bytecode types fall back to the standard prefix match.
+func (b *bytecodeType) MatchMagic(head []byte) bool {
+	if b.name == "bytecode/jvm" {
+		return bytes.HasPrefix(head, []byte{0xCA, 0xFE, 0xBA, 0xBE}) && !isMachoFatHeader(head)
+	}
+	for _, m := range b.magic {
+		if bytes.HasPrefix(head, m) {
+			return true
+		}
+	}
+	return false
+}
 
 // Attributes dispatches to a per-format VM-bytecode parser. Each
 // parser reads the format's header only — no instruction-stream

--- a/internal/content/cafebabe_disambiguation_test.go
+++ b/internal/content/cafebabe_disambiguation_test.go
@@ -1,0 +1,55 @@
+package content_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDetect_CafebabeDisambiguation is the regression for issue #324:
+// fat/universal Mach-O binaries and Java .class files both begin with
+// 0xCAFEBABE. The magic pass used to return whichever registered first
+// (bytecode/jvm), so every universal binary — the macOS norm —
+// misdetected as Java. Detection now inspects the bytes after the magic
+// (a fat header's nfat_arch + first CPU type vs a class's version).
+func TestDetect_CafebabeDisambiguation(t *testing.T) {
+	dir := t.TempDir()
+	// Fat Mach-O: CAFEBABE + nfat_arch=2 + fat_arch[0].cputype=x86_64(0x01000007).
+	machoFat := []byte{
+		0xCA, 0xFE, 0xBA, 0xBE, // magic
+		0x00, 0x00, 0x00, 0x02, // nfat_arch = 2
+		0x01, 0x00, 0x00, 0x07, // cputype = x86_64
+		0x00, 0x00, 0x00, 0x03, // cpusubtype (filler)
+	}
+	// Java 8 class: CAFEBABE + minor 0 + major 52 + constant_pool_count.
+	javaClass := []byte{
+		0xCA, 0xFE, 0xBA, 0xBE, // magic
+		0x00, 0x00, // minor
+		0x00, 0x34, // major = 52 (Java 8)
+		0x00, 0x05, // constant_pool_count
+		0x07, 0x00, // first cp entry (filler)
+	}
+	cases := []struct {
+		file string
+		body []byte
+		want string
+	}{
+		{"fatbin", machoFat, "binary/mach-o"},     // extensionless → magic pass
+		{"Klass", javaClass, "bytecode/jvm"},      // extensionless → magic pass
+		{"App.class", javaClass, "bytecode/jvm"},  // extension pass
+	}
+	for _, tc := range cases {
+		p := filepath.Join(dir, tc.file)
+		if err := os.WriteFile(p, tc.body, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		ct := detectAt(p)
+		if ct == nil {
+			t.Errorf("%s: got nil, want %s", tc.file, tc.want)
+			continue
+		}
+		if ct.Name() != tc.want {
+			t.Errorf("%s: got %s, want %s", tc.file, ct.Name(), tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Fat/universal Mach-O binaries and Java `.class` files both start with the big-endian magic `0xCAFEBABE`. Only `bytecode/jvm` registered that magic (`binary/mach-o` registered just the thin `FEEDFACE/CF` magics — the fat header isn't a fixed byte prefix), so every **universal binary — the macOS norm** (e.g. `/bin/ls`) — misdetected as `bytecode/jvm` and never reached `readMachoInfo` (which already handles fat files). Found in the mixed-format dogfood.

```sh
file-search-on attrs /bin/ls --check-disguised   # was: magic_content_type = bytecode/jvm
```

## Fix

Disambiguate via the `MagicMatcher` hook (added in #322) by inspecting the bytes after the magic — a fat header has a small `nfat_arch` count + a recognised CPU type in the first `fat_arch` entry; a class file has its minor/major version + constant pool there.

- `isMachoFatHeader` (`binary_macho.go`): `CAFEBABE` + `nfat_arch ∈ [1,64]` + a known `fat_arch[0].cputype` (x86 / x86_64 / arm / arm64 / arm64_32 / ppc / ppc64).
- `binaryType.MatchMagic`: claims fat Mach-O (plus existing thin Mach-O / ELF / PE prefixes).
- `bytecodeType.MatchMagic`: jvm claims `CAFEBABE` only when **not** a fat header.

Mutually exclusive → registration-order-independent.

## Test
`internal/content`: a crafted fat-Mach-O header → `binary/mach-o` and a Java 8 class → `bytecode/jvm`, both **extensionless** (magic pass) and by extension.

`build` / `vet` / `go fix` / `golangci-lint` clean; full `go test ./...` passes.

## Verified live
```
file-search-on attrs /bin/ls
  content_type binary/mach-o ; archs x86_64, arm64 ; bin_format mach-o ; bin_type executable
# Java .class (with/without extension) still -> bytecode/jvm
```

Closes #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)