### PR TITLE
fix: honor context cancellation in near-dup grouping and chat-export iteration

### DIFF
--- a/internal/content/chat_export.go
+++ b/internal/content/chat_export.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"io/fs"
@@ -10,6 +11,12 @@ import (
 	"strings"
 	"time"
 )
+
+// chatCtxCheckMask sets how often the streaming JSON iterators poll
+// ctx.Err(): every (mask+1) = 1024 elements. Cheap enough to be
+// invisible on normal exports, frequent enough that a cancelled
+// multi-million-message parse stops promptly.
+const chatCtxCheckMask = 1<<10 - 1
 
 // Chat-export content types (issue #214). Slack workspace exports,
 // Discord (DiscordChatExporter) dumps, and signal-cli JSON are all
@@ -264,7 +271,7 @@ func skipJSONValue(dec *json.Decoder) error {
 // calling fn with each element's raw bytes until fn returns false, the
 // array ends, or a decode error occurs. Does nothing when data isn't a
 // top-level array.
-func forEachArrayElement(data []byte, fn func(json.RawMessage) bool) {
+func forEachArrayElement(ctx context.Context, data []byte, fn func(json.RawMessage) bool) {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	t, err := dec.Token()
 	if err != nil {
@@ -273,7 +280,12 @@ func forEachArrayElement(data []byte, fn func(json.RawMessage) bool) {
 	if d, ok := t.(json.Delim); !ok || d != '[' {
 		return
 	}
-	for dec.More() {
+	for n := 0; dec.More(); n++ {
+		// A multi-million-element export must not run uninterruptibly
+		// after a timeout / Ctrl-C — check ctx periodically (#321 audit).
+		if n&chatCtxCheckMask == 0 && ctx.Err() != nil {
+			return
+		}
 		var raw json.RawMessage
 		if err := dec.Decode(&raw); err != nil {
 			return
@@ -288,9 +300,12 @@ func forEachArrayElement(data []byte, fn func(json.RawMessage) bool) {
 // handles newline-delimited JSON (signal-cli's default output) as well
 // as a single object. Calls fn with each value's raw bytes until fn
 // returns false or input is exhausted.
-func forEachJSONValue(data []byte, fn func(json.RawMessage) bool) {
+func forEachJSONValue(ctx context.Context, data []byte, fn func(json.RawMessage) bool) {
 	dec := json.NewDecoder(bytes.NewReader(data))
-	for {
+	for n := 0; ; n++ {
+		if n&chatCtxCheckMask == 0 && ctx.Err() != nil {
+			return // cancelled — stop streaming (#321 audit)
+		}
 		var raw json.RawMessage
 		if err := dec.Decode(&raw); err != nil {
 			return

--- a/internal/content/chat_export_discord.go
+++ b/internal/content/chat_export_discord.go
@@ -48,7 +48,7 @@ func (*discordExportType) Attributes(ctx context.Context, fsys fs.FS, p string) 
 	if len(buf) == 0 {
 		return Attributes{}, nil
 	}
-	c, channel, guild := parseDiscordExport(buf)
+	c, channel, guild := parseDiscordExport(ctx, buf)
 	return c.toAttributes(channel, guild), nil
 }
 
@@ -70,7 +70,7 @@ func (m *discordMessage) author() string {
 
 // parseDiscordExport extracts guild + channel names and streams the
 // messages array. Pure function — fuzz target exercises it directly.
-func parseDiscordExport(data []byte) (c *chatCollector, channel, guild string) {
+func parseDiscordExport(ctx context.Context, data []byte) (c *chatCollector, channel, guild string) {
 	c = &chatCollector{}
 	var file struct {
 		Guild    struct{ Name string `json:"name"` } `json:"guild"`
@@ -80,7 +80,7 @@ func parseDiscordExport(data []byte) (c *chatCollector, channel, guild string) {
 	if err := json.Unmarshal(data, &file); err != nil {
 		return c, "", ""
 	}
-	forEachArrayElement(file.Messages, func(raw json.RawMessage) bool {
+	forEachArrayElement(ctx, file.Messages, func(raw json.RawMessage) bool {
 		var m discordMessage
 		if err := json.Unmarshal(raw, &m); err != nil {
 			return true
@@ -103,6 +103,6 @@ func discordExportBody(ctx context.Context, fsys fs.FS, p string, maxBytes int) 
 	if len(buf) == 0 {
 		return "", nil
 	}
-	c, _, _ := parseDiscordExport(buf)
+	c, _, _ := parseDiscordExport(ctx, buf)
 	return chatBody(c, maxBytes), nil
 }

--- a/internal/content/chat_export_fuzz_test.go
+++ b/internal/content/chat_export_fuzz_test.go
@@ -1,6 +1,9 @@
 package content
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // FuzzParseChatExport exercises the three chat-export parsers and the
 // shape sniffer against arbitrary bytes. None may panic; malformed
@@ -20,9 +23,9 @@ func FuzzParseChatExport(f *testing.F) {
 	f.Add([]byte(`{"guild":{},"channel":{},"messages":[{"timestamp":"bad"}]}`))
 
 	f.Fuzz(func(_ *testing.T, data []byte) {
-		_ = parseSlackExport(data)
-		_, _, _ = parseDiscordExport(data)
-		_ = parseSignalExport(data)
+		_ = parseSlackExport(context.Background(), data)
+		_, _, _ = parseDiscordExport(context.Background(), data)
+		_ = parseSignalExport(context.Background(), data)
 		_, _ = sniffJSONShape(data)
 		// Discriminators must also never panic on arbitrary bytes.
 		_ = (&slackExportType{}).MatchesContent(data)

--- a/internal/content/chat_export_signal.go
+++ b/internal/content/chat_export_signal.go
@@ -51,7 +51,7 @@ func (*signalExportType) Attributes(ctx context.Context, fsys fs.FS, p string) (
 	if len(buf) == 0 {
 		return Attributes{}, nil
 	}
-	c := parseSignalExport(buf)
+	c := parseSignalExport(ctx, buf)
 	// chat_channel = contact (file basename without extension); no
 	// workspace concept for Signal.
 	channel := signalContactFromPath(p)
@@ -79,7 +79,7 @@ func (e *signalEnvelope) author() string {
 // parseSignalExport streams envelope objects from either the NDJSON or
 // the wrapped-array form. Pure function — fuzz target exercises it
 // directly.
-func parseSignalExport(data []byte) *chatCollector {
+func parseSignalExport(ctx context.Context, data []byte) *chatCollector {
 	c := &chatCollector{}
 	consume := func(raw json.RawMessage) bool {
 		var e signalEnvelope
@@ -94,9 +94,9 @@ func parseSignalExport(data []byte) *chatCollector {
 		return !c.full()
 	}
 	if startsWithJSONArray(data) {
-		forEachArrayElement(data, consume)
+		forEachArrayElement(ctx, data, consume)
 	} else {
-		forEachJSONValue(data, consume)
+		forEachJSONValue(ctx, data, consume)
 	}
 	return c
 }
@@ -115,5 +115,5 @@ func signalExportBody(ctx context.Context, fsys fs.FS, p string, maxBytes int) (
 	if len(buf) == 0 {
 		return "", nil
 	}
-	return chatBody(parseSignalExport(buf), maxBytes), nil
+	return chatBody(parseSignalExport(ctx, buf), maxBytes), nil
 }

--- a/internal/content/chat_export_slack.go
+++ b/internal/content/chat_export_slack.go
@@ -56,7 +56,7 @@ func (*slackExportType) Attributes(ctx context.Context, fsys fs.FS, p string) (A
 	if len(buf) == 0 {
 		return Attributes{}, nil
 	}
-	c := parseSlackExport(buf)
+	c := parseSlackExport(ctx, buf)
 	return c.toAttributes(dirName(p), grandDirName(p)), nil
 }
 
@@ -85,7 +85,7 @@ func (m *slackMessage) author() string {
 // parseSlackExport streams the message array (array form) or the
 // wrapped object's `messages` array, collecting the shared chat surface.
 // Pure function — fuzz target exercises it directly.
-func parseSlackExport(data []byte) *chatCollector {
+func parseSlackExport(ctx context.Context, data []byte) *chatCollector {
 	c := &chatCollector{}
 	consume := func(raw json.RawMessage) bool {
 		var m slackMessage
@@ -96,7 +96,7 @@ func parseSlackExport(data []byte) *chatCollector {
 		return !c.full()
 	}
 	if startsWithJSONArray(data) {
-		forEachArrayElement(data, consume)
+		forEachArrayElement(ctx, data, consume)
 		return c
 	}
 	// Wrapped object form: {"messages": [...]}.
@@ -106,7 +106,7 @@ func parseSlackExport(data []byte) *chatCollector {
 	if err := json.Unmarshal(data, &wrapper); err != nil || len(wrapper.Messages) == 0 {
 		return c
 	}
-	forEachArrayElement(wrapper.Messages, consume)
+	forEachArrayElement(ctx, wrapper.Messages, consume)
 	return c
 }
 
@@ -118,5 +118,5 @@ func slackExportBody(ctx context.Context, fsys fs.FS, p string, maxBytes int) (s
 	if len(buf) == 0 {
 		return "", nil
 	}
-	return chatBody(parseSlackExport(buf), maxBytes), nil
+	return chatBody(parseSlackExport(ctx, buf), maxBytes), nil
 }

--- a/internal/content/chat_export_test.go
+++ b/internal/content/chat_export_test.go
@@ -26,7 +26,7 @@ func TestSlackExport_Detection(t *testing.T) {
 }
 
 func TestSlackExport_Attributes(t *testing.T) {
-	c := parseSlackExport([]byte(slackArrayFixture))
+	c := parseSlackExport(t.Context(), []byte(slackArrayFixture))
 	attrs := c.toAttributes(dirName("acme/engineering/2021-01-01.json"), grandDirName("acme/engineering/2021-01-01.json"))
 
 	if got := attrs["chat_message_count"]; got != int64(3) {
@@ -54,14 +54,14 @@ func TestSlackExport_WrappedObjectForm(t *testing.T) {
 	if ct == nil || ct.Name() != "chat/slack-export" {
 		t.Fatalf("wrapped-form Detect = %v, want chat/slack-export", ctName(ct))
 	}
-	c := parseSlackExport([]byte(wrapped))
+	c := parseSlackExport(t.Context(), []byte(wrapped))
 	if c.count != 3 {
 		t.Errorf("wrapped count = %d, want 3", c.count)
 	}
 }
 
 func TestSlackExport_Body(t *testing.T) {
-	body := chatBody(parseSlackExport([]byte(slackArrayFixture)), 1<<20)
+	body := chatBody(parseSlackExport(t.Context(), []byte(slackArrayFixture)), 1<<20)
 	if !strings.Contains(body, "kubernetes") {
 		t.Errorf("body should contain 'kubernetes': %q", body)
 	}
@@ -91,7 +91,7 @@ func TestDiscordExport_Detection(t *testing.T) {
 }
 
 func TestDiscordExport_Attributes(t *testing.T) {
-	c, channel, guild := parseDiscordExport([]byte(discordFixture))
+	c, channel, guild := parseDiscordExport(t.Context(), []byte(discordFixture))
 	attrs := c.toAttributes(channel, guild)
 	if got := attrs["chat_message_count"]; got != int64(2) {
 		t.Errorf("chat_message_count = %v, want 2", got)
@@ -125,7 +125,7 @@ func TestSignalExport_Detection_NDJSON(t *testing.T) {
 }
 
 func TestSignalExport_Attributes(t *testing.T) {
-	c := parseSignalExport([]byte(signalNDJSON))
+	c := parseSignalExport(t.Context(), []byte(signalNDJSON))
 	attrs := c.toAttributes(signalContactFromPath("+15550001.json"), "")
 	if got := attrs["chat_message_count"]; got != int64(2) {
 		t.Errorf("chat_message_count = %v, want 2", got)
@@ -144,7 +144,7 @@ func TestSignalExport_Attributes(t *testing.T) {
 
 func TestSignalExport_ArrayForm(t *testing.T) {
 	arr := `[` + strings.ReplaceAll(signalNDJSON, "}}\n{", "}},{") + `]`
-	c := parseSignalExport([]byte(arr))
+	c := parseSignalExport(t.Context(), []byte(arr))
 	if c.count != 2 {
 		t.Errorf("array-form count = %d, want 2", c.count)
 	}

--- a/internal/content/chat_iter_cancel_test.go
+++ b/internal/content/chat_iter_cancel_test.go
@@ -1,0 +1,39 @@
+package content
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestChatIterators_Cancellation verifies the streaming JSON iterators
+// stop on a cancelled context instead of running over every element of a
+// huge export (the ctx-cancellation audit gap).
+func TestChatIterators_Cancellation(t *testing.T) {
+	// A large top-level array and an NDJSON stream.
+	arr := "[" + strings.Repeat(`{"x":1},`, 5000) + `{"x":1}]`
+	ndjson := strings.Repeat(`{"x":1}`+"\n", 5001)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	count := 0
+	forEachArrayElement(ctx, []byte(arr), func(json.RawMessage) bool { count++; return true })
+	if count != 0 {
+		t.Errorf("forEachArrayElement: processed %d elements under cancelled ctx, want 0", count)
+	}
+
+	count = 0
+	forEachJSONValue(ctx, []byte(ndjson), func(json.RawMessage) bool { count++; return true })
+	if count != 0 {
+		t.Errorf("forEachJSONValue: processed %d values under cancelled ctx, want 0", count)
+	}
+
+	// Sanity: a live ctx processes everything.
+	count = 0
+	forEachArrayElement(context.Background(), []byte(arr), func(json.RawMessage) bool { count++; return true })
+	if count != 5001 {
+		t.Errorf("forEachArrayElement live: processed %d, want 5001", count)
+	}
+}

--- a/internal/search/near_duplicates.go
+++ b/internal/search/near_duplicates.go
@@ -150,7 +150,7 @@ func FindNearDuplicates(ctx context.Context, opts Options, registry *content.Reg
 	}
 
 	if len(candidates) >= 2 {
-		out.Groups = groupNearDuplicates(candidates, threshold)
+		out.Groups = groupNearDuplicates(ctx, candidates, threshold)
 		out.GroupCount = int64(len(out.Groups))
 		applyNearDupCaps(&out.Groups, opts.NearDupMembersLimit, opts.NearDupGroupLimit)
 	}
@@ -231,8 +231,13 @@ func fingerprintFromCacheOrCompute(path string, size int64, modTime time.Time, b
 //
 // O(N²) — fine for thousands of candidates. For larger trees an
 // LSH banding step would prune the pairwise space; out of scope
-// for v1.
-func groupNearDuplicates(candidates []nearDupCandidate, threshold float64) []NearDuplicateGroup {
+// for v1. The O(N²) pass runs AFTER the (cancellable) walk, so it
+// checks ctx once per outer iteration and bails with no groups on
+// cancellation — otherwise a timed-out / Ctrl-C'd call would still
+// grind through tens of millions of comparisons on a large candidate
+// set before returning. The caller stamps cancelled=true via
+// classifyCancellation when ctx is done.
+func groupNearDuplicates(ctx context.Context, candidates []nearDupCandidate, threshold float64) []NearDuplicateGroup {
 	parent := make([]int, len(candidates))
 	for i := range parent {
 		parent[i] = i
@@ -254,6 +259,9 @@ func groupNearDuplicates(candidates []nearDupCandidate, threshold float64) []Nea
 	// Pairwise compare. For each pair (i, j) with i < j, union when
 	// their fingerprints are within the threshold's Hamming distance.
 	for i := range candidates {
+		if ctx.Err() != nil {
+			return nil // cancelled mid-grouping — caller reports cancelled=true
+		}
 		fi := candidates[i].fingerprint
 		for j := i + 1; j < len(candidates); j++ {
 			fj := candidates[j].fingerprint

--- a/internal/search/neardup_cancel_test.go
+++ b/internal/search/neardup_cancel_test.go
@@ -1,0 +1,31 @@
+package search
+
+import (
+	"context"
+	"testing"
+)
+
+// TestGroupNearDuplicates_Cancellation verifies the O(n^2) grouping loop
+// honours context cancellation — a cancelled ctx returns no groups
+// instead of grinding through the full pairwise comparison set (the
+// ctx-cancellation audit gap).
+func TestGroupNearDuplicates_Cancellation(t *testing.T) {
+	// Two identical fingerprints would normally union into one group.
+	cands := []nearDupCandidate{
+		{path: "a", size: 100, fingerprint: 0xABCD},
+		{path: "b", size: 100, fingerprint: 0xABCD},
+		{path: "c", size: 100, fingerprint: 0xABCD},
+	}
+
+	// Sanity: live ctx groups them.
+	if got := groupNearDuplicates(context.Background(), cands, 0.85); len(got) != 1 {
+		t.Fatalf("live ctx: got %d groups, want 1", len(got))
+	}
+
+	// Cancelled ctx: bail with no groups.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := groupNearDuplicates(ctx, cands, 0.85); got != nil {
+		t.Errorf("cancelled ctx: got %d groups, want nil (bail on cancel)", len(got))
+	}
+}


### PR DESCRIPTION
## Context

Audited every `context.Context`-passing path with a loop in the call tree for cancellation correctness. The **hot paths are well-guarded** — `WalkStream` producer/workers, `FindMatches` per-line scan, `FindDuplicates`/`diff` hash loops, all the hand-rolled binary/container walkers (mp4/mkv/avi/pdf/office/epub/email/sqlite), `cryptohash` per-chunk, `embed` via `http.NewRequestWithContext`, `gitmeta` via `exec.CommandContext`, the bbolt writer goroutines, and MCP handlers (per-call timeout + ctx threaded into `search.*`).

Two long-running loops ignored ctx — both run unbounded work a timeout / Ctrl-C couldn't interrupt:

### 1. `groupNearDuplicates` O(N²) loop — `internal/search/near_duplicates.go`
The pairwise union-find runs **after** the cancellable walk with no ctx check. On a large candidate set (10k candidates ≈ 50M comparisons) a cancelled/timed-out `FindNearDuplicates` ground on to completion. Now takes `ctx` and bails (returns no groups) when cancelled — the caller already stamps `cancelled=true` via `classifyCancellation`.

### 2. Chat-export JSON iterators — `internal/content/chat_export.go`
`forEachArrayElement` / `forEachJSONValue` streamed every element of an in-memory Slack/Discord/Signal export with no ctx, so a multi-million-message export couldn't be cancelled mid-parse. Threaded `ctx` through the iterators + `parse{Slack,Discord,Signal}Export` + their `Attributes`/body callers; the iterators poll `ctx.Err()` every 1024 elements and stop on cancel.

## Tests
- `TestGroupNearDuplicates_Cancellation` — no groups under a cancelled ctx; 1 group under a live ctx.
- `TestChatIterators_Cancellation` — both iterators process 0 elements under a cancelled ctx, all under a live one.
- Updated chat-export unit + fuzz callers to pass a context.

`build` / `vet` / `go fix` / `golangci-lint` clean; full `go test ./...` passes; `content` + `search` pass under `-race`.

## Left as-is (lower-risk, by design)
- `gitmeta` log parsing loop — runs over **already-completed** subprocess output (the `git log` itself used `CommandContext`).
- `projecttype.ProjectResolver.Resolve` — shallow, per-dir-cached walk-up with no ctx param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)