### PR TITLE
feat(mcp): cursor-based pagination for search + search_semantic (#336)

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,8 +452,8 @@ Twenty tools are exposed, grouped by family:
 
 | Tool | What it does |
 | --- | --- |
-| `search` | CEL expression over a directory tree. Supports `sort_by` / `limit` (top-K), `rank` (custom CEL sort key), `include_body` (full body filter), `include_snippet` (preview), `ocr_images` (run OCR before evaluating), `with_phash` (perceptual hash + `image_similar_to` function), `compute_hashes`, `check_disguised`, `with_xattrs`, `resolve_projects`, `prune_build_artefacts`, `fields` (token-saving projection — path / content_type / size always-on). Returns matches with the full attribute set + partial-result fields. |
-| `search_semantic` | Natural-language similarity search via local Ollama embeddings. Pre-prunes with an optional `expr`, embeds the query, ranks files by cosine similarity, applies a `threshold` cap. Embeddings cache per file. |
+| `search` | CEL expression over a directory tree. Supports `sort_by` / `limit` (top-K), `rank` (custom CEL sort key), `cursor` / `next_cursor` (stable keyset pagination — page a large match set in bounded chunks), `include_body` (full body filter), `include_snippet` (preview), `ocr_images` (run OCR before evaluating), `with_phash` (perceptual hash + `image_similar_to` function), `compute_hashes`, `check_disguised`, `with_xattrs`, `resolve_projects`, `prune_build_artefacts`, `fields` (token-saving projection — path / content_type / size always-on). Returns matches with the full attribute set + partial-result fields. |
+| `search_semantic` | Natural-language similarity search via local Ollama embeddings. Pre-prunes with an optional `expr`, embeds the query, ranks files by cosine similarity, applies a `threshold` cap, and supports `cursor` / `next_cursor` pagination. Embeddings cache per file. |
 | `read_attributes` | Attributes for a single path — same shape as one `search` match. Accepts `fields` for token-saving projection. |
 | `read_lines` | A specific line range of a file — pairs with `search` for context around matches. |
 
@@ -499,6 +499,8 @@ Twenty tools are exposed, grouped by family:
 | `monitor_info` | This server's monitoring-dashboard URL + the registry of sibling instances. Pass `enable: true` to start the dashboard on demand if it isn't already running. |
 
 Every walking tool (`search`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `find_projects`, `diff_trees`) honours the same partial-result contract: on timeout the call returns `cancelled=true` with the results gathered so far, never an error. Agents inspect the flag rather than catching exceptions.
+
+**Pagination.** `search` and `search_semantic` support stateless **cursor pagination** for large result sets. Pass `limit` to cap a page; when the set is truncated the response carries an opaque `next_cursor`. Pass it back as `cursor` (with the *same* `sort_by` / `order` / `rank` / `query`) to fetch the next page. The cursor is a keyset over the sort key + path, so paging is stable under an unchanged tree and survives a server restart — there's no server-side cached result set. Each page re-walks the tree, but attribute extraction is index-cached, so re-walks are cheap. An agent can stream a 10k-match set in bounded pages without blowing its context or losing the tail to a hard `limit`.
 
 Since v0.64.0 the on-disk index is **on by default**. The MCP server (like every other long-running subcommand) auto-creates a per-cwd bbolt cache at `<UserCacheDir>/file-search-on/indexes/<basename>-<sha1[:6]>.db` — repeated `search` / `read_attributes` calls against unchanged files skip parsing entirely. The default path is per-cwd so concurrent agents in different projects never collide; same-cwd contention falls back gracefully to in-memory (logged on stderr, surfaced on the dashboard as `index_fallback_reason: "lock_contention"`). Override with `--index-path`; opt out with `--no-index` for hermetic CI runs:
 

--- a/internal/mcpserver/search_semantic_tool.go
+++ b/internal/mcpserver/search_semantic_tool.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -24,7 +23,8 @@ type SearchSemanticInput struct {
 	Dirs            []string `json:"dirs,omitempty" jsonschema:"Multiple directories to search in one call. When non-empty, takes precedence over 'dir'."`
 	Expr            string   `json:"expr,omitempty" jsonschema:"Optional CEL pre-filter using the regular search vocabulary (is_pdf, is_office, etc.). When set, the threshold is AND-combined: only files matching the CEL filter AND with similarity >= threshold are returned."`
 	Threshold       float64  `json:"threshold,omitempty" jsonschema:"Minimum cosine similarity (0..1) for a match. Default 0.5. Higher = stricter. 0.7 is a useful tightness for 'definitely about this topic'; 0.4-0.5 catches related-but-tangential content. Implemented by AND-ing 'similarity >= <value>' onto the expr filter, so it combines with (does not replace) any similarity comparison in your expr."`
-	Limit           int      `json:"limit,omitempty" jsonschema:"Cap on returned matches (top-K ranked by similarity desc). Default 50."`
+	Limit           int      `json:"limit,omitempty" jsonschema:"Cap on returned matches (top-K ranked by similarity desc). Default 50. When the ranked set is truncated by limit, the response carries an opaque next_cursor — pass it back as 'cursor' to fetch the next page."`
+	Cursor          string   `json:"cursor,omitempty" jsonschema:"Opaque pagination token from a previous response's next_cursor. Resumes the similarity-ranked result set immediately after the last item of the prior page. Re-embeds the query and re-walks each page (file vectors are cached, so the re-walk is cheap); paging is stable under an unchanged tree. Use the SAME query/threshold for consistent paging."`
 	Model           string   `json:"model,omitempty" jsonschema:"Override the server's default embedding model for this call (e.g. nomic-embed-text, mxbai-embed-large). When the server has no default and this is empty, the call returns 'no embedding model configured'."`
 	EmbeddingServer string   `json:"embedding_server,omitempty" jsonschema:"Override the server's default Ollama base URL for this call (e.g. http://gpu-box:11434). Defaults to the server-startup setting or http://localhost:11434."`
 	Excludes        []string `json:"excludes,omitempty" jsonschema:"Glob patterns matched against the basename of each file/directory; matched directories are pruned. Same semantics as the search tool."`
@@ -45,6 +45,10 @@ type SearchSemanticOutput struct {
 	CommonOutput
 	Matches            []search.Match `json:"matches"`
 	Count              int            `json:"count"`
+	// NextCursor is an opaque token, present only when the ranked set was
+	// truncated by Limit and more matches remain. Pass it back as the
+	// 'cursor' input to fetch the next page. Empty means last page. #336.
+	NextCursor         string         `json:"next_cursor,omitempty"`
 	ElapsedSeconds     float64        `json:"elapsed_seconds"`
 	EmbeddingModel     string         `json:"embedding_model"`
 	SimilarityThreshold float64       `json:"similarity_threshold"`
@@ -188,29 +192,28 @@ func (h *handlers) searchSemanticHandler(ctx context.Context, req *mcp.CallToolR
 		return nil, SearchSemanticOutput{}, fmt.Errorf("walk: %w", walkErr)
 	}
 
-	// Sort by similarity desc + apply limit. SortAndLimit handles the
-	// case where results have a mix of zero similarities (binary content
-	// that skipped the embedding) by grouping them at the end — the
-	// threshold filter above already excluded them in normal use, so
-	// the bottom of the list is sparse only on edge cases.
-	results = search.SortAndLimit(results, search.Options{
-		Sort:  "similarity",
-		Order: "desc",
-		Limit: limit,
-	})
+	// Rank by similarity desc, resume past the cursor, cap to limit, and
+	// emit next_cursor when more remain. PaginateResults sorts in a
+	// stable total order (similarity desc, path asc tiebreak) so paging
+	// is consistent across calls — that path tiebreak is also why we no
+	// longer need the old defensive re-sort. Files with zero similarity
+	// (binary content that skipped embedding) group at the end; the
+	// threshold filter above already excludes them in normal use.
+	page, nextCursor, perr := search.PaginateResults(results, "similarity", "desc", in.Cursor, limit)
+	if perr != nil {
+		return nil, SearchSemanticOutput{}, fmt.Errorf("cursor: %w", perr)
+	}
+	results = page
 
 	matches := make([]search.Match, len(results))
 	for i, r := range results {
 		matches[i] = search.MatchFrom(r)
 	}
-	// Re-sort by similarity to defend against any future shuffling
-	// inside SortAndLimit (defensive — Sort=="similarity" already does
-	// the right thing today).
-	sort.SliceStable(matches, func(i, j int) bool { return matches[i].Similarity > matches[j].Similarity })
 
 	output := SearchSemanticOutput{
 		Matches:             matches,
 		Count:               len(matches),
+		NextCursor:          nextCursor,
 		ElapsedSeconds:      elapsed,
 		EmbeddingModel:      model,
 		SimilarityThreshold: threshold,

--- a/internal/mcpserver/search_tool.go
+++ b/internal/mcpserver/search_tool.go
@@ -27,7 +27,8 @@ type SearchInput struct {
 	SortBy           string   `json:"sort_by,omitempty" jsonschema:"Sort matches by attribute. Recognised keys: size, name, path, mod_time, word_count, line_count, page_count, duration, bitrate, sample_rate, video_height, video_width, frame_rate, iso, focal_length, taken_at, sent_at, year, entry_count, uncompressed_size, loc, attachment_count, email_count. Files missing the attribute group at the end. Sorting buffers the full result set (top-K is incoherent with streaming)."`
 	Order            string   `json:"order,omitempty" jsonschema:"Sort direction when sort_by is set: 'asc' (default) or 'desc'."`
 	Rank             string   `json:"rank,omitempty" jsonschema:"CEL expression returning double / int / bool — evaluated per file as a custom sort key. Higher values rank first. Composes with semantic_query (similarity is a CEL variable). When set, overrides sort_by; default order is desc. Example: 'similarity * 0.7 + (mod_time > timestamp(\"2025-01-01T00:00:00Z\") ? 0.3 : 0.0)'."`
-	Limit            int      `json:"limit,omitempty" jsonschema:"Cap the returned match count. With sort_by, returns the top-N (after sorting). Without sort_by, returns the first N in walk order. 0 = unlimited."`
+	Limit            int      `json:"limit,omitempty" jsonschema:"Cap the returned match count. With sort_by, returns the top-N (after sorting). Without sort_by, returns the first N ordered by path. 0 = unlimited. When the result set is truncated by limit, the response carries an opaque next_cursor — pass it back as 'cursor' to fetch the next page."`
+	Cursor           string   `json:"cursor,omitempty" jsonschema:"Opaque pagination token from a previous response's next_cursor. Resumes the result set immediately after the last item of the prior page, using the SAME sort_by/order/rank as that call (a mismatch errors). Paging is stable across calls under an unchanged tree; the walk is re-run each page (cheap — attributes are cached). Combine with 'limit' to stream a large match set in bounded pages."`
 	IncludeSnippet   bool     `json:"include_snippet,omitempty" jsonschema:"When true, populate each match's 'snippet' field with the first N lines of the file body (see snippet_lines). Only text-based content types (markdown / text / html / csv / json / xml / source/*) populate; binary families leave snippet empty."`
 	SnippetLines     int      `json:"snippet_lines,omitempty" jsonschema:"How many lines to include per snippet (default 10). Ignored when include_snippet is false."`
 	IncludeBody      bool     `json:"include_body,omitempty" jsonschema:"When true, the full file body is exposed to the CEL expression as the 'body' string variable, so filters like body.contains(\"transformer\") or body.matches(\"\\\\bAPI\\\\b\") run at search time. Only text-based content types populate body; capped at body_max_bytes (default 1 MiB). Expensive: reads every candidate file's body, not just headers — pair with tight expr / excludes / timeout."`
@@ -63,6 +64,11 @@ type SearchOutput struct {
 	CommonOutput
 	Matches            []search.Match `json:"matches"`
 	Count              int            `json:"count"`
+	// NextCursor is an opaque token, present only when the result set was
+	// truncated by Limit and more matches remain. Pass it back as the
+	// 'cursor' input (with the same sort_by/order/rank) to fetch the next
+	// page. Empty means this is the last page. Issue #336.
+	NextCursor         string         `json:"next_cursor,omitempty"`
 	Cancelled          bool           `json:"cancelled,omitempty"`
 	CancellationReason string         `json:"cancellation_reason,omitempty"`
 	ElapsedSeconds     float64        `json:"elapsed_seconds,omitempty"`
@@ -244,25 +250,34 @@ func (h *handlers) searchHandler(ctx context.Context, req *mcp.CallToolRequest, 
 		return nil, SearchOutput{}, fmt.Errorf("walk: %w", walkErr)
 	}
 
-	// Order: explicit sort_by > legacy path-sort default. Limit is
-	// applied AFTER sorting so the response respects top-K
-	// semantics. sortAndLimit lives in internal/search next to the
-	// type-aware compareByKey so this stays the single source of
-	// truth for sort/limit logic.
-	if in.Rank != "" || in.SortBy != "" || in.Limit > 0 {
-		sortOpts := search.Options{Sort: in.SortBy, Order: in.Order, Limit: in.Limit}
-		// Rank overrides sort_by: when set, sort by rank desc by
-		// default (mirrors the CLI / walker behaviour).
-		if in.Rank != "" {
-			sortOpts.Sort = "rank"
-			if sortOpts.Order == "" {
-				sortOpts.Order = "desc"
-			}
+	// Resolve the effective sort key/order. Rank overrides sort_by:
+	// when set, sort by rank desc by default (mirrors the CLI / walker).
+	sortKey, order := in.SortBy, in.Order
+	if in.Rank != "" {
+		sortKey = "rank"
+		if order == "" {
+			order = "desc"
 		}
-		results = search.SortAndLimit(results, sortOpts)
-	} else {
-		// Historical contract: matches sorted by path. Preserve it
-		// when the caller didn't request a specific sort.
+	}
+
+	// Pagination path: a cursor OR a limit means the caller may be
+	// paging, so route through PaginateResults — it sorts in a stable
+	// total order (sort key + path tiebreak), resumes past the cursor,
+	// caps to limit, and emits next_cursor when more remain. Empty
+	// sortKey orders by path (the same default as the non-paged branch).
+	var nextCursor string
+	switch {
+	case in.Cursor != "" || in.Limit > 0:
+		page, next, perr := search.PaginateResults(results, sortKey, order, in.Cursor, in.Limit)
+		if perr != nil {
+			return nil, SearchOutput{}, fmt.Errorf("cursor: %w", perr)
+		}
+		results, nextCursor = page, next
+	case sortKey != "":
+		results = search.SortAndLimit(results, search.Options{Sort: sortKey, Order: order})
+	default:
+		// Historical contract: matches sorted by path when the caller
+		// didn't request a specific sort.
 		sort.Slice(results, func(i, j int) bool { return results[i].Path < results[j].Path })
 	}
 
@@ -278,6 +293,7 @@ func (h *handlers) searchHandler(ctx context.Context, req *mcp.CallToolRequest, 
 	output := SearchOutput{
 		Matches:        matches,
 		Count:          len(matches),
+		NextCursor:     nextCursor,
 		ElapsedSeconds: elapsed,
 	}
 	if cancelled {

--- a/internal/mcpserver/server_pagination_test.go
+++ b/internal/mcpserver/server_pagination_test.go
@@ -1,0 +1,106 @@
+package mcpserver
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestSearchTool_CursorPagination pages through a result set two at a
+// time and asserts the union of pages covers every file exactly once,
+// in a stable sorted order, with next_cursor clearing on the last page
+// (issue #336).
+func TestSearchTool_CursorPagination(t *testing.T) {
+	dir := t.TempDir()
+	names := []string{"a.md", "b.md", "c.md", "d.md", "e.md"}
+	for _, n := range names {
+		mustWrite(t, filepath.Join(dir, n), "# "+n+"\n\nbody\n")
+	}
+
+	ctx, cs := newSession(t)
+
+	var got []string
+	cursor := ""
+	pages := 0
+	for {
+		pages++
+		if pages > 100 {
+			t.Fatal("pagination did not terminate")
+		}
+		res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+			Name: "search",
+			Arguments: SearchInput{
+				Expr:   "is_markdown",
+				Dir:    dir,
+				SortBy: "name",
+				Order:  "asc",
+				Limit:  2,
+				Cursor: cursor,
+			},
+		})
+		if err != nil {
+			t.Fatalf("page %d CallTool: %v", pages, err)
+		}
+		if res.GetError() != nil {
+			t.Fatalf("page %d tool error: %v", pages, res.GetError())
+		}
+		var out SearchOutput
+		mustDecodeStructured(t, res, &out)
+
+		if out.Count > 2 {
+			t.Fatalf("page %d returned %d matches, want <= limit 2", pages, out.Count)
+		}
+		for _, m := range out.Matches {
+			got = append(got, filepath.Base(m.Path))
+		}
+		if out.NextCursor == "" {
+			break
+		}
+		cursor = out.NextCursor
+	}
+
+	if pages != 3 { // 2 + 2 + 1
+		t.Errorf("pages = %d, want 3", pages)
+	}
+	want := []string{"a.md", "b.md", "c.md", "d.md", "e.md"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("paged result = %v, want %v (every file once, in name order)", got, want)
+	}
+}
+
+// TestSearchTool_CursorSortMismatchErrors confirms reusing a cursor with
+// a different sort_by is rejected rather than silently returning garbage.
+func TestSearchTool_CursorSortMismatchErrors(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{"a.md", "b.md", "c.md"} {
+		mustWrite(t, filepath.Join(dir, n), "# "+n+"\n\nbody\n")
+	}
+	ctx, cs := newSession(t)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search",
+		Arguments: SearchInput{Expr: "is_markdown", Dir: dir, SortBy: "name", Order: "asc", Limit: 1},
+	})
+	if err != nil {
+		t.Fatalf("page1 CallTool: %v", err)
+	}
+	var out SearchOutput
+	mustDecodeStructured(t, res, &out)
+	if out.NextCursor == "" {
+		t.Fatal("expected a next_cursor after page 1")
+	}
+
+	// Reuse the name-sorted cursor against a size sort → must error.
+	res2, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search",
+		Arguments: SearchInput{Expr: "is_markdown", Dir: dir, SortBy: "size", Order: "asc", Limit: 1, Cursor: out.NextCursor},
+	})
+	if err != nil {
+		t.Fatalf("page2 CallTool transport: %v", err)
+	}
+	if !res2.IsError {
+		t.Error("expected IsError=true when the cursor's sort differs from the call's sort_by")
+	}
+}

--- a/internal/search/cursor.go
+++ b/internal/search/cursor.go
@@ -1,0 +1,221 @@
+package search
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Cursor-based pagination for buffered result sets (issue #336). The
+// design is a STATELESS KEYSET cursor: there is no server-side cached
+// result list. Each page re-walks the tree (attribute extraction is
+// index-cached, so the re-walk is cheap) and resumes past an opaque
+// token that encodes the sort key, the order, and the last returned
+// item's (sort value, path). Paging is stable across calls under an
+// unchanged tree, survives a server restart, and degrades gracefully
+// when the tree changes (the keyset comparison finds the first item
+// strictly after the cursor's position regardless of whether the exact
+// cursor file still exists).
+//
+// The total order is (sort key, path). Path is the tiebreaker so the
+// ordering is total even when many files share a sort value — without a
+// total order, keyset resumption can't be consistent. The tiebreaker is
+// ALWAYS ascending by path, independent of the primary order, so the
+// page boundary is well-defined in both asc and desc modes.
+
+// pageCursor is the decoded form of the opaque token. Encoded as
+// base64(JSON) so it's a single opaque string to the client.
+type pageCursor struct {
+	Sort  string    `json:"sort"`
+	Order string    `json:"order"`
+	Val   cursorVal `json:"val"`
+	Path  string    `json:"path"`
+}
+
+// cursorVal is a type-tagged scalar so the JSON round-trip preserves the
+// distinction between int / float / string / time that a bare JSON
+// number would lose (every JSON number decodes to float64).
+type cursorVal struct {
+	Kind string  `json:"k"` // "int" | "float" | "str" | "time" | "nil"
+	Int  int64   `json:"i,omitempty"`
+	Flt  float64 `json:"f,omitempty"`
+	Str  string  `json:"s,omitempty"`
+	Time string  `json:"t,omitempty"` // RFC3339Nano
+}
+
+// PaginateResults applies a deterministic total-order sort (sortKey with
+// path as tiebreaker), resumes past cursor (empty = first page), caps to
+// limit, and returns an opaque next cursor when more results remain
+// (next == "" means the last page). Empty sortKey orders by path. The
+// passed slice is sorted in place. Issue #336.
+func PaginateResults(results []Result, sortKey, order, cursor string, limit int) (page []Result, next string, err error) {
+	order = normalizeOrder(order)
+	sortResultsPageable(results, sortKey, order)
+
+	if cursor != "" {
+		cur, derr := decodeCursor(cursor)
+		if derr != nil {
+			return nil, "", derr
+		}
+		if cur.Sort != sortKey || cur.Order != order {
+			return nil, "", fmt.Errorf("cursor was issued for sort=%q order=%q but this call uses sort=%q order=%q — start a fresh page or match the original sort", cur.Sort, cur.Order, sortKey, order)
+		}
+		// The slice is in total order, so "is strictly after the cursor"
+		// is monotone (false… then true…) and a binary search finds the
+		// first surviving element.
+		idx := sort.Search(len(results), func(i int) bool {
+			return afterCursor(results[i], sortKey, order, cur)
+		})
+		results = results[idx:]
+	}
+
+	if limit > 0 && len(results) > limit {
+		last := results[limit-1]
+		next = encodeCursor(pageCursor{
+			Sort:  sortKey,
+			Order: order,
+			Val:   toCursorVal(sortValueOf(last, sortKey)),
+			Path:  last.Path,
+		})
+		return results[:limit], next, nil
+	}
+	return results, "", nil
+}
+
+// normalizeOrder lowercases and defaults the order so a cursor issued
+// with order "" (asc default) round-trips equal to a later call that
+// passes "asc" explicitly.
+func normalizeOrder(order string) string {
+	if strings.EqualFold(order, "desc") {
+		return "desc"
+	}
+	return "asc"
+}
+
+// sortResultsPageable orders results by (sortKey per order, path asc).
+// Uses the same scalar comparison as compareByKey via the shared
+// cursorVal path, so the pageable order matches the display order.
+func sortResultsPageable(in []Result, key, order string) {
+	desc := order == "desc"
+	sort.Slice(in, func(i, j int) bool {
+		c := cmpCursorVal(toCursorVal(sortValueOf(in[i], key)), toCursorVal(sortValueOf(in[j], key)))
+		if c != 0 {
+			if desc {
+				return c > 0
+			}
+			return c < 0
+		}
+		return in[i].Path < in[j].Path // total-order tiebreak, always asc
+	})
+}
+
+// afterCursor reports whether r sorts strictly after the cursor position
+// in the (sortKey per order, path asc) total order.
+func afterCursor(r Result, key, order string, cur pageCursor) bool {
+	c := cmpCursorVal(toCursorVal(sortValueOf(r, key)), cur.Val)
+	if order == "desc" {
+		c = -c
+	}
+	if c != 0 {
+		return c > 0
+	}
+	return r.Path > cur.Path
+}
+
+// sortValueOf extracts the comparable sort value for a result under the
+// named key. Mirrors compareByKey's key handling. Empty/"path" → path.
+// Returns nil for an absent attribute (sorts last, like compareByKey).
+func sortValueOf(r Result, key string) any {
+	switch key {
+	case "", "path":
+		return r.Path
+	case "size":
+		return r.Size
+	case "name":
+		return filenameOf(r)
+	case "mod_time":
+		return modTimeOf(r)
+	case "similarity":
+		return similarityOf(r)
+	case "rank":
+		return r.Rank
+	case "git_last_commit_time":
+		return gitLastCommitTimeOf(r)
+	case "git_first_seen":
+		return gitFirstSeenOf(r)
+	case "git_commit_count":
+		return gitCommitCountOf(r)
+	}
+	if v, ok := extraScalar(r, key); ok {
+		return v
+	}
+	return nil
+}
+
+func toCursorVal(v any) cursorVal {
+	switch x := v.(type) {
+	case int64:
+		return cursorVal{Kind: "int", Int: x}
+	case float64:
+		return cursorVal{Kind: "float", Flt: x}
+	case string:
+		return cursorVal{Kind: "str", Str: x}
+	case time.Time:
+		return cursorVal{Kind: "time", Time: x.Format(time.RFC3339Nano)}
+	default:
+		return cursorVal{Kind: "nil"}
+	}
+}
+
+// cmpCursorVal compares two tagged values. A "nil" value (absent
+// attribute) sorts after any present value, matching compareByKey's
+// "missing groups at the end" rule. Differing non-nil kinds (which a
+// single sort key shouldn't produce in practice) fall back to comparing
+// the kind string so the order stays total.
+func cmpCursorVal(a, b cursorVal) int {
+	if a.Kind == "nil" || b.Kind == "nil" {
+		if a.Kind == b.Kind {
+			return 0
+		}
+		if a.Kind == "nil" {
+			return 1 // a missing → after b
+		}
+		return -1
+	}
+	if a.Kind != b.Kind {
+		return strings.Compare(a.Kind, b.Kind)
+	}
+	switch a.Kind {
+	case "int":
+		return cmpInt(a.Int, b.Int)
+	case "float":
+		return cmpFloat(a.Flt, b.Flt)
+	case "str":
+		return cmpString(a.Str, b.Str)
+	case "time":
+		at, _ := time.Parse(time.RFC3339Nano, a.Time)
+		bt, _ := time.Parse(time.RFC3339Nano, b.Time)
+		return cmpTime(at, bt)
+	}
+	return 0
+}
+
+func encodeCursor(c pageCursor) string {
+	b, _ := json.Marshal(c)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func decodeCursor(s string) (pageCursor, error) {
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return pageCursor{}, fmt.Errorf("invalid cursor encoding: %w", err)
+	}
+	var c pageCursor
+	if err := json.Unmarshal(b, &c); err != nil {
+		return pageCursor{}, fmt.Errorf("invalid cursor payload: %w", err)
+	}
+	return c, nil
+}

--- a/internal/search/cursor_test.go
+++ b/internal/search/cursor_test.go
@@ -1,0 +1,209 @@
+package search
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+)
+
+// collectPages walks every page via PaginateResults, returning the
+// concatenated paths in page order and the number of pages it took. It
+// fails the test on any pagination error or if paging doesn't terminate.
+func collectPages(t *testing.T, build func() []Result, sortKey, order string, limit int) ([]string, int) {
+	t.Helper()
+	var paths []string
+	cursor := ""
+	pages := 0
+	for {
+		pages++
+		if pages > 1000 {
+			t.Fatalf("pagination did not terminate after 1000 pages")
+		}
+		// Rebuild the (unsorted) result set each page to model the
+		// stateless re-walk the MCP handler performs.
+		page, next, err := PaginateResults(build(), sortKey, order, cursor, limit)
+		if err != nil {
+			t.Fatalf("PaginateResults page %d: %v", pages, err)
+		}
+		for _, r := range page {
+			paths = append(paths, r.Path)
+		}
+		if next == "" {
+			break
+		}
+		if len(page) == 0 {
+			t.Fatalf("page %d returned a next_cursor but no results (would loop forever)", pages)
+		}
+		cursor = next
+	}
+	return paths, pages
+}
+
+func resultsBySize() []Result {
+	// Deliberately unsorted, with a size tie (b and d both 20) to
+	// exercise the path tiebreaker.
+	return []Result{
+		{Path: "c.txt", Size: 30},
+		{Path: "a.txt", Size: 10},
+		{Path: "d.txt", Size: 20},
+		{Path: "b.txt", Size: 20},
+		{Path: "e.txt", Size: 40},
+	}
+}
+
+func TestPaginate_CoversEveryItemOnceInOrder(t *testing.T) {
+	paths, pages := collectPages(t, resultsBySize, "size", "asc", 2)
+	want := []string{"a.txt", "b.txt", "d.txt", "c.txt", "e.txt"} // size asc, path tiebreak on the 20s
+	if fmt.Sprint(paths) != fmt.Sprint(want) {
+		t.Errorf("paged order = %v, want %v", paths, want)
+	}
+	if pages != 3 { // 2 + 2 + 1
+		t.Errorf("pages = %d, want 3", pages)
+	}
+}
+
+func TestPaginate_DescOrder(t *testing.T) {
+	paths, _ := collectPages(t, resultsBySize, "size", "desc", 2)
+	want := []string{"e.txt", "c.txt", "b.txt", "d.txt", "a.txt"} // size desc, path tiebreak still asc on the 20s
+	if fmt.Sprint(paths) != fmt.Sprint(want) {
+		t.Errorf("paged desc order = %v, want %v", paths, want)
+	}
+}
+
+func TestPaginate_NoLimitReturnsAllNoCursor(t *testing.T) {
+	page, next, err := PaginateResults(resultsBySize(), "size", "asc", "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != "" {
+		t.Errorf("next_cursor = %q, want empty (no limit → single page)", next)
+	}
+	if len(page) != 5 {
+		t.Errorf("len(page) = %d, want 5", len(page))
+	}
+}
+
+func TestPaginate_LastPageHasNoCursor(t *testing.T) {
+	// limit == len means one full page and no more.
+	_, next, err := PaginateResults(resultsBySize(), "size", "asc", "", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != "" {
+		t.Errorf("next_cursor = %q, want empty when the page exhausts the set", next)
+	}
+}
+
+func TestPaginate_EmptySortKeyOrdersByPath(t *testing.T) {
+	paths, _ := collectPages(t, func() []Result {
+		return []Result{{Path: "z.txt"}, {Path: "a.txt"}, {Path: "m.txt"}}
+	}, "", "", 1)
+	want := []string{"a.txt", "m.txt", "z.txt"}
+	if fmt.Sprint(paths) != fmt.Sprint(want) {
+		t.Errorf("empty-sort paged order = %v, want %v (by path)", paths, want)
+	}
+}
+
+// TestPaginate_RobustToDeletedCursorItem confirms the keyset resume
+// finds the first item strictly after the cursor position even when the
+// exact file the cursor pointed at is gone on the next walk.
+func TestPaginate_RobustToDeletedCursorItem(t *testing.T) {
+	// Page 1 of size-asc: a(10), b(20). Cursor anchors on b(20).
+	_, next, err := PaginateResults(resultsBySize(), "size", "asc", "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next == "" {
+		t.Fatal("expected a next_cursor after page 1")
+	}
+	// Now b.txt is deleted before page 2's re-walk.
+	withoutB := []Result{
+		{Path: "c.txt", Size: 30},
+		{Path: "a.txt", Size: 10},
+		{Path: "d.txt", Size: 20},
+		{Path: "e.txt", Size: 40},
+	}
+	page2, _, err := PaginateResults(withoutB, "size", "asc", next, 2)
+	if err != nil {
+		t.Fatalf("page 2 with deleted cursor item: %v", err)
+	}
+	// d(20) sorts after b(20) on the path tiebreak, so it must lead page 2.
+	got := []string{}
+	for _, r := range page2 {
+		got = append(got, r.Path)
+	}
+	want := []string{"d.txt", "c.txt"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("page 2 = %v, want %v (resume past deleted cursor)", got, want)
+	}
+}
+
+func TestPaginate_SortMismatchErrors(t *testing.T) {
+	_, next, err := PaginateResults(resultsBySize(), "size", "asc", "", 2)
+	if err != nil || next == "" {
+		t.Fatalf("setup: err=%v next=%q", err, next)
+	}
+	if _, _, err := PaginateResults(resultsBySize(), "name", "asc", next, 2); err == nil {
+		t.Error("expected an error when the cursor's sort key differs from the call's")
+	}
+	if _, _, err := PaginateResults(resultsBySize(), "size", "desc", next, 2); err == nil {
+		t.Error("expected an error when the cursor's order differs from the call's")
+	}
+}
+
+func TestPaginate_InvalidCursorErrors(t *testing.T) {
+	if _, _, err := PaginateResults(resultsBySize(), "size", "asc", "!!!not-base64!!!", 2); err == nil {
+		t.Error("expected an error for a malformed cursor token")
+	}
+}
+
+// TestPaginate_ExtraScalarKey covers a per-family scalar pulled from
+// FileAttributes.Extra (e.g. word_count) rather than a typed field.
+func TestPaginate_ExtraScalarKey(t *testing.T) {
+	build := func() []Result {
+		return []Result{
+			{Path: "a.md", Attrs: &celexpr.FileAttributes{Extra: map[string]any{"word_count": int64(300)}}},
+			{Path: "b.md", Attrs: &celexpr.FileAttributes{Extra: map[string]any{"word_count": int64(100)}}},
+			{Path: "c.md", Attrs: &celexpr.FileAttributes{Extra: map[string]any{"word_count": int64(200)}}},
+		}
+	}
+	paths, _ := collectPages(t, build, "word_count", "asc", 1)
+	want := []string{"b.md", "c.md", "a.md"} // 100, 200, 300
+	if fmt.Sprint(paths) != fmt.Sprint(want) {
+		t.Errorf("word_count paged order = %v, want %v", paths, want)
+	}
+}
+
+// TestPaginate_MissingAttributeSortsLast mirrors compareByKey's rule:
+// a result with no value for the sort key groups at the end.
+func TestPaginate_MissingAttributeSortsLast(t *testing.T) {
+	build := func() []Result {
+		return []Result{
+			{Path: "has.md", Attrs: &celexpr.FileAttributes{Extra: map[string]any{"iso": int64(800)}}},
+			{Path: "missing.md", Attrs: &celexpr.FileAttributes{Extra: map[string]any{}}},
+		}
+	}
+	paths, _ := collectPages(t, build, "iso", "asc", 1)
+	want := []string{"has.md", "missing.md"}
+	if fmt.Sprint(paths) != fmt.Sprint(want) {
+		t.Errorf("missing-attr order = %v, want %v", paths, want)
+	}
+}
+
+func TestPaginate_TimeKeyRoundTrips(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	build := func() []Result {
+		return []Result{
+			{Path: "new.md", Attrs: &celexpr.FileAttributes{ModTime: t0.Add(48 * time.Hour)}},
+			{Path: "old.md", Attrs: &celexpr.FileAttributes{ModTime: t0}},
+			{Path: "mid.md", Attrs: &celexpr.FileAttributes{ModTime: t0.Add(24 * time.Hour)}},
+		}
+	}
+	paths, _ := collectPages(t, build, "mod_time", "desc", 1)
+	want := []string{"new.md", "mid.md", "old.md"}
+	if fmt.Sprint(paths) != fmt.Sprint(want) {
+		t.Errorf("mod_time desc paged order = %v, want %v", paths, want)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #336 (the two flat-list result tools; group-shaped tools noted as a follow-up below). On large trees an agent that gets thousands of matches had to either cap with `limit` (losing the tail) or pull everything (blowing its context). This adds **stateless keyset cursor pagination** so a large match set can be streamed in bounded pages.

- **`internal/search/cursor.go`** — `PaginateResults` sorts results into a stable **total order** (sort key, then path as tiebreaker), resumes past an opaque `base64(JSON)` cursor via a monotone `sort.Search`, caps to `limit`, and emits a `next_cursor` when more remain.
- The cursor encodes the sort key, order, and the last item's type-tagged `(value, path)`. Because resume is a **keyset comparison** (not an offset or an exact-path lookup), it:
  - survives a **tree change** — finds the first item strictly after the cursor position even if the exact cursor file was deleted;
  - survives a **server restart** — there's no server-side cached result set;
  - is **stable** under an unchanged tree.
- **`search`** — new `cursor` input + `next_cursor` output. A cursor or a limit routes the sort/limit step through `PaginateResults`.
- **`search_semantic`** — same `cursor` / `next_cursor`, paging the similarity-desc ranking. Drops the old defensive re-sort (the path tiebreak already yields a canonical order).
- A cursor issued for a **different** `sort_by` / `order` is rejected rather than silently returning wrong results.

## Decisions (confirmed up front)

- **Scope: #336 only.** #335 (hybrid BM25 + HNSW ANN index) is two large features and deserves its own session/PR.
- **Stateless keyset** over a server-side cached result set — no server memory/eviction, survives restarts, stable under an unchanged tree.

## Behaviour note

A **limit-only, no-sort** `search` now returns the first N ordered by **path** rather than walk order. Walk order was already documented as non-deterministic across runs, and a deterministic order is required for stable paging; the no-sort/no-limit default was already path-sorted, so this is consistent.

## Follow-up (not in this PR)

`find_matches`, `find_near_duplicates`, and `stats` groups return group-shaped results that page over a different unit (files / groups / buckets) — a separate cursor shape. Left for a follow-up so this PR stays focused and reviewable.

## Testing

- `cursor.go` unit tests: full coverage with no overlap, asc/desc, size ties, deleted-cursor robustness, sort/order mismatch error, invalid-token error, extra-scalar / time / missing-attribute keys.
- MCP-level paging tests through the `search` tool (page through a tree two at a time; sort-mismatch rejection).
- `go test ./...`, `-race` on `search` + `mcpserver`, `go vet`, `go fix` (idempotent), `golangci-lint run` — all clean.
- README documents the pagination contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)