### PR TITLE
feat(mcp): extend cursor pagination to find_matches, stats, find_near_duplicates (#336)

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,14 +461,14 @@ Twenty tools are exposed, grouped by family:
 
 | Tool | What it does |
 | --- | --- |
-| `stats` | Histogram + totals for a directory tree, bucketed by `group_by` (default `content_type`; recognised: `ext`, `dir`, `language`, `camera_make`, `camera_model`, `lens`, `artist`, `album`, `genre`, time buckets like `taken_at_month`, …). |
+| `stats` | Histogram + totals for a directory tree, bucketed by `group_by` (default `content_type`; recognised: `ext`, `dir`, `language`, `camera_make`, `camera_model`, `lens`, `artist`, `album`, `genre`, time buckets like `taken_at_month`, …). Buckets support `limit` / `cursor` pagination for high-cardinality keys. |
 
 **Dedup & diff**
 
 | Tool | What it does |
 | --- | --- |
 | `find_duplicates` | Byte-identical files keyed by sha256 — two-pass (size-bucket then hash). Sorted by `wasted_bytes` desc. |
-| `find_near_duplicates` | Similar files by SimHash fingerprint of extracted body. Catches typo edits, regenerated headers, template copies. Configurable similarity threshold (default 0.85). |
+| `find_near_duplicates` | Similar files by SimHash fingerprint of extracted body. Catches typo edits, regenerated headers, template copies. Configurable similarity threshold (default 0.85). Clusters support `group_limit` / `cursor` pagination. |
 | `diff_trees` | Cross-tree set operations by sha256 content hash — `a-minus-b`, `b-minus-a`, `intersect`, `union`, `mismatch` (same relative path, different content). Read-only; never mutates either tree. |
 
 **Archive**
@@ -482,7 +482,7 @@ Twenty tools are exposed, grouped by family:
 
 | Tool | What it does |
 | --- | --- |
-| `find_matches` | Line-level regex (RE2) hits across a tree with `context_before` / `context_after` windows. CEL pre-prune (e.g. `is_source && language == "go"`) keeps the regex pass narrow. Replaces the search-then-`read_lines` dance with one call. |
+| `find_matches` | Line-level regex (RE2) hits across a tree with `context_before` / `context_after` windows. CEL pre-prune (e.g. `is_source && language == "go"`) keeps the regex pass narrow. Replaces the search-then-`read_lines` dance with one call. Supports `limit` / `cursor` pagination over the (path, line)-ordered hits. |
 | `watch_search` | Bounded "tell me when X appears" subscription — block up to `duration_seconds` (default 30, capped at 600), return every new / changed file that matches the CEL filter. |
 
 **Project + introspection + monitoring**
@@ -500,7 +500,7 @@ Twenty tools are exposed, grouped by family:
 
 Every walking tool (`search`, `stats`, `find_duplicates`, `find_near_duplicates`, `find_matches`, `find_projects`, `diff_trees`) honours the same partial-result contract: on timeout the call returns `cancelled=true` with the results gathered so far, never an error. Agents inspect the flag rather than catching exceptions.
 
-**Pagination.** `search` and `search_semantic` support stateless **cursor pagination** for large result sets. Pass `limit` to cap a page; when the set is truncated the response carries an opaque `next_cursor`. Pass it back as `cursor` (with the *same* `sort_by` / `order` / `rank` / `query`) to fetch the next page. The cursor is a keyset over the sort key + path, so paging is stable under an unchanged tree and survives a server restart — there's no server-side cached result set. Each page re-walks the tree, but attribute extraction is index-cached, so re-walks are cheap. An agent can stream a 10k-match set in bounded pages without blowing its context or losing the tail to a hard `limit`.
+**Pagination.** `search`, `search_semantic`, `find_matches`, `stats`, and `find_near_duplicates` support stateless **cursor pagination** for large result sets. Pass `limit` (or `group_limit` for `find_near_duplicates`) to cap a page; when the set is truncated the response carries an opaque `next_cursor`. Pass it back as `cursor` (with the *same* sort / query / `group_by` / `threshold`) to fetch the next page. The cursor is a keyset over the result's ordering (sort key + path for `search`; path + line for `find_matches`; count-desc + name for `stats`; count-desc + representative for `find_near_duplicates`), so paging is stable under an unchanged tree and survives a server restart — there's no server-side cached result set. Each page re-walks the tree, but attribute extraction is index-cached, so re-walks are cheap. An agent can stream a 10k-result set in bounded pages without blowing its context or losing the tail to a hard `limit`. (For `find_matches` / `stats` / `find_near_duplicates`, the total counters — `count` / `total_count` / `group_count` — stay whole-tree, while the list field carries the current page.)
 
 Since v0.64.0 the on-disk index is **on by default**. The MCP server (like every other long-running subcommand) auto-creates a per-cwd bbolt cache at `<UserCacheDir>/file-search-on/indexes/<basename>-<sha1[:6]>.db` — repeated `search` / `read_attributes` calls against unchanged files skip parsing entirely. The default path is per-cwd so concurrent agents in different projects never collide; same-cwd contention falls back gracefully to in-memory (logged on stderr, surfaced on the dashboard as `index_fallback_reason: "lock_contention"`). Override with `--index-path`; opt out with `--no-index` for hermetic CI runs:
 

--- a/internal/mcpserver/find_matches_tool.go
+++ b/internal/mcpserver/find_matches_tool.go
@@ -24,6 +24,8 @@ type FindMatchesInput struct {
 	ContextAfter        int      `json:"context_after,omitempty" jsonschema:"Number of lines of trailing context to attach to each match. 0 means no After window."`
 	MaxMatchesPerFile   int      `json:"max_matches_per_file,omitempty" jsonschema:"Cap on matches reported per file. 0 = unlimited. The scan keeps reading past the cap until pending After windows are filled, so the last matches still carry full trailing context."`
 	MatchIn             string   `json:"match_in,omitempty" jsonschema:"Filter matches by per-line role. One of: 'any' (default — every regex hit), 'comments' (only hits on lines classified as a comment under the source file's language syntax: Go //, Python #, C /* */, plus block-comment continuation lines), 'code' (only hits on lines that AREN'T comments). Drops the typical TODO-sweep noise (test fixtures, string literals, fuzz seeds) without the agent having to hand-roll '^\\\\s*//<pattern>' regexes. Non-source files (markdown / json / plain text) are unaffected — they have no language syntax registered and the filter no-ops. Line-granular: a trailing-comment line like 'x := 1 // TODO' classifies as code. 'strings' mode (matching inside string literals) is deferred to a follow-up. Unknown values return an error. Issue #272."`
+	Limit               int      `json:"limit,omitempty" jsonschema:"Cap the number of line matches returned in this page (ordered by path, then line). 0 = all. When the set is truncated, the response carries next_cursor — pass it back as 'cursor' to fetch the next page. Distinct from max_matches_per_file (a per-file cap applied during the scan)."`
+	Cursor              string   `json:"cursor,omitempty" jsonschema:"Opaque pagination token from a previous response's next_cursor. Resumes the (path, line)-ordered match list after the last item of the prior page. Use the SAME pattern/expr/context for stable paging; the scan re-runs each page (attributes are cached, so it's cheap)."`
 	Excludes            []string `json:"excludes,omitempty" jsonschema:"Glob patterns matched against file/dir basenames; matches are pruned. Same semantics as search."`
 	RespectGitignore    bool     `json:"respect_gitignore,omitempty" jsonschema:"When true, parse a .gitignore at the walk root and skip matching paths."`
 	FollowSymlinks      bool     `json:"follow_symlinks,omitempty" jsonschema:"When true, descend through symbolic links to directories. Off by default."`
@@ -47,6 +49,11 @@ type FindMatchesOutput struct {
 	// wasn't scanned, so a regex match past the cap silently misses.
 	// Pair with the corresponding suggestion entry. Issue #283.
 	TruncatedFiles     []string `json:"truncated_files,omitempty"`
+	// NextCursor is present only when the match list was truncated by
+	// Limit and more hits remain. Count stays the total found across the
+	// walk; Matches is the current page. Pass next_cursor back as
+	// 'cursor' to fetch the next page. Issue #336.
+	NextCursor         string   `json:"next_cursor,omitempty"`
 	Cancelled          bool     `json:"cancelled,omitempty"`
 	CancellationReason string   `json:"cancellation_reason,omitempty"`
 	ElapsedSeconds     float64  `json:"elapsed_seconds,omitempty"`
@@ -173,6 +180,21 @@ func (h *handlers) findMatchesHandler(ctx context.Context, _ *mcp.CallToolReques
 					len(out.TruncatedFiles)))
 		}
 	}
+
+	// Cursor pagination over the (path, line)-ordered match list. Count
+	// stays the total found across the walk; Matches becomes the page.
+	// Computed AFTER the suggestion heuristics above so they see the full
+	// match set. Issue #336.
+	if in.Cursor != "" || in.Limit > 0 {
+		page, next, perr := search.PaginateGeneric(out.Matches, func(m LineMatch) []any {
+			return []any{m.Path, int64(m.Line)}
+		}, []string{"asc", "asc"}, in.Cursor, in.Limit)
+		if perr != nil {
+			return nil, FindMatchesOutput{}, fmt.Errorf("cursor: %w", perr)
+		}
+		out.Matches, out.NextCursor = page, next
+	}
+
 	out.ServerVersion = h.version
 	return nil, out, nil
 }

--- a/internal/mcpserver/find_near_duplicates_tool.go
+++ b/internal/mcpserver/find_near_duplicates_tool.go
@@ -28,7 +28,8 @@ type FindNearDuplicatesInput struct {
 	FollowSymlinks   bool     `json:"follow_symlinks,omitempty" jsonschema:"When true, descend through symbolic links to directories. Off by default."`
 	MinSize              int64 `json:"min_size,omitempty" jsonschema:"Skip files smaller than this many bytes (on-disk size, not extracted body)."`
 	MembersLimitPerGroup int   `json:"members_limit_per_group,omitempty" jsonschema:"Cap the per-group members list to this many entries. 0 (default) returns every member. Members are sorted by similarity descending before truncation so the survivors are the strongest matches. When a group is truncated, members_total + members_truncated are stamped on the group so the caller knows there's more to drill into. Useful for triage queries that just want a top-N preview per cluster. Issue #279."`
-	GroupLimit           int   `json:"group_limit,omitempty" jsonschema:"Cap the number of groups returned. 0 (default) returns every group. Groups are sorted by member count desc / representative size desc before truncation, so the largest / most-interesting clusters are kept. Pair with members_limit_per_group for bounded responses on huge corpora. Issue #279."`
+	GroupLimit           int   `json:"group_limit,omitempty" jsonschema:"Cap the number of groups returned per page. 0 (default) returns every group. Groups are ordered by member count desc, then representative path asc. When more groups remain, the response carries next_cursor — pass it back as 'cursor' to page through the rest. Pair with members_limit_per_group for bounded responses on huge corpora. Issue #279."`
+	Cursor               string `json:"cursor,omitempty" jsonschema:"Opaque pagination token from a previous response's next_cursor. Resumes the group list (count desc, representative asc) after the last group of the prior page. Use the SAME expr/threshold for stable paging. group_count always reflects the total number of clusters, not the page."`
 }
 
 // FindNearDuplicatesOutput mirrors search.NearDuplicates with a
@@ -40,6 +41,11 @@ type FindNearDuplicatesOutput struct {
 	GroupCount         int64                    `json:"group_count"`
 	Threshold          float64                  `json:"threshold"`
 	Groups             []NearDuplicateGroupWire `json:"groups"`
+	// NextCursor is present only when the group list was truncated by
+	// group_limit and more groups remain. group_count stays the total
+	// cluster count; Groups is the current page. Pass next_cursor back as
+	// 'cursor' to fetch the next page. Issue #336.
+	NextCursor         string                   `json:"next_cursor,omitempty"`
 	Cancelled          bool                     `json:"cancelled,omitempty"`
 	CancellationReason string                   `json:"cancellation_reason,omitempty"`
 	ElapsedSeconds     float64                  `json:"elapsed_seconds,omitempty"`
@@ -112,7 +118,9 @@ func (h *handlers) findNearDuplicatesHandler(ctx context.Context, _ *mcp.CallToo
 		MinSize:             in.MinSize,
 		SimilarityThreshold: in.Threshold,
 		NearDupMembersLimit: in.MembersLimitPerGroup,
-		NearDupGroupLimit:   in.GroupLimit,
+		// When paginating, let the engine return ALL groups (the handler
+		// pages them below); otherwise keep the legacy top-N truncation.
+		NearDupGroupLimit: groupEngineLimit(in),
 	}, content.DefaultRegistry())
 	elapsed := time.Since(start).Seconds()
 
@@ -147,7 +155,34 @@ func (h *handlers) findNearDuplicatesHandler(ctx context.Context, _ *mcp.CallToo
 				MembersTruncated: g.MembersTruncated,
 			}
 		}
+
+		// Cursor pagination over the cluster list (member count desc,
+		// representative path asc). group_count stays the total. The
+		// first page with group_limit=N matches the legacy top-N-by-count
+		// behaviour; next_cursor pages through the rest. Issue #336.
+		if in.Cursor != "" || in.GroupLimit > 0 {
+			page, next, perr := search.PaginateGeneric(out.Groups, func(g NearDuplicateGroupWire) []any {
+				return []any{int64(g.Count), g.Representative}
+			}, []string{"desc", "asc"}, in.Cursor, in.GroupLimit)
+			if perr != nil {
+				return nil, FindNearDuplicatesOutput{}, fmt.Errorf("cursor: %w", perr)
+			}
+			out.Groups, out.NextCursor = page, next
+		}
 	}
 	out.ServerVersion = h.version
 	return nil, out, nil
+}
+
+// groupEngineLimit returns the group cap to hand the dedup engine. When
+// the caller is paginating (cursor set, or group_limit used as a page
+// size), the engine must return every group so the handler can page over
+// the full ordered set — so we pass 0 (no truncation) and let
+// PaginateGeneric do the capping. Otherwise the legacy top-N truncation
+// stands.
+func groupEngineLimit(in FindNearDuplicatesInput) int {
+	if in.Cursor != "" || in.GroupLimit > 0 {
+		return 0
+	}
+	return in.GroupLimit
 }

--- a/internal/mcpserver/server_pagination_test.go
+++ b/internal/mcpserver/server_pagination_test.go
@@ -3,6 +3,7 @@ package mcpserver
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -104,3 +105,155 @@ func TestSearchTool_CursorSortMismatchErrors(t *testing.T) {
 		t.Error("expected IsError=true when the cursor's sort differs from the call's sort_by")
 	}
 }
+
+// TestFindMatchesTool_CursorPagination pages the (path, line)-ordered
+// line-match list and asserts full, ordered, non-overlapping coverage.
+func TestFindMatchesTool_CursorPagination(t *testing.T) {
+	dir := t.TempDir()
+	// 6 hits total: two files, three matching lines each.
+	mustWrite(t, filepath.Join(dir, "a.txt"), "TODO one\nx\nTODO two\ny\nTODO three\n")
+	mustWrite(t, filepath.Join(dir, "b.txt"), "TODO four\nz\nTODO five\nw\nTODO six\n")
+
+	ctx, cs := newSession(t)
+
+	var hits []string
+	cursor := ""
+	pages := 0
+	for {
+		pages++
+		if pages > 50 {
+			t.Fatal("pagination did not terminate")
+		}
+		res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "find_matches",
+			Arguments: FindMatchesInput{Pattern: "TODO", Dir: dir, Limit: 2, Cursor: cursor},
+		})
+		if err != nil {
+			t.Fatalf("page %d: %v", pages, err)
+		}
+		var out FindMatchesOutput
+		mustDecodeStructured(t, res, &out)
+		if out.Count != 6 {
+			t.Errorf("page %d: count=%d want 6 (total found, not page size)", pages, out.Count)
+		}
+		if len(out.Matches) > 2 {
+			t.Fatalf("page %d returned %d matches, want <= 2", pages, len(out.Matches))
+		}
+		for _, m := range out.Matches {
+			hits = append(hits, fmt.Sprintf("%s:%d", filepath.Base(m.Path), m.Line))
+		}
+		if out.NextCursor == "" {
+			break
+		}
+		cursor = out.NextCursor
+	}
+	if pages != 3 {
+		t.Errorf("pages = %d, want 3", pages)
+	}
+	want := []string{"a.txt:1", "a.txt:3", "a.txt:5", "b.txt:1", "b.txt:3", "b.txt:5"}
+	if fmt.Sprint(hits) != fmt.Sprint(want) {
+		t.Errorf("paged hits = %v, want %v", hits, want)
+	}
+}
+
+// TestStatsTool_CursorPagination pages the histogram buckets (count
+// desc, name asc) and asserts each bucket appears once across pages.
+func TestStatsTool_CursorPagination(t *testing.T) {
+	dir := t.TempDir()
+	// Distinct extensions with differing counts to exercise count-desc.
+	mustWrite(t, filepath.Join(dir, "a.md"), "x")
+	mustWrite(t, filepath.Join(dir, "b.md"), "x")
+	mustWrite(t, filepath.Join(dir, "c.md"), "x")
+	mustWrite(t, filepath.Join(dir, "a.json"), "{}")
+	mustWrite(t, filepath.Join(dir, "b.json"), "{}")
+	mustWrite(t, filepath.Join(dir, "a.txt"), "x")
+
+	ctx, cs := newSession(t)
+
+	var names []string
+	cursor := ""
+	pages := 0
+	for {
+		pages++
+		if pages > 50 {
+			t.Fatal("pagination did not terminate")
+		}
+		res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "stats",
+			Arguments: StatsInput{Dir: dir, GroupBy: "ext", Limit: 1, Cursor: cursor},
+		})
+		if err != nil {
+			t.Fatalf("page %d: %v", pages, err)
+		}
+		var out StatsOutput
+		mustDecodeStructured(t, res, &out)
+		if out.TotalCount != 6 {
+			t.Errorf("page %d: total_count=%d want 6 (whole tree, not page)", pages, out.TotalCount)
+		}
+		for _, b := range out.Groups {
+			names = append(names, b.Name)
+		}
+		if out.NextCursor == "" {
+			break
+		}
+		cursor = out.NextCursor
+	}
+	// .md (3) > .json (2) > .txt (1) — count desc.
+	want := []string{".md", ".json", ".txt"}
+	if fmt.Sprint(names) != fmt.Sprint(want) {
+		t.Errorf("paged buckets = %v, want %v", names, want)
+	}
+}
+
+// TestFindNearDuplicatesTool_CursorPagination pages near-duplicate
+// clusters and asserts every cluster is visited once.
+func TestFindNearDuplicatesTool_CursorPagination(t *testing.T) {
+	dir := t.TempDir()
+	// Two distinct clusters of near-identical prose.
+	base1 := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 60)
+	base2 := strings.Repeat("Pack my box with five dozen liquor jugs today. ", 60)
+	mustWrite(t, filepath.Join(dir, "c1a.md"), base1)
+	mustWrite(t, filepath.Join(dir, "c1b.md"), strings.Replace(base1, "lazy", "sleepy", 1))
+	mustWrite(t, filepath.Join(dir, "c2a.md"), base2)
+	mustWrite(t, filepath.Join(dir, "c2b.md"), strings.Replace(base2, "today", "tonight", 1))
+
+	ctx, cs := newSession(t)
+
+	seen := map[string]bool{}
+	cursor := ""
+	pages := 0
+	var total int64
+	for {
+		pages++
+		if pages > 50 {
+			t.Fatal("pagination did not terminate")
+		}
+		res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "find_near_duplicates",
+			Arguments: FindNearDuplicatesInput{Dir: dir, Threshold: 0.8, GroupLimit: 1, Cursor: cursor},
+		})
+		if err != nil {
+			t.Fatalf("page %d: %v", pages, err)
+		}
+		var out FindNearDuplicatesOutput
+		mustDecodeStructured(t, res, &out)
+		total = out.GroupCount
+		if len(out.Groups) > 1 {
+			t.Fatalf("page %d returned %d groups, want <= group_limit 1", pages, len(out.Groups))
+		}
+		for _, g := range out.Groups {
+			if seen[g.Representative] {
+				t.Errorf("group %s returned on more than one page", g.Representative)
+			}
+			seen[g.Representative] = true
+		}
+		if out.NextCursor == "" {
+			break
+		}
+		cursor = out.NextCursor
+	}
+	if int64(len(seen)) != total || total == 0 {
+		t.Errorf("paged %d unique groups, group_count=%d (want equal, non-zero)", len(seen), total)
+	}
+}
+

--- a/internal/mcpserver/stats_tool.go
+++ b/internal/mcpserver/stats_tool.go
@@ -25,6 +25,8 @@ type StatsInput struct {
 	FollowSymlinks      bool     `json:"follow_symlinks,omitempty" jsonschema:"When true, descend through symbolic links to directories. Off by default; symlinks-to-dirs surface as is_symlink=true leaf entries."`
 	PruneBuildArtefacts bool     `json:"prune_build_artefacts,omitempty" jsonschema:"When true, pre-walks each root to discover project subdirectories and prunes the canonical build-artefact basenames for every detected project type — vendor (Go), node_modules (Node), target (Rust / Java Maven), __pycache__/.venv/.tox (Python), bin/obj (.NET), .terraform (Terraform), etc. Unioned with 'excludes'. Saves the boilerplate exclude list when running stats over monorepos or large multi-project trees. Opt-in: pre-walk I/O is proportional to tree size. Parity with the search / find_matches / find_near_duplicates tools. Issue #277."`
 	GroupBy             string   `json:"group_by,omitempty" jsonschema:"Bucket key. Default 'content_type'. Recognised: content_type, ext, dir, language, camera_make, camera_model, lens, artist, album, genre, kernel, binary_format, binary_type, frontmatter_format. Unknown values fall back to content_type. Use group_by=ext to histogram by file extension, group_by=language to count source files per language, group_by=camera_make to bucket photos by camera, etc."`
+	Limit               int      `json:"limit,omitempty" jsonschema:"Cap the number of buckets returned in this page (buckets are ordered by count desc, then name asc). 0 = all. When truncated, the response carries next_cursor. Useful for high-cardinality group_by like ext / dir / language on a large tree."`
+	Cursor              string   `json:"cursor,omitempty" jsonschema:"Opaque pagination token from a previous response's next_cursor. Resumes the bucket list after the last bucket of the prior page. Use the SAME group_by/expr for stable paging. total_count / total_size always reflect the full tree, not the page."`
 }
 
 // StatsOutput is the structured output of the `stats` tool — a
@@ -43,6 +45,10 @@ type StatsOutput struct {
 	GroupBy            string                   `json:"group_by,omitempty"`
 	Groups             []StatsBucket            `json:"groups"`
 	ContentTypes       []StatsContentTypeBucket `json:"content_types,omitempty"`
+	// NextCursor is present only when the bucket list was truncated by
+	// Limit and more buckets remain. Pass it back as 'cursor' to fetch
+	// the next page. Issue #336.
+	NextCursor         string                   `json:"next_cursor,omitempty"`
 	Cancelled          bool                     `json:"cancelled,omitempty"`
 	CancellationReason string                   `json:"cancellation_reason,omitempty"`
 	ElapsedSeconds     float64                  `json:"elapsed_seconds,omitempty"`
@@ -139,6 +145,27 @@ func (h *handlers) statsHandler(ctx context.Context, _ *mcp.CallToolRequest, in 
 					Name:      b.Name,
 					Count:     b.Count,
 					TotalSize: b.TotalSize,
+				}
+			}
+		}
+
+		// Cursor pagination over the buckets (count desc, name asc — the
+		// same order ComputeStats emits). total_count / total_size stay
+		// whole-tree. When group_by is content_type the ContentTypes
+		// mirror is trimmed to the same page so the two views agree.
+		// Issue #336.
+		if in.Cursor != "" || in.Limit > 0 {
+			page, next, perr := search.PaginateGeneric(out.Groups, func(b StatsBucket) []any {
+				return []any{b.Count, b.Name}
+			}, []string{"desc", "asc"}, in.Cursor, in.Limit)
+			if perr != nil {
+				return nil, StatsOutput{}, fmt.Errorf("cursor: %w", perr)
+			}
+			out.Groups, out.NextCursor = page, next
+			if out.ContentTypes != nil {
+				out.ContentTypes = out.ContentTypes[:0]
+				for _, b := range out.Groups {
+					out.ContentTypes = append(out.ContentTypes, StatsContentTypeBucket(b))
 				}
 			}
 		}

--- a/internal/search/cursor.go
+++ b/internal/search/cursor.go
@@ -203,6 +203,103 @@ func cmpCursorVal(a, b cursorVal) int {
 	return 0
 }
 
+// genericCursor is the opaque token for PaginateGeneric. It records the
+// per-component order directions (so a cursor can't be reused against a
+// different ordering) plus the last returned item's full ordered key.
+type genericCursor struct {
+	Orders []string    `json:"o"`
+	Key    []cursorVal `json:"k"`
+}
+
+// PaginateGeneric applies a stateless keyset cursor to a slice whose
+// natural order is a tuple of scalar key components — the group-shaped
+// result tools (find_matches line hits, stats buckets, near-duplicate
+// groups) that don't fit the FileAttributes-based PaginateResults. It
+// sorts items in place into the canonical total order, resumes past
+// token (empty = first page), caps to limit, and returns a next cursor
+// when more remain (empty = last page).
+//
+// keyOf maps an item to its ordered key components as []any; each
+// component is a string / int64 / float64 / time.Time. The LAST
+// component MUST be unique across items so the order is total (a unique
+// path / name / representative is the usual choice). orders gives the
+// direction ("asc"/"desc") per component; the tuple compares
+// left-to-right. Issue #336.
+func PaginateGeneric[T any](items []T, keyOf func(T) []any, orders []string, token string, limit int) (page []T, next string, err error) {
+	norm := make([]string, len(orders))
+	for i, o := range orders {
+		norm[i] = normalizeOrder(o)
+	}
+	keyVals := func(it T) []cursorVal {
+		raw := keyOf(it)
+		out := make([]cursorVal, len(raw))
+		for i, v := range raw {
+			out[i] = toCursorVal(v)
+		}
+		return out
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		return cmpKeyVals(keyVals(items[i]), keyVals(items[j]), norm) < 0
+	})
+
+	if token != "" {
+		gc, derr := decodeGenericCursor(token)
+		if derr != nil {
+			return nil, "", derr
+		}
+		if strings.Join(gc.Orders, ",") != strings.Join(norm, ",") {
+			return nil, "", fmt.Errorf("cursor was issued for ordering %v but this call uses %v — start a fresh page or match the original ordering", gc.Orders, norm)
+		}
+		idx := sort.Search(len(items), func(i int) bool {
+			return cmpKeyVals(keyVals(items[i]), gc.Key, norm) > 0
+		})
+		items = items[idx:]
+	}
+
+	if limit > 0 && len(items) > limit {
+		last := items[limit-1]
+		next = encodeGenericCursor(genericCursor{Orders: norm, Key: keyVals(last)})
+		return items[:limit], next, nil
+	}
+	return items, "", nil
+}
+
+// cmpKeyVals compares two key tuples left-to-right, honouring the
+// per-component order direction. A shorter tuple sorts before a longer
+// one on a shared prefix (shouldn't happen — tuples are fixed-width per
+// call — but keeps the order total).
+func cmpKeyVals(a, b []cursorVal, orders []string) int {
+	n := min(len(a), len(b))
+	for i := range n {
+		c := cmpCursorVal(a[i], b[i])
+		if i < len(orders) && orders[i] == "desc" {
+			c = -c
+		}
+		if c != 0 {
+			return c
+		}
+	}
+	return cmpInt(int64(len(a)), int64(len(b)))
+}
+
+func encodeGenericCursor(c genericCursor) string {
+	b, _ := json.Marshal(c)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func decodeGenericCursor(s string) (genericCursor, error) {
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return genericCursor{}, fmt.Errorf("invalid cursor encoding: %w", err)
+	}
+	var c genericCursor
+	if err := json.Unmarshal(b, &c); err != nil {
+		return genericCursor{}, fmt.Errorf("invalid cursor payload: %w", err)
+	}
+	return c, nil
+}
+
 func encodeCursor(c pageCursor) string {
 	b, _ := json.Marshal(c)
 	return base64.RawURLEncoding.EncodeToString(b)

--- a/internal/search/cursor_test.go
+++ b/internal/search/cursor_test.go
@@ -192,6 +192,85 @@ func TestPaginate_MissingAttributeSortsLast(t *testing.T) {
 	}
 }
 
+// --- PaginateGeneric (group-shaped tools, issue #336) ---
+
+type bucket struct {
+	name  string
+	count int64
+}
+
+func bktKeyFn(b bucket) []any { return []any{b.count, b.name} }
+
+func collectGenericPages(t *testing.T, build func() []bucket, orders []string, limit int) []string {
+	t.Helper()
+	var names []string
+	cursor := ""
+	pages := 0
+	for {
+		pages++
+		if pages > 1000 {
+			t.Fatal("generic pagination did not terminate")
+		}
+		page, next, err := PaginateGeneric(build(), bktKeyFn, orders, cursor, limit)
+		if err != nil {
+			t.Fatalf("PaginateGeneric page %d: %v", pages, err)
+		}
+		for _, b := range page {
+			names = append(names, b.name)
+		}
+		if next == "" {
+			break
+		}
+		if len(page) == 0 {
+			t.Fatal("non-empty next cursor with empty page")
+		}
+		cursor = next
+	}
+	return names
+}
+
+func buckets() []bucket {
+	// count desc, name asc tiebreak on the two 5s.
+	return []bucket{
+		{"go", 5}, {"md", 2}, {"py", 5}, {"txt", 1}, {"json", 3},
+	}
+}
+
+func TestPaginateGeneric_CountDescNameAsc(t *testing.T) {
+	names := collectGenericPages(t, buckets, []string{"desc", "asc"}, 2)
+	want := []string{"go", "py", "json", "md", "txt"} // 5,5 (go<py), 3, 2, 1
+	if fmt.Sprint(names) != fmt.Sprint(want) {
+		t.Errorf("paged buckets = %v, want %v", names, want)
+	}
+}
+
+func TestPaginateGeneric_NoLimitNoCursor(t *testing.T) {
+	page, next, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != "" || len(page) != 5 {
+		t.Errorf("want single full page no cursor; got len=%d next=%q", len(page), next)
+	}
+}
+
+func TestPaginateGeneric_OrderMismatchErrors(t *testing.T) {
+	_, next, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "", 2)
+	if err != nil || next == "" {
+		t.Fatalf("setup: err=%v next=%q", err, next)
+	}
+	// Reuse a (desc,asc) cursor against (asc,asc) → reject.
+	if _, _, err := PaginateGeneric(buckets(), bktKeyFn, []string{"asc", "asc"}, next, 2); err == nil {
+		t.Error("expected an error when the cursor's ordering differs from the call's")
+	}
+}
+
+func TestPaginateGeneric_InvalidCursorErrors(t *testing.T) {
+	if _, _, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "@@bad@@", 2); err == nil {
+		t.Error("expected an error for a malformed generic cursor")
+	}
+}
+
 func TestPaginate_TimeKeyRoundTrips(t *testing.T) {
 	t0 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	build := func() []Result {


### PR DESCRIPTION
## Summary

Follow-up to #341, which added cursor pagination to `search` / `search_semantic`. This brings the remaining result-returning tools onto the same stateless keyset cursor, via a shared generic paginator — closing out the full scope of #336.

- **`internal/search/cursor.go`** — `PaginateGeneric[T]`: a stateless keyset paginator over a slice whose order is a tuple of scalar key components (passed as `[]any` so the unexported `cursorVal` stays internal). Sorts into the canonical total order, resumes past an opaque `base64(JSON)` cursor via a monotone `sort.Search`, caps to `limit`, emits `next_cursor` when more remain. The last key component must be unique (path / name / representative) so the order is total.
- **`find_matches`** — `limit` + `cursor` → `next_cursor`. Pages the `(path, line)`-ordered hit list.
- **`stats`** — `limit` + `cursor` → `next_cursor`. Pages buckets in the engine's `(count desc, name asc)` order. When `group_by` is `content_type`, the `content_types` mirror is trimmed to the page so the two views agree.
- **`find_near_duplicates`** — `cursor` → `next_cursor`; `group_limit` becomes the page size. When paginating, the dedup engine is told *not* to truncate (returns all clusters) and the handler pages them by `(count desc, representative asc)` — the first page still matches the legacy top-N-by-count behaviour.

For the three group-shaped tools, the **total counters** (`count` / `total_count` / `group_count`) stay whole-tree; the list field carries the current page. A cursor reused against a different ordering is rejected.

## Testing

- `PaginateGeneric` unit tests: full coverage with no overlap, count-desc/name-asc ordering, order-mismatch rejection, invalid-token rejection.
- MCP-level paging tests through all three tools — full, ordered, non-overlapping coverage; totals verified to stay whole-tree.
- `go test ./...`, `-race` on `search` + `mcpserver`, `go vet`, `go fix` (idempotent), `golangci-lint run ./internal/...` — all clean.
- README documents the per-tool ordering.

## Result

All five result-returning MCP tools (`search`, `search_semantic`, `find_matches`, `stats`, `find_near_duplicates`) now support stable keyset pagination. #336 is fully addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)