### PR TITLE
fix(audio): extract OGG metadata for Opus and FLAC-in-OGG, not just Vorbis (#325)

### DIFF
--- a/examples/audio.md
+++ b/examples/audio.md
@@ -1,8 +1,8 @@
 # Recipes — Audio
 
-Audio content types: `audio/mpeg` (MP3), `audio/mp4` (M4A/AAC), `audio/flac`, `audio/ogg`, `audio/wav` (`.wav`/`.wave`). Umbrella boolean `is_audio`.
+Audio content types: `audio/mpeg` (MP3), `audio/mp4` (M4A/AAC), `audio/flac`, `audio/ogg` (Vorbis, Opus `.opus`, and FLAC-in-OGG), `audio/wav` (`.wav`/`.wave`). Umbrella boolean `is_audio`.
 
-Tags are extracted via [`dhowden/tag`](https://github.com/dhowden/tag) — handles ID3v1/v2 (MP3), MP4 atoms (M4A), and Vorbis comments (FLAC, OGG) under one API. Playback metadata (duration, bitrate, sample rate, channels, bit depth) is hand-rolled per format; WAV reads its `fmt `/`data` chunks directly. WAV / WebP / AVI all share the `RIFF` magic, so detection checks the form-type at bytes 8..11 (`WAVE`/`WEBP`/`AVI `) to disambiguate.
+Tags are extracted via [`dhowden/tag`](https://github.com/dhowden/tag) — handles ID3v1/v2 (MP3), MP4 atoms (M4A), and Vorbis comments (FLAC, OGG) under one API. Playback metadata (duration, bitrate, sample rate, channels, bit depth) is hand-rolled per format; WAV reads its `fmt `/`data` chunks directly, and the OGG reader dispatches on the page codec (Vorbis / Opus / FLAC-in-OGG) — Opus duration uses the 48 kHz granule. WAV / WebP / AVI all share the `RIFF` magic, so detection checks the form-type at bytes 8..11 (`WAVE`/`WEBP`/`AVI `) to disambiguate.
 
 ## Tags
 

--- a/internal/content/audio_ogg.go
+++ b/internal/content/audio_ogg.go
@@ -7,69 +7,123 @@ import (
 	"io"
 )
 
-// readOGGInfo parses the Vorbis identification header in the first audio
-// page (gives sample_rate + channels) and reads the granule_position from
-// the last OggS page (gives total samples → duration).
-//
-// The ID header layout inside the page payload:
-//
-//	"\x01vorbis"           (7 bytes)
-//	uint32 vorbis_version  (LE, offset +7)
-//	uint8  channels                (offset +11)
-//	uint32 sample_rate     (LE, offset +12)
-//	int32  bitrate_max     (LE, offset +16)
-//	int32  bitrate_nominal (LE, offset +20)
-//	int32  bitrate_min     (LE, offset +24)
-//	uint8  blocksizes              (offset +28)
-//	uint8  framing                 (offset +29)
+// readOGGInfo recovers sample_rate / channels / duration from an OGG
+// container, dispatching on the codec carried in the first page: Vorbis
+// (the classic .ogg/.oga), Opus (.opus and modern .ogg), and FLAC-in-OGG.
+// Previously only Vorbis was handled, so Opus / FLAC-in-OGG files
+// detected as audio/ogg but surfaced no playback metadata (issue #325).
 func readOGGInfo(r io.ReadSeeker, fileSize int64) (audioInfo, error) {
 	// Read the start of the file — enough to span the first page header
-	// and the Vorbis ID header (typically <100 bytes).
+	// and the codec identification header (typically <100 bytes).
 	head := make([]byte, 4096)
 	n, _ := io.ReadFull(r, head)
 	head = head[:n]
 
-	idx := bytes.Index(head, []byte("\x01vorbis"))
-	if idx < 0 || idx+30 > len(head) {
-		return audioInfo{}, errors.New("no Vorbis identification header found")
+	switch {
+	case bytes.Contains(head, []byte("\x01vorbis")):
+		return readOGGVorbis(r, head, fileSize)
+	case bytes.Contains(head, []byte("OpusHead")):
+		return readOGGOpus(r, head, fileSize)
+	case bytes.Contains(head, []byte("\x7fFLAC")):
+		return readOGGFLAC(r, head, fileSize)
 	}
+	return audioInfo{}, errors.New("no recognised OGG codec (Vorbis/Opus/FLAC) header")
+}
 
-	channels := int64(head[idx+11])
-	sampleRate := int64(binary.LittleEndian.Uint32(head[idx+12 : idx+16]))
-	bitrateNominal := int32(binary.LittleEndian.Uint32(head[idx+20 : idx+24]))
-
-	info := audioInfo{
-		SampleRate: sampleRate,
-		Channels:   channels,
-	}
-	// bitrate_nominal is stored in bps; convert to kbps for consistency
-	// with the existing computed `bitrate`. Negative or zero means
-	// "not specified" — leave NominalBitrate unset in that case.
-	if bitrateNominal > 0 {
-		info.NominalBitrate = int64(bitrateNominal) / 1000
-	}
-	if sampleRate <= 0 {
-		return info, nil
-	}
-
-	// Find the last OggS page by reading the trailing 64 KiB and scanning
-	// backwards for the magic. Granule position is at byte offset 6 in the
-	// 27-byte page header (8 bytes, little-endian, signed int64).
+// oggLastGranule scans the trailing 64 KiB backwards for the last OggS
+// page header and returns its granule_position (8 bytes LE at offset 6
+// of the 27-byte page header). The granule unit is codec-defined:
+// samples-at-sample-rate for Vorbis/FLAC, 48 kHz samples for Opus.
+func oggLastGranule(r io.ReadSeeker, fileSize int64) (int64, bool) {
 	tailSize := min(fileSize, int64(64*1024))
+	if tailSize < 27 {
+		return 0, false
+	}
 	tail := make([]byte, tailSize)
 	if _, err := r.Seek(fileSize-tailSize, io.SeekStart); err != nil {
-		return info, nil
+		return 0, false
 	}
 	if _, err := io.ReadFull(r, tail); err != nil {
-		return info, nil
+		return 0, false
 	}
 	for off := len(tail) - 27; off >= 0; off-- {
 		if tail[off] == 'O' && tail[off+1] == 'g' && tail[off+2] == 'g' && tail[off+3] == 'S' {
-			gran := int64(binary.LittleEndian.Uint64(tail[off+6 : off+14]))
-			if gran > 0 {
-				info.Duration = float64(gran) / float64(sampleRate)
-			}
-			break
+			return int64(binary.LittleEndian.Uint64(tail[off+6 : off+14])), true
+		}
+	}
+	return 0, false
+}
+
+// readOGGVorbis parses the Vorbis identification header (channels at +11,
+// sample_rate LE at +12, bitrate_nominal LE at +20) + the last granule.
+func readOGGVorbis(r io.ReadSeeker, head []byte, fileSize int64) (audioInfo, error) {
+	idx := bytes.Index(head, []byte("\x01vorbis"))
+	if idx < 0 || idx+30 > len(head) {
+		return audioInfo{}, errors.New("truncated Vorbis identification header")
+	}
+	info := audioInfo{
+		Channels:   int64(head[idx+11]),
+		SampleRate: int64(binary.LittleEndian.Uint32(head[idx+12 : idx+16])),
+	}
+	// bitrate_nominal (bps) → kbps; <= 0 means "not specified".
+	if bn := int32(binary.LittleEndian.Uint32(head[idx+20 : idx+24])); bn > 0 {
+		info.NominalBitrate = int64(bn) / 1000
+	}
+	if info.SampleRate > 0 {
+		if g, ok := oggLastGranule(r, fileSize); ok && g > 0 {
+			info.Duration = float64(g) / float64(info.SampleRate)
+		}
+	}
+	return info, nil
+}
+
+// readOGGOpus parses the OpusHead identification header. Opus always
+// decodes at 48 kHz and its granule positions are in 48 kHz samples, so
+// duration = (last_granule - pre_skip) / 48000. channels at +9, pre_skip
+// (LE u16) at +10.
+func readOGGOpus(r io.ReadSeeker, head []byte, fileSize int64) (audioInfo, error) {
+	idx := bytes.Index(head, []byte("OpusHead"))
+	if idx < 0 || idx+12 > len(head) {
+		return audioInfo{}, errors.New("truncated OpusHead header")
+	}
+	const opusRate = 48000
+	preSkip := int64(binary.LittleEndian.Uint16(head[idx+10 : idx+12]))
+	info := audioInfo{
+		Channels:   int64(head[idx+9]),
+		SampleRate: opusRate,
+	}
+	if g, ok := oggLastGranule(r, fileSize); ok {
+		if samples := g - preSkip; samples > 0 {
+			info.Duration = float64(samples) / float64(opusRate)
+		}
+	}
+	return info, nil
+}
+
+// readOGGFLAC handles FLAC-in-OGG: the first page payload is the
+// FLAC-in-Ogg mapping header (0x7F "FLAC" version + packet count) followed
+// by the native "fLaC" signature + STREAMINFO. Slicing to the native
+// signature lets readFLACInfo recover sample_rate / channels / bit_depth /
+// duration (STREAMINFO carries total_samples, so no granule scan needed).
+func readOGGFLAC(r io.ReadSeeker, head []byte, fileSize int64) (audioInfo, error) {
+	idx := bytes.Index(head, []byte("\x7fFLAC"))
+	if idx < 0 {
+		return audioInfo{}, errors.New("no FLAC-in-OGG mapping header")
+	}
+	native := bytes.Index(head[idx:], []byte("fLaC"))
+	if native < 0 {
+		return audioInfo{}, errors.New("no native fLaC block in OGG-FLAC")
+	}
+	info, err := readFLACInfo(bytes.NewReader(head[idx+native:]))
+	if err != nil {
+		return info, err
+	}
+	// Streamed FLAC-in-OGG often leaves STREAMINFO total_samples = 0
+	// (unknown length); fall back to the OGG granule, which counts
+	// samples at the FLAC sample rate.
+	if info.Duration == 0 && info.SampleRate > 0 {
+		if g, ok := oggLastGranule(r, fileSize); ok && g > 0 {
+			info.Duration = float64(g) / float64(info.SampleRate)
 		}
 	}
 	return info, nil

--- a/internal/content/audio_ogg_test.go
+++ b/internal/content/audio_ogg_test.go
@@ -1,77 +1,70 @@
-package content_test
+package content
 
 import (
 	"bytes"
 	"encoding/binary"
-	"os"
-	"path/filepath"
 	"testing"
-
 )
 
-// buildOGG builds a minimal OGG file containing:
-//   - one page wrapping a Vorbis identification header (gives sample_rate +
-//     channels)
-//   - one final page whose granule_position encodes the total sample count
-//
-// The pages aren't checksummed correctly — the parser doesn't verify CRCs.
-func buildOGG(sampleRate uint32, channels uint8, totalSamples int64) []byte {
-	// Vorbis identification packet (30 bytes).
-	var packet bytes.Buffer
-	packet.WriteString("\x01vorbis")
-	_ = binary.Write(&packet, binary.LittleEndian, uint32(0)) // vorbis version
-	packet.WriteByte(channels)
-	_ = binary.Write(&packet, binary.LittleEndian, sampleRate)
-	_ = binary.Write(&packet, binary.LittleEndian, uint32(0))   // bitrate_max
-	_ = binary.Write(&packet, binary.LittleEndian, uint32(0))   // bitrate_nominal
-	_ = binary.Write(&packet, binary.LittleEndian, uint32(0))   // bitrate_min
-	packet.WriteByte(0xB8)                                  // blocksizes 8/8
-	packet.WriteByte(0x01)                                  // framing flag
-
-	page := func(granule int64, payload []byte) []byte {
-		var p bytes.Buffer
-		p.WriteString("OggS")
-		p.WriteByte(0)                                       // version
-		p.WriteByte(0)                                       // header type
-		_ = binary.Write(&p, binary.LittleEndian, granule)        // granule_position (int64)
-		_ = binary.Write(&p, binary.LittleEndian, uint32(0))     // serial number
-		_ = binary.Write(&p, binary.LittleEndian, uint32(0))     // page sequence
-		_ = binary.Write(&p, binary.LittleEndian, uint32(0))     // checksum (we cheat)
-		p.WriteByte(1)                                       // page segments
-		p.WriteByte(byte(len(payload)))                      // segment table
-		p.Write(payload)
-		return p.Bytes()
-	}
-
-	var out bytes.Buffer
-	out.Write(page(0, packet.Bytes()))            // first audio page
-	out.Write(make([]byte, 1024))                  // some filler so the file isn't tiny
-	out.Write(page(totalSamples, []byte("end"))) // last page with the granule
-	return out.Bytes()
+// oggPage wraps payload in a single-page OggS header carrying granule at
+// offset 6, enough for readOGGInfo's codec sniff + last-granule scan.
+func oggPage(granule uint64, payload []byte) []byte {
+	b := make([]byte, 28)
+	copy(b, "OggS")
+	binary.LittleEndian.PutUint64(b[6:14], granule)
+	b[26] = 1
+	b[27] = byte(len(payload))
+	return append(b, payload...)
 }
 
-func TestOGGInfo(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "song.ogg")
-	// 48000 Hz, 2 channels, 4_800_000 samples = 100 seconds.
-	if err := os.WriteFile(path, buildOGG(48000, 2, 4_800_000), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	ct := detectAt(path)
-	if ct == nil || ct.Name() != "audio/ogg" {
-		t.Fatalf("Detect: got %v, want audio/ogg", ct)
-	}
-	attrs, err := attributesAt(t.Context(), ct, path)
-	if err != nil {
-		t.Fatalf("Attributes: %v", err)
-	}
-	if got := attrs["sample_rate"]; got != int64(48000) {
-		t.Errorf("sample_rate = %v, want 48000", got)
-	}
-	if got := attrs["channels"]; got != int64(2) {
-		t.Errorf("channels = %v, want 2", got)
-	}
-	if got := attrs["duration"]; got != float64(100) {
-		t.Errorf("duration = %v, want 100", got)
-	}
+// TestReadOGGInfo_Codecs is the regression for issue #325: readOGGInfo
+// handled only Vorbis, so Opus / FLAC-in-OGG surfaced no metadata. It
+// now dispatches on the codec identification header.
+func TestReadOGGInfo_Codecs(t *testing.T) {
+	t.Run("vorbis", func(t *testing.T) {
+		p := []byte("\x01vorbis")
+		p = binary.LittleEndian.AppendUint32(p, 0)      // version
+		p = append(p, 2)                                // channels (+11)
+		p = binary.LittleEndian.AppendUint32(p, 44100)  // sample_rate (+12)
+		p = binary.LittleEndian.AppendUint32(p, 0)      // bitrate_max
+		p = binary.LittleEndian.AppendUint32(p, 128000) // bitrate_nominal (+20)
+		p = binary.LittleEndian.AppendUint32(p, 0)      // bitrate_min
+		p = append(p, 0, 0)                             // blocksizes, framing
+		buf := oggPage(88200, p)                        // 2s @ 44100
+		info, err := readOGGInfo(bytes.NewReader(buf), int64(len(buf)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.SampleRate != 44100 || info.Channels != 2 || info.NominalBitrate != 128 {
+			t.Errorf("vorbis: %+v", info)
+		}
+		if info.Duration < 1.99 || info.Duration > 2.01 {
+			t.Errorf("vorbis Duration=%v want ~2", info.Duration)
+		}
+	})
+
+	t.Run("opus", func(t *testing.T) {
+		p := []byte("OpusHead")
+		p = append(p, 1, 2)                            // version, channels (+9)
+		p = binary.LittleEndian.AppendUint16(p, 312)   // pre_skip (+10)
+		p = binary.LittleEndian.AppendUint32(p, 48000) // input rate
+		p = append(p, 0, 0, 0)
+		buf := oggPage(336312, p) // (336312-312)/48000 = 7s
+		info, err := readOGGInfo(bytes.NewReader(buf), int64(len(buf)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.SampleRate != 48000 || info.Channels != 2 {
+			t.Errorf("opus: %+v", info)
+		}
+		if info.Duration < 6.99 || info.Duration > 7.01 {
+			t.Errorf("opus Duration=%v want ~7", info.Duration)
+		}
+	})
+
+	t.Run("unrecognised", func(t *testing.T) {
+		if _, err := readOGGInfo(bytes.NewReader(oggPage(0, []byte("SpeexNotSupported"))), 100); err == nil {
+			t.Error("expected error for unrecognised OGG codec")
+		}
+	})
 }

--- a/internal/content/audiotype.go
+++ b/internal/content/audiotype.go
@@ -14,7 +14,7 @@ func init() {
 	Register(&audioType{name: "audio/mpeg", exts: []string{".mp3"}, magic: [][]byte{[]byte("ID3"), {0xFF, 0xFB}, {0xFF, 0xF3}, {0xFF, 0xF2}}})
 	Register(&audioType{name: "audio/mp4", exts: []string{".m4a", ".m4b", ".m4p", ".aac"}, magic: nil})
 	Register(&audioType{name: "audio/flac", exts: []string{".flac"}, magic: [][]byte{[]byte("fLaC")}})
-	Register(&audioType{name: "audio/ogg", exts: []string{".ogg", ".oga"}, magic: [][]byte{[]byte("OggS")}})
+	Register(&audioType{name: "audio/ogg", exts: []string{".ogg", ".oga", ".opus"}, magic: [][]byte{[]byte("OggS")}})
 	// WAV is a RIFF container ("RIFF"<size>"WAVE"); see MatchMagic for the
 	// form-type disambiguation against WebP / AVI (issue #322).
 	Register(&audioType{name: "audio/wav", exts: []string{".wav", ".wave"}, magic: [][]byte{[]byte("RIFF")}})


### PR DESCRIPTION
## Problem

`readOGGInfo` only looked for the Vorbis identification header (`\x01vorbis`), so **Opus** (`.opus` / modern `.ogg`) and **FLAC-in-OGG** files detected as `audio/ogg` but surfaced no `duration` / `sample_rate` / `channels`. Found in the mixed-format dogfood — a FLAC-in-OGG `tone.ogg` returned only `content_type`.

## Fix

`readOGGInfo` now sniffs the first-page codec and dispatches:

- **Vorbis** — unchanged (channels / sample_rate / bitrate_nominal + granule).
- **Opus** — `OpusHead` → channels + pre_skip. Opus decodes at 48 kHz and its granule is in 48 kHz samples, so `duration = (last_granule - pre_skip) / 48000`.
- **FLAC-in-OGG** — slice to the native `fLaC` block and reuse `readFLACInfo`; fall back to the OGG granule for duration when STREAMINFO `total_samples` is 0 (common for streamed FLAC).

The last-granule scan is factored into `oggLastGranule`. `.opus` registered on `audio/ogg` so Opus files also match by extension.

## Test
`internal/content`: `readOGGInfo` dispatch — Vorbis (44100 / 2ch / ~2s), Opus (48000 / 2ch / ~7s with pre-skip), unrecognised codec errors.

Verified live: a real Opus `.ogg` → `duration 7, sample_rate 48000`; the dogfood FLAC-in-OGG `tone.ogg` → `duration 20, sample_rate 44100, bit_depth 16` (was nothing).

`build` / `vet` / `go fix` / `golangci-lint` clean; full `go test ./...` passes.

**Note:** this covers playback metadata; Vorbis-comment **tag** extraction for Opus / FLAC-in-OGG still goes through `dhowden/tag` and is unchanged.

Closes #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)