### PR TITLE
fix(mcp): reject cross-dimension cursor reuse in stats/find_matches/find_near_duplicates (#347)

### DIFF
--- a/internal/mcpserver/find_matches_tool.go
+++ b/internal/mcpserver/find_matches_tool.go
@@ -188,7 +188,7 @@ func (h *handlers) findMatchesHandler(ctx context.Context, _ *mcp.CallToolReques
 	if in.Cursor != "" || in.Limit > 0 {
 		page, next, perr := search.PaginateGeneric(out.Matches, func(m LineMatch) []any {
 			return []any{m.Path, int64(m.Line)}
-		}, []string{"asc", "asc"}, in.Cursor, in.Limit)
+		}, []string{"asc", "asc"}, "find_matches:"+in.Pattern, in.Cursor, in.Limit)
 		if perr != nil {
 			return nil, FindMatchesOutput{}, fmt.Errorf("cursor: %w", perr)
 		}

--- a/internal/mcpserver/find_near_duplicates_tool.go
+++ b/internal/mcpserver/find_near_duplicates_tool.go
@@ -163,7 +163,7 @@ func (h *handlers) findNearDuplicatesHandler(ctx context.Context, _ *mcp.CallToo
 		if in.Cursor != "" || in.GroupLimit > 0 {
 			page, next, perr := search.PaginateGeneric(out.Groups, func(g NearDuplicateGroupWire) []any {
 				return []any{int64(g.Count), g.Representative}
-			}, []string{"desc", "asc"}, in.Cursor, in.GroupLimit)
+			}, []string{"desc", "asc"}, fmt.Sprintf("neardup:%g", out.Threshold), in.Cursor, in.GroupLimit)
 			if perr != nil {
 				return nil, FindNearDuplicatesOutput{}, fmt.Errorf("cursor: %w", perr)
 			}

--- a/internal/mcpserver/server_pagination_test.go
+++ b/internal/mcpserver/server_pagination_test.go
@@ -205,6 +205,44 @@ func TestStatsTool_CursorPagination(t *testing.T) {
 	}
 }
 
+// TestStatsTool_CursorGroupByMismatchErrors is the #347 regression: a
+// stats cursor issued for one group_by must be REJECTED when reused with
+// a different group_by, not silently return an empty page.
+func TestStatsTool_CursorGroupByMismatchErrors(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "a.md"), "x")
+	mustWrite(t, filepath.Join(dir, "b.json"), "{}")
+	mustWrite(t, filepath.Join(dir, "c.txt"), "x")
+
+	ctx, cs := newSession(t)
+
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "stats",
+		Arguments: StatsInput{Dir: dir, GroupBy: "ext", Limit: 1},
+	})
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	var out StatsOutput
+	mustDecodeStructured(t, res, &out)
+	if out.NextCursor == "" {
+		t.Fatal("expected a next_cursor after page 1")
+	}
+
+	// Reuse the group_by=ext cursor with group_by=content_type → must error
+	// (previously returned an empty page silently — #347).
+	res2, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "stats",
+		Arguments: StatsInput{Dir: dir, GroupBy: "content_type", Limit: 1, Cursor: out.NextCursor},
+	})
+	if err != nil {
+		t.Fatalf("page2 transport: %v", err)
+	}
+	if !res2.IsError {
+		t.Error("expected IsError=true reusing a group_by=ext cursor with group_by=content_type (#347)")
+	}
+}
+
 // TestFindNearDuplicatesTool_CursorPagination pages near-duplicate
 // clusters and asserts every cluster is visited once.
 func TestFindNearDuplicatesTool_CursorPagination(t *testing.T) {

--- a/internal/mcpserver/stats_tool.go
+++ b/internal/mcpserver/stats_tool.go
@@ -157,7 +157,7 @@ func (h *handlers) statsHandler(ctx context.Context, _ *mcp.CallToolRequest, in 
 		if in.Cursor != "" || in.Limit > 0 {
 			page, next, perr := search.PaginateGeneric(out.Groups, func(b StatsBucket) []any {
 				return []any{b.Count, b.Name}
-			}, []string{"desc", "asc"}, in.Cursor, in.Limit)
+			}, []string{"desc", "asc"}, "stats:"+out.GroupBy, in.Cursor, in.Limit)
 			if perr != nil {
 				return nil, StatsOutput{}, fmt.Errorf("cursor: %w", perr)
 			}

--- a/internal/search/cursor.go
+++ b/internal/search/cursor.go
@@ -205,9 +205,13 @@ func cmpCursorVal(a, b cursorVal) int {
 
 // genericCursor is the opaque token for PaginateGeneric. It records the
 // per-component order directions (so a cursor can't be reused against a
-// different ordering) plus the last returned item's full ordered key.
+// different ordering), the caller's SCOPE (the query dimension that
+// defines the ordered set — group_by / pattern / threshold — so a cursor
+// can't be reused against a different one, issue #347), plus the last
+// returned item's full ordered key.
 type genericCursor struct {
 	Orders []string    `json:"o"`
+	Scope  string      `json:"s,omitempty"`
 	Key    []cursorVal `json:"k"`
 }
 
@@ -225,7 +229,14 @@ type genericCursor struct {
 // path / name / representative is the usual choice). orders gives the
 // direction ("asc"/"desc") per component; the tuple compares
 // left-to-right. Issue #336.
-func PaginateGeneric[T any](items []T, keyOf func(T) []any, orders []string, token string, limit int) (page []T, next string, err error) {
+//
+// scope identifies the query dimension that defines the ordered set —
+// the caller passes a stable string built from its distinguishing input
+// (e.g. "stats:ext", "find_matches:TODO", "neardup:0.85"). A cursor
+// carries its scope and a call with a DIFFERENT scope is rejected, so a
+// token issued for one group_by / pattern / threshold can't silently
+// mis-page against another (issue #347). Pass "" to opt out.
+func PaginateGeneric[T any](items []T, keyOf func(T) []any, orders []string, scope, token string, limit int) (page []T, next string, err error) {
 	norm := make([]string, len(orders))
 	for i, o := range orders {
 		norm[i] = normalizeOrder(o)
@@ -248,6 +259,9 @@ func PaginateGeneric[T any](items []T, keyOf func(T) []any, orders []string, tok
 		if derr != nil {
 			return nil, "", derr
 		}
+		if gc.Scope != scope {
+			return nil, "", fmt.Errorf("cursor was issued for %q but this call uses %q — start a fresh page or match the original query", gc.Scope, scope)
+		}
 		if strings.Join(gc.Orders, ",") != strings.Join(norm, ",") {
 			return nil, "", fmt.Errorf("cursor was issued for ordering %v but this call uses %v — start a fresh page or match the original ordering", gc.Orders, norm)
 		}
@@ -259,7 +273,7 @@ func PaginateGeneric[T any](items []T, keyOf func(T) []any, orders []string, tok
 
 	if limit > 0 && len(items) > limit {
 		last := items[limit-1]
-		next = encodeGenericCursor(genericCursor{Orders: norm, Key: keyVals(last)})
+		next = encodeGenericCursor(genericCursor{Orders: norm, Scope: scope, Key: keyVals(last)})
 		return items[:limit], next, nil
 	}
 	return items, "", nil

--- a/internal/search/cursor_test.go
+++ b/internal/search/cursor_test.go
@@ -211,7 +211,7 @@ func collectGenericPages(t *testing.T, build func() []bucket, orders []string, l
 		if pages > 1000 {
 			t.Fatal("generic pagination did not terminate")
 		}
-		page, next, err := PaginateGeneric(build(), bktKeyFn, orders, cursor, limit)
+		page, next, err := PaginateGeneric(build(), bktKeyFn, orders, "test", cursor, limit)
 		if err != nil {
 			t.Fatalf("PaginateGeneric page %d: %v", pages, err)
 		}
@@ -245,7 +245,7 @@ func TestPaginateGeneric_CountDescNameAsc(t *testing.T) {
 }
 
 func TestPaginateGeneric_NoLimitNoCursor(t *testing.T) {
-	page, next, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "", 0)
+	page, next, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "test", "", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,18 +255,32 @@ func TestPaginateGeneric_NoLimitNoCursor(t *testing.T) {
 }
 
 func TestPaginateGeneric_OrderMismatchErrors(t *testing.T) {
-	_, next, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "", 2)
+	_, next, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "test", "", 2)
 	if err != nil || next == "" {
 		t.Fatalf("setup: err=%v next=%q", err, next)
 	}
-	// Reuse a (desc,asc) cursor against (asc,asc) → reject.
-	if _, _, err := PaginateGeneric(buckets(), bktKeyFn, []string{"asc", "asc"}, next, 2); err == nil {
+	// Reuse a (desc,asc) cursor against (asc,asc), same scope → reject.
+	if _, _, err := PaginateGeneric(buckets(), bktKeyFn, []string{"asc", "asc"}, "test", next, 2); err == nil {
 		t.Error("expected an error when the cursor's ordering differs from the call's")
 	}
 }
 
+// TestPaginateGeneric_ScopeMismatchErrors is the #347 regression: a
+// cursor issued for one query dimension (scope) must be rejected when
+// reused against a different dimension, rather than silently mis-paging.
+func TestPaginateGeneric_ScopeMismatchErrors(t *testing.T) {
+	_, next, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "stats:ext", "", 2)
+	if err != nil || next == "" {
+		t.Fatalf("setup: err=%v next=%q", err, next)
+	}
+	// Same ordering, DIFFERENT scope → reject.
+	if _, _, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "stats:language", next, 2); err == nil {
+		t.Error("expected an error when the cursor's scope differs from the call's (#347)")
+	}
+}
+
 func TestPaginateGeneric_InvalidCursorErrors(t *testing.T) {
-	if _, _, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "@@bad@@", 2); err == nil {
+	if _, _, err := PaginateGeneric(buckets(), bktKeyFn, []string{"desc", "asc"}, "test", "@@bad@@", 2); err == nil {
 		t.Error("expected an error for a malformed generic cursor")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #347 (P3, found in the round-3 EPUB dogfood). `PaginateGeneric`'s cursor encoded only the ordering tuple, **not** the query dimension that defines the ordered set. So a cursor issued for one `group_by` / `pattern` / `threshold` could be reused against another and would **silently mis-page**:

```
stats group_by=language limit=3   → page 1 [en, de, fr], next_cursor=C
stats group_by=content_type cursor=C   → {"groups": []}   (empty, NO error)
```

An agent concludes "no more buckets" when it actually reused a wrong-dimension cursor. `search`'s `PaginateResults` already rejects a sort/order mismatch with a clear error — this brings the group-shaped tools to parity.

## Fix

`PaginateGeneric` gains a `scope` string (the caller's distinguishing dimension); the cursor carries it, and a call with a different scope is rejected. Callers pass:
- `stats` → `"stats:"+group_by`
- `find_matches` → `"find_matches:"+pattern`
- `find_near_duplicates` → `"neardup:"+threshold`

## Testing

- `TestPaginateGeneric_ScopeMismatchErrors` (unit) — same ordering, different scope → error.
- `TestStatsTool_CursorGroupByMismatchErrors` (MCP) — the exact repro, now `IsError` instead of a silent empty page.
- `go test ./internal/search ./internal/mcpserver`, `go vet`, `go fix` (idempotent), `golangci-lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)