### PR TITLE
feat(content): magic-conflict guard test + declarative offset-magic helper (#334)

### DIFF
--- a/.claude/skills/add-content-type/references/detection.md
+++ b/.claude/skills/add-content-type/references/detection.md
@@ -7,12 +7,12 @@ How `Registry.Detect` decides what a file is, what `Attributes(ctx, fsys, path)`
 The detector is in `internal/content/detector.go`. The algorithm:
 
 1. **Extension first.** Lower-case `filepath.Ext(path)` and check it against each registered type's `Extensions()` slice. First match wins.
-2. **Magic-byte fallback.** If no extension matched, read up to 512 bytes from the file. For each registered type, walk its `MagicBytes()` slice; if any entry is a prefix of the read bytes, that type wins.
+2. **Magic-byte fallback.** If no extension matched, read up to 512 bytes from the file. For each registered type, the detector calls `magicMatches(ct, head)`: if the type implements the optional **`MagicMatcher`** interface (`MatchMagic(head []byte) bool`), that decides; otherwise it falls back to a prefix check over `MagicBytes()`. First match wins.
 3. **No match → `nil`.** `BuildAttributes` treats this as "no content type"; the `content_type` CEL attribute is the empty string and every `is_*` flag is false.
 
 This means:
 
-- Registration order matters when multiple types claim the same extension or the same magic prefix. The detector returns the first match. In practice the existing types don't overlap, but if you register a type whose extensions or magic overlap an existing one, expect a flaky-feeling bug.
+- Registration order matters when multiple types claim the same extension or the same magic prefix. The detector returns the first match. **If two types share an overlapping magic prefix, BOTH must implement `MagicMatcher` to disambiguate** — otherwise detection is silently registration-order-dependent. `TestMagicConflicts` (`internal/content/magic_conflict_test.go`) fails the build if you register an overlapping magic without a matcher, so you'll find out at test time, not in the field (issue #334).
 - A type with `Extensions() = nil` and `MagicBytes() = nil` is unreachable. The detector will never return it.
 
 ## Worked example: detecting an EPUB
@@ -31,6 +31,7 @@ Pragmatic recommendation: start with extension-only. Add magic bytes when you ha
 - **First 512 bytes only.** Magic deeper into the file is invisible. PDFs (`%PDF-`) at byte 0 work; EPUB `mimetype` entries usually do, by spec.
 - **Prefix, not substring.** The detector checks `bytes.HasPrefix(read, magic)`. A magic of `"foo"` won't match a file that starts with `"\xef\xbb\xbffoo"` (BOM-prefixed). If you need BOM tolerance, register multiple magic entries: `[]byte("foo"), []byte("\xef\xbb\xbffoo")`.
 - **Avoid super-short or super-common prefixes.** `"{"` matches every JSON file but also every file that happens to start with `{`. JSON gets away with it because almost nothing else does. CSV has no usable magic — leave `MagicBytes` as `nil`.
+- **Shared-magic containers need a `MagicMatcher`.** Several formats share a leading magic and carry their real type at a fixed later offset — the RIFF family (`RIFF` then `WEBP`/`AVI `/`WAVE` at bytes 8..11) and the `ftyp`-at-offset-4 family (MP4 / HEIC / …). Set `MagicBytes()` to the shared prefix AND implement `MatchMagic` using `matchOffsetSigs(head, offsetSig{0, []byte("RIFF")}, offsetSig{8, []byte("WEBP")})` (see `internal/content/magic.go`). For structural disambiguation that isn't a fixed-offset pattern (e.g. fat Mach-O vs Java `.class`, both `0xCAFEBABE`), write a custom check like `isMachoFatHeader`. `TestMagicConflicts` enforces this.
 
 ## What `Attributes(ctx, fsys, path)` should and should not do
 

--- a/internal/content/audiotype.go
+++ b/internal/content/audiotype.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -36,14 +35,9 @@ func (a *audioType) MagicBytes() [][]byte { return a.magic }
 // back to the standard prefix match.
 func (a *audioType) MatchMagic(head []byte) bool {
 	if a.name == "audio/wav" {
-		return len(head) >= 12 && string(head[0:4]) == "RIFF" && string(head[8:12]) == "WAVE"
+		return matchOffsetSigs(head, offsetSig{0, []byte("RIFF")}, offsetSig{8, []byte("WAVE")})
 	}
-	for _, m := range a.magic {
-		if bytes.HasPrefix(head, m) {
-			return true
-		}
-	}
-	return false
+	return matchAnyPrefix(head, a.magic)
 }
 
 // Attributes reads audio tags via dhowden/tag. The library auto-detects the

--- a/internal/content/binarytype.go
+++ b/internal/content/binarytype.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io/fs"
@@ -46,15 +45,13 @@ func (b *binaryType) MagicBytes() [][]byte { return b.magic }
 // isn't expressible as a fixed byte prefix (issue #324). Other binary
 // types (ELF, PE) fall back to the standard prefix match.
 func (b *binaryType) MatchMagic(head []byte) bool {
+	// Fat Mach-O (0xCAFEBABE + nfat_arch + a known CPU type) is a
+	// STRUCTURAL check, not a fixed-offset byte pattern, so it can't use
+	// matchOffsetSigs — see isMachoFatHeader.
 	if b.name == "binary/mach-o" && isMachoFatHeader(head) {
 		return true
 	}
-	for _, m := range b.magic {
-		if bytes.HasPrefix(head, m) {
-			return true
-		}
-	}
-	return false
+	return matchAnyPrefix(head, b.magic)
 }
 
 // Attributes dispatches to a per-format binary parser. All parsers

--- a/internal/content/bytecodetype.go
+++ b/internal/content/bytecodetype.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io/fs"
@@ -47,14 +46,11 @@ func (b *bytecodeType) MagicBytes() [][]byte { return b.magic }
 // bytecode types fall back to the standard prefix match.
 func (b *bytecodeType) MatchMagic(head []byte) bool {
 	if b.name == "bytecode/jvm" {
-		return bytes.HasPrefix(head, []byte{0xCA, 0xFE, 0xBA, 0xBE}) && !isMachoFatHeader(head)
+		// Shares 0xCAFEBABE with fat Mach-O; claim it only when the
+		// bytes that follow are NOT a fat-Mach-O header (#324).
+		return matchAnyPrefix(head, b.magic) && !isMachoFatHeader(head)
 	}
-	for _, m := range b.magic {
-		if bytes.HasPrefix(head, m) {
-			return true
-		}
-	}
-	return false
+	return matchAnyPrefix(head, b.magic)
 }
 
 // Attributes dispatches to a per-format VM-bytecode parser. Each

--- a/internal/content/imagetype.go
+++ b/internal/content/imagetype.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"bytes"
 	"context"
 	"image"
 	_ "image/gif"
@@ -46,14 +45,9 @@ func (i *imageType) MagicBytes() [][]byte { return i.magic }
 // fall back to the standard prefix match.
 func (i *imageType) MatchMagic(head []byte) bool {
 	if i.name == "image/webp" {
-		return len(head) >= 12 && string(head[0:4]) == "RIFF" && string(head[8:12]) == "WEBP"
+		return matchOffsetSigs(head, offsetSig{0, []byte("RIFF")}, offsetSig{8, []byte("WEBP")})
 	}
-	for _, m := range i.magic {
-		if bytes.HasPrefix(head, m) {
-			return true
-		}
-	}
-	return false
+	return matchAnyPrefix(head, i.magic)
 }
 
 func (i *imageType) Attributes(ctx context.Context, fsys fs.FS, path string) (Attributes, error) {

--- a/internal/content/magic.go
+++ b/internal/content/magic.go
@@ -1,0 +1,45 @@
+package content
+
+import "bytes"
+
+// This file holds the shared helpers a ContentType's MagicMatcher
+// implementation uses to disambiguate formats that a plain byte-prefix
+// (MagicBytes) can't tell apart — most notably containers that share a
+// leading magic but carry their real form-type at a fixed later offset
+// (the RIFF family: WebP / AVI / WAV all start with "RIFF" but differ at
+// bytes 8..11). See the MagicMatcher interface in detector.go and the
+// conflict-guard test in magic_conflict_test.go. Issue #334.
+
+// offsetSig is a fixed byte pattern expected at a fixed offset in a
+// file's head. A WebP file, for example, is {0:"RIFF", 8:"WEBP"}.
+type offsetSig struct {
+	at   int
+	want []byte
+}
+
+// matchOffsetSigs reports whether head contains every signature at its
+// declared offset. Bounds-checked: a head shorter than any signature's
+// extent fails closed.
+func matchOffsetSigs(head []byte, sigs ...offsetSig) bool {
+	for _, s := range sigs {
+		if s.at+len(s.want) > len(head) {
+			return false
+		}
+		if !bytes.Equal(head[s.at:s.at+len(s.want)], s.want) {
+			return false
+		}
+	}
+	return true
+}
+
+// matchAnyPrefix is the default prefix match a MagicMatcher falls back
+// to for the formats in its family that aren't ambiguous — equivalent
+// to the detector's plain MagicBytes pass.
+func matchAnyPrefix(head []byte, magics [][]byte) bool {
+	for _, m := range magics {
+		if bytes.HasPrefix(head, m) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/content/magic_conflict_test.go
+++ b/internal/content/magic_conflict_test.go
@@ -1,0 +1,103 @@
+package content_test
+
+import (
+	"bytes"
+	"context"
+	"io/fs"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/content"
+)
+
+// magicMatcher mirrors the unexported content.MagicMatcher interface so
+// the test can tell which registered types disambiguate structurally.
+type magicMatcher interface {
+	MatchMagic(head []byte) bool
+}
+
+// magicConflicts returns a human-readable conflict for every pair of
+// types whose MagicBytes prefixes overlap (one is a prefix of the other,
+// so a single input could HasPrefix-match both) where at least one type
+// lacks a MagicMatcher — i.e. detection would be registration-order-
+// dependent. Issue #334.
+func magicConflicts(types []content.ContentType) []string {
+	overlaps := func(a, b [][]byte) bool {
+		for _, x := range a {
+			for _, y := range b {
+				if len(x) == 0 || len(y) == 0 {
+					continue
+				}
+				if bytes.HasPrefix(x, y) || bytes.HasPrefix(y, x) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	var out []string
+	for i := range types {
+		for j := i + 1; j < len(types); j++ {
+			a, b := types[i], types[j]
+			if len(a.MagicBytes()) == 0 || len(b.MagicBytes()) == 0 {
+				continue // extension-only types don't magic-sniff
+			}
+			if !overlaps(a.MagicBytes(), b.MagicBytes()) {
+				continue
+			}
+			_, aOK := a.(magicMatcher)
+			_, bOK := b.(magicMatcher)
+			if !aOK || !bOK {
+				out = append(out, a.Name()+" / "+b.Name())
+			}
+		}
+	}
+	return out
+}
+
+// TestMagicConflicts is the regression guard: the real registry must
+// have NO order-dependent magic conflicts. Catches the #322 class
+// (RIFF: WebP/AVI/WAV) if a future type claims an overlapping magic
+// without a MagicMatcher.
+func TestMagicConflicts(t *testing.T) {
+	if c := magicConflicts(content.DefaultRegistry().Types()); len(c) > 0 {
+		t.Errorf("registration-order-dependent magic conflicts (add a MagicMatcher to disambiguate, issue #334):\n  %v", c)
+	}
+}
+
+// fakeType is a minimal ContentType for exercising magicConflicts.
+type fakeType struct {
+	name  string
+	magic [][]byte
+}
+
+func (f fakeType) Name() string         { return f.name }
+func (f fakeType) Extensions() []string { return nil }
+func (f fakeType) MagicBytes() [][]byte { return f.magic }
+func (f fakeType) Attributes(context.Context, fs.FS, string) (content.Attributes, error) {
+	return nil, nil
+}
+
+type fakeMatcherType struct{ fakeType }
+
+func (f fakeMatcherType) MatchMagic([]byte) bool { return true }
+
+// TestMagicConflicts_Detects proves the guard fires: two "RIFF" types
+// where one lacks a MagicMatcher is a conflict; once both implement it,
+// it's clean.
+func TestMagicConflicts_Detects(t *testing.T) {
+	riff := [][]byte{[]byte("RIFF")}
+	unguarded := []content.ContentType{
+		fakeType{name: "a/webp", magic: riff},
+		fakeType{name: "a/wav", magic: riff},
+	}
+	if c := magicConflicts(unguarded); len(c) != 1 {
+		t.Errorf("want 1 conflict for two unguarded RIFF types, got %v", c)
+	}
+	guarded := []content.ContentType{
+		fakeMatcherType{fakeType{name: "a/webp", magic: riff}},
+		fakeMatcherType{fakeType{name: "a/wav", magic: riff}},
+	}
+	if c := magicConflicts(guarded); len(c) != 0 {
+		t.Errorf("two guarded RIFF types must not conflict, got %v", c)
+	}
+}

--- a/internal/content/magic_test.go
+++ b/internal/content/magic_test.go
@@ -1,0 +1,17 @@
+package content
+
+import "testing"
+
+func TestMatchOffsetSigs(t *testing.T) {
+	webp := append([]byte("RIFF\x00\x00\x00\x00WEBP"), []byte("VP8 ")...)
+	if !matchOffsetSigs(webp, offsetSig{0, []byte("RIFF")}, offsetSig{8, []byte("WEBP")}) {
+		t.Error("webp head should match RIFF+WEBP")
+	}
+	wav := append([]byte("RIFF\x00\x00\x00\x00WAVE"), []byte("fmt ")...)
+	if matchOffsetSigs(wav, offsetSig{0, []byte("RIFF")}, offsetSig{8, []byte("WEBP")}) {
+		t.Error("wav head must NOT match WEBP at offset 8")
+	}
+	if matchOffsetSigs([]byte("RIFF\x00"), offsetSig{8, []byte("WEBP")}) {
+		t.Error("short head must fail closed, not panic")
+	}
+}

--- a/internal/content/videotype.go
+++ b/internal/content/videotype.go
@@ -1,7 +1,6 @@
 package content
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -32,14 +31,9 @@ func (v *videoType) MagicBytes() [][]byte { return v.magic }
 // back to the standard prefix match.
 func (v *videoType) MatchMagic(head []byte) bool {
 	if v.name == "video/x-msvideo" {
-		return len(head) >= 12 && string(head[0:4]) == "RIFF" && string(head[8:12]) == "AVI "
+		return matchOffsetSigs(head, offsetSig{0, []byte("RIFF")}, offsetSig{8, []byte("AVI ")})
 	}
-	for _, m := range v.magic {
-		if bytes.HasPrefix(head, m) {
-			return true
-		}
-	}
-	return false
+	return matchAnyPrefix(head, v.magic)
 }
 
 // Attributes dispatches to a per-format binary parser. Each parser is


### PR DESCRIPTION
## Problem

Magic-byte detection is a byte-PREFIX match that returns the **first** registered type to match. So two types claiming an overlapping magic with no disambiguation is a silent, registration-order-dependent bug — the class behind #322 (WAV/WebP/AVI all start with `RIFF`). It's only caught when someone notices a `.wav` reported as `image/webp`.

## What this adds

- **Guard test** (`magic_conflict_test.go`): fails the build if any pair of registered types share an overlapping `MagicBytes` prefix and either lacks a `MagicMatcher`. Passes today — it **validates the #322 RIFF fixes hold**, and a synthetic sub-test proves it actually fires on an unguarded RIFF pair (and goes clean once both are guarded).
- **Declarative offset-magic helper** (`magic.go`): `offsetSig` + `matchOffsetSigs` for the common "shared prefix + form-type marker at a fixed later offset" shape (the RIFF family, and the future `ftyp`-at-offset-4 family). Migrated the WebP/AVI/WAV `MatchMagic` one-offs onto it and DRY'd the prefix fallbacks via `matchAnyPrefix`.
- Fat Mach-O vs Java `.class` (#324) stays a **structural** `isMachoFatHeader` check (not a fixed-offset byte pattern) — documented in code.
- Documented the `MagicMatcher` requirement + the guard test in the `add-content-type` detection reference, so the next content-type author can't reintroduce the class.

## Tests
`TestMatchOffsetSigs` (helper bounds/match/mismatch), `TestMagicConflicts` (real registry clean), `TestMagicConflicts_Detects` (guard fires on an unguarded overlap, clean once guarded).

`build` / `vet` / `go fix` / `golangci-lint` clean; full `go test ./...` passes.

Closes #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)