### PR TITLE
feat(pdf): use poppler pdftotext for body extraction when available (#333)

### DIFF
--- a/examples/pdf.md
+++ b/examples/pdf.md
@@ -45,6 +45,8 @@ file-search-on 'is_pdf' -d ~/Documents --sort-by mod_time --order desc --limit 2
 
 Pass `--body` (CLI) / `include_body: true` (MCP) and the `body` CEL variable carries the document text. The extractor walks every page in numeric order, decoding glyph-to-Unicode mappings against the page fonts. Page text is joined with a newline so `body.contains(...)` and `body.matches(...)` find content that spans pages.
 
+**Word spacing.** PDFs encode words as positioned glyph runs, not spaced text — the pure-Go path reconstructs word breaks from horizontal gaps, but `ledongthuc/pdf`'s geometry is often zeroed (justified LaTeX/arXiv output), so a few words can run together. **If [poppler](https://poppler.freedesktop.org/)'s `pdftotext` is on your `PATH`, it's used automatically** for materially better spacing and layout (and falls back to the pure-Go extractor when absent or on error — no hard dependency). `brew install poppler` / `apt install poppler-utils` to enable it.
+
 ```sh
 # Find every PDF mentioning a topic
 file-search-on 'is_pdf && body.contains("transformer architecture")' --body -d ~/Papers

--- a/internal/content/body_pdf.go
+++ b/internal/content/body_pdf.go
@@ -2,7 +2,10 @@ package content
 
 import (
 	"context"
+	"io"
 	"io/fs"
+	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 
@@ -14,6 +17,10 @@ import (
 // ToUnicode CMap. These are pure noise for body search — strip them
 // in one pass at the end of extraction.
 var pdfCIDPattern = regexp.MustCompile(`\(cid:\d+\)`)
+
+// defaultPDFBodyCap bounds the pdftotext output read when the caller
+// passes maxBytes <= 0 (1 MiB, matching the body-cache default).
+const defaultPDFBodyCap = 1 << 20
 
 // pdfSpaceGapRatio is the fraction of the font size above which a
 // horizontal gap between two text runs is treated as a word break.
@@ -98,6 +105,17 @@ func pdfBody(ctx context.Context, fsys fs.FS, filePath string, maxBytes int) (st
 	}
 	defer func() { _ = closer() }()
 
+	// Prefer poppler's pdftotext when it's on PATH — it reconstructs word
+	// spacing properly, which the pure-Go path below can only approximate
+	// from ledongthuc/pdf's (often zeroed) glyph geometry (issue #333).
+	// Any failure falls through to the pure-Go extractor, so this is a
+	// best-effort quality boost, never a hard dependency.
+	if bin := pdftotextBin(); bin != "" {
+		if s, ok := pdfBodyViaPdftotext(ctx, bin, ra, size, maxBytes); ok {
+			return s, nil
+		}
+	}
+
 	// pdf.NewReader can panic on malformed input despite returning
 	// an error in the documented path — the library uses panic for
 	// many internal parse failures. Wrap the entire extraction in
@@ -168,4 +186,56 @@ func pdfBody(ctx context.Context, fsys fs.FS, filePath string, maxBytes int) (st
 		return result, err
 	}
 	return result, nil
+}
+
+// pdftotextBin returns the path to poppler's pdftotext binary, or "" if
+// it isn't on PATH. Resolved per call (LookPath is cheap relative to PDF
+// parsing) so tests can inject a stub via PATH.
+func pdftotextBin() string {
+	p, _ := exec.LookPath("pdftotext")
+	return p
+}
+
+// pdfBodyViaPdftotext extracts text with poppler's pdftotext. pdftotext
+// needs a seekable file, so the PDF bytes are copied to a temp file
+// (works for archive entries / in-memory FSes too, where no OS path
+// exists). Output is read from a pipe bounded to maxBytes so a huge PDF
+// can't blow up memory. Returns ("", false) on ANY failure — missing
+// output, non-zero exit, copy error — so the caller falls back to the
+// pure-Go extractor. ctx cancels the subprocess via CommandContext.
+func pdfBodyViaPdftotext(ctx context.Context, bin string, ra io.ReaderAt, size int64, maxBytes int) (string, bool) {
+	tmp, err := os.CreateTemp("", "fso-pdf-*.pdf")
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := io.Copy(tmp, io.NewSectionReader(ra, 0, size)); err != nil {
+		_ = tmp.Close()
+		return "", false
+	}
+	if err := tmp.Close(); err != nil {
+		return "", false
+	}
+
+	// "-q" quiet, UTF-8 output, Unix EOLs; write text to stdout ("-").
+	cmd := exec.CommandContext(ctx, bin, "-q", "-enc", "UTF-8", "-eol", "unix", tmp.Name(), "-")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", false
+	}
+	if err := cmd.Start(); err != nil {
+		return "", false
+	}
+	limit := int64(maxBytes)
+	if limit <= 0 {
+		limit = defaultPDFBodyCap
+	}
+	data, _ := io.ReadAll(io.LimitReader(stdout, limit))
+	if err := cmd.Wait(); err != nil {
+		return "", false
+	}
+	if len(data) == 0 {
+		return "", false
+	}
+	return string(data), true
 }

--- a/internal/content/body_pdf_pdftotext_test.go
+++ b/internal/content/body_pdf_pdftotext_test.go
@@ -1,0 +1,65 @@
+package content
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestPDFBody_PdftotextShellout exercises the #333 shell-out path with a
+// stub `pdftotext` on PATH (so the test doesn't need real poppler): when
+// the binary is present, pdfBody copies the PDF bytes to a temp file,
+// runs it, and returns its stdout.
+func TestPDFBody_PdftotextShellout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub is POSIX")
+	}
+	bin := t.TempDir()
+	stub := filepath.Join(bin, "pdftotext")
+	// Ignores its args; emits known text to stdout. Proves wiring + capture.
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nprintf 'word one two three from pdftotext\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	dir := t.TempDir()
+	// pdfBody opens the file before shelling out; content is ignored by the stub.
+	if err := os.WriteFile(filepath.Join(dir, "x.pdf"), []byte("%PDF-1.4\n%%EOF\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body, err := pdfBody(context.Background(), os.DirFS(dir), "x.pdf", 0)
+	if err != nil {
+		t.Fatalf("pdfBody: %v", err)
+	}
+	if !strings.Contains(body, "word one two three from pdftotext") {
+		t.Errorf("expected pdftotext stub output, got %q", body)
+	}
+}
+
+// TestPDFBody_FallsBackWhenPdftotextFails verifies that a failing/exiting
+// pdftotext (non-zero exit) does NOT break extraction — pdfBody falls
+// through to the pure-Go path.
+func TestPDFBody_FallsBackWhenPdftotextFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub is POSIX")
+	}
+	bin := t.TempDir()
+	stub := filepath.Join(bin, "pdftotext")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Use the committed ReportLab fixture; the pure-Go fallback extracts it.
+	fsys := os.DirFS(filepath.Join("testdata", "fixtures"))
+	body, err := pdfBody(context.Background(), fsys, "sample.pdf", 1<<20)
+	if err != nil {
+		t.Fatalf("pdfBody: %v", err)
+	}
+	if !strings.Contains(body, "content-type test suite") {
+		t.Errorf("fallback path should still extract the fixture body, got %q", body[:min(120, len(body))])
+	}
+}


### PR DESCRIPTION
## Problem

The pure-Go PDF path (#323) reconstructs word spacing heuristically from `ledongthuc/pdf`'s glyph geometry — which is often **zeroed** for justified LaTeX/arXiv PDFs, so some words still run together ("Y oshua") and phrase search misses them.

## Fix

When poppler's **`pdftotext`** is on `PATH`, `pdfBody` uses it: the PDF bytes are copied to a temp file (works for archive entries / in-memory FSes too, where no OS path exists), `pdftotext -q -enc UTF-8 -eol unix <tmp> -` runs via `exec.CommandContext` (ctx-cancellable), and stdout is read through a `maxBytes`-bounded pipe.

**ANY failure** — binary absent, non-zero exit, copy error, empty output — falls through to the existing pure-Go extractor. So it's a best-effort quality boost, **never a hard dependency**. `LookPath` is resolved per call, so a deployment that installs poppler later picks it up with no rebuild.

## Tests
- A **stub `pdftotext`** on `PATH` proves the shell-out wiring + temp-file + stdout capture — no real poppler needed in CI.
- A **failing stub** proves the fall-through still extracts the committed ReportLab fixture.
- Deterministic regardless of whether CI has poppler (the tests control `PATH`).

`build` / `vet` / `go fix` / `golangci-lint` clean; full `go test ./...` passes; content `-race` clean. `examples/pdf.md` documents the optional dependency (`brew install poppler` / `apt install poppler-utils`).

Closes #333.

🤖 Generated with [Claude Code](https://claude.com/claude-code)