### PR TITLE
fix(pdf): reconstruct word spaces in body extraction (#323)

### DIFF
--- a/internal/content/body_pdf.go
+++ b/internal/content/body_pdf.go
@@ -15,6 +15,55 @@ import (
 // in one pass at the end of extraction.
 var pdfCIDPattern = regexp.MustCompile(`\(cid:\d+\)`)
 
+// pdfSpaceGapRatio is the fraction of the font size above which a
+// horizontal gap between two text runs is treated as a word break.
+// Inter-word spaces render ~0.25em wide; intra-word kerning is near
+// zero, so 0.2em cleanly separates words without splitting them.
+const pdfSpaceGapRatio = 0.2
+
+// pdfRowsToText flattens GetTextByRow output into plain text, inserting
+// a space between consecutive runs whose horizontal gap implies a word
+// boundary (the library's own GetPlainText drops these — issue #323).
+// Rows are newline-separated, in the order GetTextByRow returns them
+// (top-to-bottom); runs within a row are already sorted left-to-right.
+func pdfRowsToText(rows pdf.Rows) string {
+	var out strings.Builder
+	for _, row := range rows {
+		if row == nil {
+			continue
+		}
+		var line strings.Builder
+		prevEnd := 0.0
+		lastWasSpace := true // suppress a leading space on each row
+		for _, t := range row.Content {
+			if !lastWasSpace && !strings.HasPrefix(t.S, " ") {
+				// When the library reports usable geometry (font size +
+				// width), space on a word-width gap. Many PDFs (e.g.
+				// justified arXiv papers) come back with zeroed X/W/
+				// FontSize — there each run is already a word-ish token,
+				// so default to a single separating space rather than
+				// concatenating everything into one blob.
+				gapKnown := t.FontSize > 0 && t.W > 0
+				if !gapKnown || t.X-prevEnd > pdfSpaceGapRatio*t.FontSize {
+					line.WriteByte(' ')
+				}
+			}
+			line.WriteString(t.S)
+			prevEnd = t.X + t.W
+			lastWasSpace = strings.HasSuffix(t.S, " ")
+		}
+		s := strings.TrimRight(line.String(), " \t")
+		if s == "" {
+			continue
+		}
+		if out.Len() > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(s)
+	}
+	return out.String()
+}
+
 // pdfBody extracts the plain-text body of a PDF document, one page at a
 // time, in numeric page order. Uses github.com/ledongthuc/pdf (already
 // a direct dep for metadata in pdftype.go) — no new dependency.
@@ -68,34 +117,15 @@ func pdfBody(ctx context.Context, fsys fs.FS, filePath string, maxBytes int) (st
 			return
 		}
 
-		// Pass 1 — build a single font cache shared across pages.
-		// Mirrors the library's own Reader.GetPlainText pattern.
-		fonts := make(map[string]*pdf.Font)
-		for i := 1; i <= numPages; i++ {
-			if err := ctx.Err(); err != nil {
-				return
-			}
-			func() {
-				defer func() { _ = recover() }()
-				p := r.Page(i)
-				if p.V.IsNull() {
-					return
-				}
-				for _, name := range p.Fonts() {
-					if _, ok := fonts[name]; !ok {
-						f := p.Font(name)
-						fonts[name] = &f
-					}
-				}
-			}()
-		}
-
-		if err := ctx.Err(); err != nil {
-			return
-		}
-
-		// Pass 2 — extract text from each page using the cached fonts.
-		// Per-page failures contribute nothing and don't stop the walk.
+		// Extract text per page via GetTextByRow (positional) rather
+		// than GetPlainText: the latter concatenates text-show operators
+		// with no spacing, so "Attention Is All You Need" comes out as
+		// "AttentionIsAllYouNeed" and multi-word body.contains /
+		// find-matches queries miss (issue #323). pdfRowsToText
+		// reconstructs word breaks from the horizontal gaps between text
+		// runs. GetTextByRow resolves fonts per page internally, so no
+		// shared font cache is needed. Per-page failures contribute
+		// nothing and don't stop the walk.
 		for i := 1; i <= numPages; i++ {
 			if err := ctx.Err(); err != nil {
 				return
@@ -109,11 +139,11 @@ func pdfBody(ctx context.Context, fsys fs.FS, filePath string, maxBytes int) (st
 				if p.V.IsNull() {
 					return ""
 				}
-				s, err := p.GetPlainText(fonts)
+				rows, err := p.GetTextByRow()
 				if err != nil {
 					return ""
 				}
-				return s
+				return pdfRowsToText(rows)
 			}()
 			if text == "" {
 				continue

--- a/internal/content/body_pdf_spacing_test.go
+++ b/internal/content/body_pdf_spacing_test.go
@@ -1,0 +1,58 @@
+package content
+
+import (
+	"testing"
+
+	"github.com/ledongthuc/pdf"
+)
+
+// TestPDFRowsToText_WordSpacing is the regression for issue #323. Many
+// PDFs (justified LaTeX output) come back from GetTextByRow as separate
+// word-ish runs with zeroed geometry; pdfRowsToText must join them with
+// spaces (not concatenate) so multi-word phrase search works. When
+// geometry IS present it spaces on a word-width gap instead.
+func TestPDFRowsToText_WordSpacing(t *testing.T) {
+	t.Run("zeroed geometry: join runs with spaces", func(t *testing.T) {
+		rows := pdf.Rows{
+			&pdf.Row{Position: 100, Content: pdf.TextHorizontal{
+				{S: "Attention"}, {S: "Is"}, {S: "All"}, {S: "You"}, {S: "Need"},
+			}},
+			&pdf.Row{Position: 90, Content: pdf.TextHorizontal{
+				{S: "neural"}, {S: "machine"}, {S: "translation"},
+			}},
+		}
+		got := pdfRowsToText(rows)
+		want := "Attention Is All You Need\nneural machine translation"
+		if got != want {
+			t.Errorf("got %q\nwant %q", got, want)
+		}
+	})
+
+	t.Run("present geometry: gap-based spacing", func(t *testing.T) {
+		rows := pdf.Rows{
+			&pdf.Row{Position: 100, Content: pdf.TextHorizontal{
+				// "foo" then "bar" contiguous (no gap) -> "foobar"; then a
+				// wide gap before "baz" -> space.
+				{S: "foo", X: 0, W: 30, FontSize: 10},
+				{S: "bar", X: 30, W: 30, FontSize: 10},
+				{S: "baz", X: 90, W: 30, FontSize: 10}, // gap 30 >> 0.2*10
+			}},
+		}
+		got := pdfRowsToText(rows)
+		want := "foobar baz"
+		if got != want {
+			t.Errorf("got %q want %q", got, want)
+		}
+	})
+
+	t.Run("does not double existing spaces", func(t *testing.T) {
+		rows := pdf.Rows{
+			&pdf.Row{Position: 100, Content: pdf.TextHorizontal{
+				{S: "hello "}, {S: "world"},
+			}},
+		}
+		if got := pdfRowsToText(rows); got != "hello world" {
+			t.Errorf("got %q want %q", got, "hello world")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`pdfBody` used the library's `Page.GetPlainText`, which concatenates text-show operators with **no spacing** — "Attention Is All You Need" → `AttentionIsAllYouNeed`. So multi-word `body.contains` / `body.matches` / `find_matches` phrase queries silently returned nothing on PDFs (single words still matched as substrings). Found in the mixed-format dogfood.

## Fix

Extract via `GetTextByRow` (positional) and reconstruct word breaks in `pdfRowsToText`:
- when the library reports usable geometry, insert a space on a word-width gap (`> 0.2em`);
- many PDFs (justified LaTeX/arXiv output) return **zeroed** X/W/FontSize with each run already a word-ish token — there, join runs with a single space instead of concatenating;
- never double an existing space; rows are newline-separated.

Also drops the old O(pages²) font pre-pass (`GetTextByRow` resolves fonts per page). Per-page panics/errors still degrade to `""`; ctx cancellation + `maxBytes` retained.

## Result (arXiv corpus)
Multi-word phrase search now works on PDF bodies:

| query (`--expr is_pdf`) | before | after |
|---|---|---|
| `neural machine translation` | 0 | **5** line hits |
| `dominant sequence transduction` | 0 | **1** |

Extracted text is readable (`"Neural machine translation by jointly"`). Single-word search and the ReportLab `sample.pdf` fixture (literal spaces) are unaffected.

**Honest scope:** the reconstruction is heuristic — `ledongthuc/pdf`'s geometry is unreliable (zeroed widths), so heavily-kerned runs (often after capitals / proper nouns, e.g. `Y oshua`) can still split, and title-page / line-wrapped phrases may miss. The common case is fixed; perfect PDF phrase extraction would need a different PDF engine (larger effort).

## Test
`pdfRowsToText` word-spacing (zeroed geometry → join with spaces; present geometry → gap-based; no double-spacing). Existing `TestExtractBody_Fixtures` still passes.

`build` / `vet` / `go fix` / `golangci-lint` clean; full `go test ./...` passes.

Closes #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)