### PR TITLE
feat(semantic): chunk bodies and score by max-sim so deep passages rank (#332)

### DIFF
--- a/examples/semantic-search.md
+++ b/examples/semantic-search.md
@@ -86,9 +86,11 @@ Per-call `model` / `embedding_server` inputs override the startup defaults. If n
 1. The query is embedded ONCE per call (one Ollama round-trip).
 2. The walker visits each file matching the CEL pre-filter.
 3. For each file:
-   - **Cache hit** (`index.Entry.Vector` populated and `(size, mtime)` validates) — just compute the cosine, no Ollama call.
-   - **Cache miss** — extract the body (via the existing body cache from PR #142), embed via Ollama, L2-normalise, store the vector, compute the cosine.
+   - **Cache hit** (`index.Entry.ChunkVectors` populated and `(size, mtime)` validates) — just compute the max cosine over the cached chunks, no Ollama call.
+   - **Cache miss** — extract the body (via the existing body cache from PR #142), split it into overlapping chunks, embed each via Ollama, L2-normalise, store the chunk vectors, compute the max cosine.
 4. Results sort by `similarity` desc and apply the threshold filter.
+
+**Whole-document coverage (#332).** Long documents are split into overlapping ~8 KiB chunks (up to 64 per file, ≈512 KiB of covered text) and each chunk is embedded separately. A file's `similarity` is the **maximum** cosine across its chunks, so a relevant passage buried deep in a book-length document still ranks — earlier versions embedded only the opening and missed deep matches. Caches written before #332 hold a single opening-only `Vector`; they're treated as a miss and re-embedded into chunk vectors on the next semantic walk under the same model.
 
 The vector cache is the headline perf win: repeat queries against an unchanged tree avoid ~50-200ms per file of Ollama-call latency. `index_stats` surfaces `embed_hits` / `embed_misses` so you can audit the hit rate.
 
@@ -166,6 +168,5 @@ Note: image files only have semantic-search-friendly content when they carry tex
 - **Bundled embedding model** — too heavy (600 MB+). Ollama lets the user pick.
 - **HNSW / FAISS indexes** — brute-force pairwise cosine is fast enough for tens of thousands of files. File a follow-up if you hit a scale where it isn't.
 - **Cross-encoder reranking** — bi-encoder (single-embedding) is enough for v1.
-- **Per-chunk embeddings for long documents** — v1 embeds the first ~1 MiB of body (the same cap as the body cache). Long-doc retrieval with chunked vectors is a follow-up.
 - **OpenAI / llama.cpp / other embedding sources** — same wire shape; future plugin point. v1 is Ollama-only.
 - **Query expansion / synonym handling** — embeddings already handle paraphrase implicitly.

--- a/internal/celexpr/body.go
+++ b/internal/celexpr/body.go
@@ -110,20 +110,19 @@ func populateSimilarity(ctx context.Context, fsys fs.FS, fsPath, displayPath, ca
 
 	currentModel := opts.Embedder.Model()
 
-	// Cache hit path — three sub-cases:
-	//
-	//   1. Vector + EmbedModel match the current model → reuse, Dot
-	//      gives cosine (both pre-normalised). "hit".
-	//   2. Vector present but EmbedModel differs (or is empty —
-	//      pre-#154 provenance) → bump "model_mismatch" and fall
-	//      through to re-embed. We can't trust the cached vector
-	//      because dimensions and/or coordinate systems differ across
-	//      models; computing a dot product would return either 0
-	//      (length mismatch) or nonsense (same dim, different model).
-	//   3. Vector empty → bump "miss" below in the re-embed path.
-	if cached != nil && len(cached.Vector) > 0 {
+	// Cache hit path. A document is scored by the MAX cosine over its
+	// chunk vectors (issue #332), so a passage deep in a long document
+	// still ranks. Sub-cases:
+	//   1. ChunkVectors + EmbedModel match the current model → reuse,
+	//      similarity = max chunk Dot (all pre-normalised). "hit".
+	//   2. ChunkVectors present but EmbedModel differs → "model_mismatch"
+	//      + re-embed (dimensions / coordinate systems differ across
+	//      models, so a Dot would be 0 or nonsense).
+	//   3. No ChunkVectors (incl. a legacy single Vector from before
+	//      #332) → "miss" below in the re-embed path.
+	if cached != nil && len(cached.ChunkVectors) > 0 {
 		if cached.EmbedModel == currentModel && currentModel != "" {
-			attrs.Similarity = embed.Dot(opts.SemanticQueryEmbedding, cached.Vector)
+			attrs.Similarity = maxChunkSimilarity(opts.SemanticQueryEmbedding, cached.ChunkVectors)
 			if opts.Index != nil {
 				opts.Index.BumpEmbedStat("hit")
 			}
@@ -139,48 +138,37 @@ func populateSimilarity(ctx context.Context, fsys fs.FS, fsPath, displayPath, ca
 	// so we share the body cache with anything else asking for it in
 	// this walk. Empty body → no signal → leave Similarity at 0.
 	body, err := readBody(ctx, fsys, fsPath, attrs.Path, attrs.ContentType, opts.BodyMaxBytes)
+	missEligible := cached == nil || len(cached.ChunkVectors) == 0
 	if err != nil || body == "" {
-		if opts.Index != nil && (cached == nil || len(cached.Vector) == 0) {
-			// Pure cache-miss (no Vector at all). When we got here
-			// via model_mismatch we've already bumped that counter
-			// and shouldn't also bump "miss".
+		if opts.Index != nil && missEligible {
+			// Pure cache-miss. When we got here via model_mismatch we've
+			// already bumped that counter and shouldn't also bump "miss".
 			opts.Index.BumpEmbedStat("miss")
 		}
 		return
 	}
-	if opts.Index != nil && (cached == nil || len(cached.Vector) == 0) {
+	if opts.Index != nil && missEligible {
 		opts.Index.BumpEmbedStat("miss")
 	}
-	// Cap the text handed to the embedder. Embedding models truncate to
-	// their context window anyway, and some Ollama model/version combos
-	// reject over-long input with an HTTP error (which would surface as
-	// a silent "0 results") — see issue #305.
-	body = truncateForEmbed(body, opts.EmbedInputMaxBytes)
-	vec, err := opts.Embedder.Embed(ctx, body)
-	if err != nil && ctx.Err() == nil {
-		// Some models reject inputs whose TOKEN count exceeds their hard
-		// limit even after the byte cap — CJK / dense text packs far more
-		// tokens per byte than English prose. Retry once at a small,
-		// conservative size before giving up so a handful of multibyte
-		// documents don't silently drop out of the results (#305).
-		if retry := truncateForEmbed(body, embedRetryMaxBytes); len(retry) < len(body) {
-			vec, err = opts.Embedder.Embed(ctx, retry)
-		}
-	}
-	if err != nil || len(vec) == 0 {
+
+	// Chunk the body into context-window-sized windows and embed each,
+	// so the whole document is covered rather than just the opening
+	// (issue #332). Per-chunk size is the embed cap (#305); embedChunks
+	// applies the same oversized-input retry per chunk.
+	chunks := chunkForEmbed(body, opts.EmbedInputMaxBytes)
+	vecs := embedChunks(ctx, opts.Embedder, chunks)
+	if len(vecs) == 0 {
 		if opts.Index != nil {
 			opts.Index.BumpEmbedStat("error")
 		}
 		return
 	}
-	embed.Normalize(vec)
-	attrs.Similarity = embed.Dot(opts.SemanticQueryEmbedding, vec)
+	attrs.Similarity = maxChunkSimilarity(opts.SemanticQueryEmbedding, vecs)
 
-	// Write the freshly-computed vector back to the cache so the
-	// next walk against the same (size, mtime, model) skips the
-	// Embedder call. Stamp EmbedModel so future calls with a
-	// different model surface as model_mismatch instead of silently
-	// returning wrong scores.
+	// Write the freshly-computed chunk vectors back to the cache so the
+	// next walk against the same (size, mtime, model) skips the Embedder
+	// calls. Stamp EmbedModel so a different model surfaces as
+	// model_mismatch instead of silently returning wrong scores.
 	if opts.Index != nil && cacheKey != "" {
 		entry := cached
 		if entry == nil {
@@ -190,11 +178,87 @@ func populateSimilarity(ctx context.Context, fsys fs.FS, fsPath, displayPath, ca
 				ContentType:     attrs.ContentType,
 			}
 		}
-		entry.Vector = vec
+		entry.ChunkVectors = vecs
+		entry.Vector = nil // superseded by ChunkVectors (#332)
 		entry.EmbedModel = currentModel
 		_ = opts.Index.Put(cacheKey, entry)
 		opts.Index.BumpEmbedStat("put")
 	}
+}
+
+// defaultEmbedMaxChunks caps how many chunks a single document is split
+// into for embedding, bounding the per-file embed cost on very long
+// inputs. 64 chunks × the 8 KiB default chunk size ≈ 512 KiB of covered
+// text — a full book's worth — while keeping a hard ceiling on Ollama
+// calls per file.
+const defaultEmbedMaxChunks = 64
+
+// chunkForEmbed splits text into overlapping, rune-safe windows of
+// chunkBytes (0 → defaultEmbedInputMaxBytes), capped at
+// defaultEmbedMaxChunks. The overlap (1/8 of a chunk) keeps a phrase
+// that straddles a boundary intact in at least one chunk. Short text
+// returns a single chunk.
+func chunkForEmbed(text string, chunkBytes int) []string {
+	if chunkBytes <= 0 {
+		chunkBytes = defaultEmbedInputMaxBytes
+	}
+	if len(text) <= chunkBytes {
+		return []string{text}
+	}
+	overlap := chunkBytes / 8
+	step := chunkBytes - overlap
+	out := make([]string, 0, len(text)/step+1)
+	for start := 0; start < len(text) && len(out) < defaultEmbedMaxChunks; start += step {
+		end := min(start+chunkBytes, len(text))
+		// Back the cut off a rune boundary so we never split a multibyte char.
+		for end < len(text) && !utf8.RuneStart(text[end]) {
+			end++
+		}
+		out = append(out, text[start:end])
+		if end >= len(text) {
+			break
+		}
+	}
+	return out
+}
+
+// embedChunks embeds each chunk and returns the L2-normalised vectors of
+// the chunks that succeeded. A chunk that errors (after the #305
+// smaller-input retry) is skipped rather than failing the whole
+// document. Honours ctx between chunks (#321 audit): a cancelled walk
+// stops and returns what it has.
+func embedChunks(ctx context.Context, embedder embed.Embedder, chunks []string) [][]float32 {
+	vecs := make([][]float32, 0, len(chunks))
+	for _, c := range chunks {
+		if ctx.Err() != nil {
+			break
+		}
+		vec, err := embedder.Embed(ctx, c)
+		if err != nil && ctx.Err() == nil {
+			if retry := truncateForEmbed(c, embedRetryMaxBytes); len(retry) < len(c) {
+				vec, err = embedder.Embed(ctx, retry)
+			}
+		}
+		if err != nil || len(vec) == 0 {
+			continue // skip this chunk; others still contribute
+		}
+		embed.Normalize(vec)
+		vecs = append(vecs, vec)
+	}
+	return vecs
+}
+
+// maxChunkSimilarity returns the highest cosine between the pre-normalised
+// query and any chunk vector (issue #332). 0 when there are no chunks.
+func maxChunkSimilarity(query []float32, chunks [][]float32) float64 {
+	best := 0.0
+	for i, v := range chunks {
+		s := embed.Dot(query, v)
+		if i == 0 || s > best {
+			best = s
+		}
+	}
+	return best
 }
 
 // embedRetryMaxBytes is the conservative fallback size used when an

--- a/internal/celexpr/similarity_test.go
+++ b/internal/celexpr/similarity_test.go
@@ -229,8 +229,9 @@ func TestBuildAttributesWith_Similarity_ModelMismatch(t *testing.T) {
 
 // TestBuildAttributesWith_Similarity_PreV154EntryRejected exercises
 // the upgrade path: an Entry that pre-dates #154 has Vector populated
-// but EmbedModel="". We must NOT trust such a vector (we don't know
-// what produced it) — treat it as a model mismatch and re-embed.
+// but EmbedModel="". We must NOT trust such a vector. Post-#332 the live
+// pipeline reads ChunkVectors, so a legacy single-Vector entry (no
+// ChunkVectors) is simply a miss → re-embed into chunk vectors.
 func TestBuildAttributesWith_Similarity_PreV154EntryRejected(t *testing.T) {
 	ctx := t.Context()
 	dir := t.TempDir()
@@ -278,14 +279,18 @@ func TestBuildAttributesWith_Similarity_PreV154EntryRejected(t *testing.T) {
 		t.Fatalf("BuildAttributesWith: %v", err)
 	}
 	st := idx.Stats()
-	if st.EmbedModelMismatches != 1 {
-		t.Errorf("EmbedModelMismatches=%d want 1 (pre-#154 vector should be rejected); stats=%+v", st.EmbedModelMismatches, st)
+	if st.EmbedHits != 0 {
+		t.Errorf("EmbedHits=%d want 0 (must not trust a legacy single Vector); stats=%+v", st.EmbedHits, st)
+	}
+	if st.EmbedMisses != 1 {
+		t.Errorf("EmbedMisses=%d want 1 (legacy Vector has no ChunkVectors → re-embed); stats=%+v", st.EmbedMisses, st)
 	}
 	if calls != 1 {
 		t.Errorf("Ollama calls=%d want 1 (re-embed under the new model)", calls)
 	}
-	if st.EmbedHits != 0 {
-		t.Errorf("EmbedHits=%d want 0 (must not trust empty-EmbedModel vector); stats=%+v", st.EmbedHits, st)
+	// The entry must now carry chunk vectors stamped with the model.
+	if e, ok := idx.PeekAttrs(cacheKey); !ok || len(e.ChunkVectors) == 0 || e.EmbedModel != "mock" {
+		t.Errorf("legacy entry not re-embedded into ChunkVectors; ok=%v entry=%+v", ok, e)
 	}
 }
 
@@ -585,8 +590,8 @@ func TestBuildAttributesWith_Similarity_MissPathRetainsExtra(t *testing.T) {
 	if !ok {
 		t.Fatalf("no cached entry for %s after walk 1", abs)
 	}
-	if len(e.Vector) == 0 {
-		t.Errorf("cached entry missing Vector after walk 1; entry=%+v", e)
+	if len(e.ChunkVectors) == 0 {
+		t.Errorf("cached entry missing ChunkVectors after walk 1; entry=%+v", e)
 	}
 	if e.Extra == nil || e.Extra["word_count"] == nil {
 		t.Errorf("cached entry lost Extra (clobber bug): Extra=%v", e.Extra)
@@ -693,7 +698,7 @@ func TestBuildAttributesWith_Similarity_NonSemanticPreservesVector(t *testing.T)
 		t.Fatalf("non-semantic walk: %v", err)
 	}
 	// Vector must survive the non-semantic walk.
-	if e, ok := idx.PeekAttrs(abs); !ok || len(e.Vector) == 0 {
+	if e, ok := idx.PeekAttrs(abs); !ok || len(e.ChunkVectors) == 0 {
 		t.Fatalf("non-semantic walk wiped the cached vector; ok=%v entry=%+v", ok, e)
 	}
 	// Third walk: semantic again, must hit (no new Ollama call).
@@ -702,5 +707,75 @@ func TestBuildAttributesWith_Similarity_NonSemanticPreservesVector(t *testing.T)
 	}
 	if calls != 1 {
 		t.Errorf("expected 1 Ollama call; vector should have survived the non-semantic walk, got %d", calls)
+	}
+}
+
+// TestBuildAttributesWith_Similarity_DeepPassageViaChunks is the core
+// #332 regression: a document whose relevant passage is buried far past
+// the single-chunk embed cap must still score high, because the body is
+// split into chunks and scored by MAX cosine. Before #332 only the
+// opening ~8 KiB was embedded, so a match deep in a long document
+// returned ~0 and the file was missed.
+func TestBuildAttributesWith_Similarity_DeepPassageViaChunks(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "long.md")
+
+	// Build a body far larger than the (small) chunk cap below, with the
+	// target phrase buried near the end so it lands in a late chunk.
+	const marker = "quantum entanglement teleportation protocol"
+	filler := strings.Repeat("the quick brown fox jumps over the lazy dog. ", 400)
+	body := filler + "\n\n" + marker + "\n\n" + filler
+	mustWrite(t, path, body)
+
+	abs, _ := filepath.Abs(path)
+	base := filepath.Base(abs)
+	parent := filepath.Dir(abs)
+
+	// Mock Ollama: a chunk containing the marker embeds as [1,0,0]
+	// (aligned with the query); every other chunk embeds as [0,1,0]
+	// (orthogonal). The request carries {"input": "<chunk text>"}.
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var req struct {
+			Input string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		vec := []float32{0, 1, 0}
+		if strings.Contains(req.Input, marker) {
+			vec = []float32{1, 0, 0}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"embeddings": [][]float32{vec},
+		})
+	}))
+	defer srv.Close()
+
+	idx := index.NewMemory()
+	defer func() { _ = idx.Close() }()
+
+	embedder := embed.NewOllama(srv.URL, "mock")
+	a, err := celexpr.BuildAttributesWith(ctx, os.DirFS(parent), base, abs, content.DefaultRegistry(), celexpr.BuildOptions{
+		Index:                  idx,
+		Embedder:               embedder,
+		SemanticQueryEmbedding: []float32{1, 0, 0},
+		EmbedInputMaxBytes:     512, // force many chunks
+	})
+	if err != nil {
+		t.Fatalf("BuildAttributesWith: %v", err)
+	}
+
+	// Max-sim must surface the deep marker chunk.
+	if a.Similarity < 0.99 {
+		t.Errorf("Similarity=%f want ~1.0 (deep marker chunk should dominate via max-sim)", a.Similarity)
+	}
+	// The body must have been split into more than one chunk (else this
+	// test would pass even without chunking).
+	if calls < 2 {
+		t.Errorf("Ollama calls=%d want >1 (body should be chunked)", calls)
+	}
+	if e, ok := idx.PeekAttrs(abs); !ok || len(e.ChunkVectors) < 2 {
+		t.Errorf("cached entry should hold multiple chunk vectors; ok=%v nChunks=%d", ok, len(e.ChunkVectors))
 	}
 }

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -75,9 +75,19 @@ type Entry struct {
 	// pre-#151 entries decode with empty Vector and the next
 	// semantic walk repopulates them.
 	Vector []float32
-	// EmbedModel is the model name that produced Vector. Empty when
-	// Vector is empty OR when the vector came from a pre-#154 cache
-	// entry (in which case populateSimilarity treats it as a
+	// ChunkVectors holds one L2-normalised embedding per body chunk
+	// (issue #332). Whole-document semantic search embeds the body in
+	// context-window-sized chunks and scores a document by the MAX
+	// cosine over its chunks, so a relevant passage deep in a long
+	// document still ranks — the single Vector above only ever covered
+	// the opening (the #305 cap). ChunkVectors supersedes Vector: the
+	// live pipeline reads ChunkVectors and treats a legacy single
+	// Vector (no ChunkVectors) as "not chunked yet" → re-embed.
+	// gob-additive.
+	ChunkVectors [][]float32
+	// EmbedModel is the model name that produced Vector / ChunkVectors.
+	// Empty when none are set OR when the vector came from a pre-#154
+	// cache entry (in which case populateSimilarity treats it as a
 	// mismatch and re-embeds — we never trust a vector of unknown
 	// provenance). gob-additive.
 	EmbedModel string


### PR DESCRIPTION
## Summary

Closes #332. Semantic search previously embedded only the **opening ~8 KiB** of a body into a single `Vector`, so a relevant passage buried deep in a book-length document scored ~0 and the file was missed entirely. This splits the body into overlapping chunks, embeds each, and scores the file by the **maximum** cosine across its chunks.

- **Chunking** — overlapping ~8 KiB windows (overlap = `chunkBytes/8`, rune-safe cuts), capped at 64 chunks ≈ 512 KiB of covered text (a full book's worth) to bound per-file Ollama calls.
- **Max-sim scoring** — a file's `similarity` is the highest cosine over its chunk vectors, so the best-matching passage drives the rank regardless of where it sits in the document.
- **Schema bump** — `index.Entry` gains `ChunkVectors [][]float32` (gob-additive). It supersedes the single `Vector`: the live pipeline reads `ChunkVectors` and treats a legacy `Vector`-only entry (written before this PR) as a cache miss → re-embed under the current model. No manual rebuild, no silently-wrong scores.
- **Resilience** — `embedChunks` honours `ctx` between chunks (per the recent cancellation audit) and skips a chunk that fails to embed (after the #305 smaller-input retry) rather than dropping the whole document.

## Decisions (confirmed up front)

- **Per-chunk max-sim** over averaging — a single strong passage shouldn't be diluted by the rest of a long document.
- **Chunk by default** — accepts a one-time re-embed when upgrading past a legacy `Vector`-only cache; consistent with the prior `V2→V3` field-versioning precedent.

## Testing

- New `TestBuildAttributesWith_Similarity_DeepPassageViaChunks`: a marker phrase buried past the chunk cap still scores ~1.0 via max-sim, and the cache holds multiple chunk vectors.
- Updated `PreV154EntryRejected` / `MissPathRetainsExtra` / `NonSemanticPreservesVector` for the `ChunkVectors` schema.
- `go test ./...`, `-race` on `celexpr`/`index`, `go vet`, `go fix` (idempotent), `golangci-lint run` — all clean.
- `examples/semantic-search.md` documents whole-document coverage and drops the stale "follow-up" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)