### PR TITLE
fix(mcp): honor threshold:0 as "no floor" in search_semantic (#349)

### DIFF
--- a/internal/mcpserver/search_semantic_cache_test.go
+++ b/internal/mcpserver/search_semantic_cache_test.go
@@ -58,7 +58,7 @@ func TestSearchSemanticReusesCachedEmbeddings(t *testing.T) {
 		t.Helper()
 		res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 			Name:      "search_semantic",
-			Arguments: SearchSemanticInput{Query: "cyberpunk hacker", Dir: dir, Threshold: fptr(0.4), Limit: 10},
+			Arguments: SearchSemanticInput{Query: "cyberpunk hacker", Dir: dir, Threshold: new(0.4), Limit: 10},
 		})
 		if err != nil {
 			t.Fatalf("%s: CallTool: %v", label, err)
@@ -157,7 +157,7 @@ func TestSearchSemanticSurfacesEmbedErrors(t *testing.T) {
 
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "search_semantic",
-		Arguments: SearchSemanticInput{Query: "anything", Dir: dir, Threshold: fptr(0.4), Limit: 10},
+		Arguments: SearchSemanticInput{Query: "anything", Dir: dir, Threshold: new(0.4), Limit: 10},
 	})
 	if err != nil {
 		t.Fatalf("CallTool: %v", err)

--- a/internal/mcpserver/search_semantic_cache_test.go
+++ b/internal/mcpserver/search_semantic_cache_test.go
@@ -58,7 +58,7 @@ func TestSearchSemanticReusesCachedEmbeddings(t *testing.T) {
 		t.Helper()
 		res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 			Name:      "search_semantic",
-			Arguments: SearchSemanticInput{Query: "cyberpunk hacker", Dir: dir, Threshold: 0.4, Limit: 10},
+			Arguments: SearchSemanticInput{Query: "cyberpunk hacker", Dir: dir, Threshold: fptr(0.4), Limit: 10},
 		})
 		if err != nil {
 			t.Fatalf("%s: CallTool: %v", label, err)
@@ -157,7 +157,7 @@ func TestSearchSemanticSurfacesEmbedErrors(t *testing.T) {
 
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "search_semantic",
-		Arguments: SearchSemanticInput{Query: "anything", Dir: dir, Threshold: 0.4, Limit: 10},
+		Arguments: SearchSemanticInput{Query: "anything", Dir: dir, Threshold: fptr(0.4), Limit: 10},
 	})
 	if err != nil {
 		t.Fatalf("CallTool: %v", err)

--- a/internal/mcpserver/search_semantic_tool.go
+++ b/internal/mcpserver/search_semantic_tool.go
@@ -23,7 +23,7 @@ type SearchSemanticInput struct {
 	Dir             string   `json:"dir,omitempty" jsonschema:"Directory to search in. Defaults to '.'. Ignored when 'dirs' is non-empty."`
 	Dirs            []string `json:"dirs,omitempty" jsonschema:"Multiple directories to search in one call. When non-empty, takes precedence over 'dir'."`
 	Expr            string   `json:"expr,omitempty" jsonschema:"Optional CEL pre-filter using the regular search vocabulary (is_pdf, is_office, etc.). When set, the threshold is AND-combined: only files matching the CEL filter AND with similarity >= threshold are returned."`
-	Threshold       float64  `json:"threshold,omitempty" jsonschema:"Minimum cosine similarity (0..1) for a match. Default 0.5. Higher = stricter. 0.7 is a useful tightness for 'definitely about this topic'; 0.4-0.5 catches related-but-tangential content. Implemented by AND-ing 'similarity >= <value>' onto the expr filter, so it combines with (does not replace) any similarity comparison in your expr."`
+	Threshold       *float64 `json:"threshold,omitempty" jsonschema:"Minimum cosine similarity (0..1) for a match. OMITTED = default 0.5. Pass 0 explicitly for NO floor (return every ranked result, e.g. when you'll page or rank yourself). Higher = stricter; 0.7 is 'definitely about this topic', 0.4-0.5 catches related-but-tangential. Implemented by AND-ing 'similarity >= <value>' onto the expr filter, so it combines with (does not replace) any similarity comparison in your expr."`
 	Limit           int      `json:"limit,omitempty" jsonschema:"Cap on returned matches (top-K ranked by similarity desc). Default 50. When the ranked set is truncated by limit, the response carries an opaque next_cursor — pass it back as 'cursor' to fetch the next page."`
 	Cursor          string   `json:"cursor,omitempty" jsonschema:"Opaque pagination token from a previous response's next_cursor. Resumes the similarity-ranked result set immediately after the last item of the prior page. Re-embeds the query and re-walks each page (file vectors are cached, so the re-walk is cheap); paging is stable under an unchanged tree. Use the SAME query/threshold for consistent paging."`
 	Hybrid          bool     `json:"hybrid,omitempty" jsonschema:"Hybrid keyword+semantic ranking: fuse the BM25 keyword ranking with the embedding-similarity ranking via reciprocal-rank fusion (no manual weights). The keyword query defaults to 'query' unless keyword_query is set. Catches both exact-term hits and paraphrase. Issue #335."`
@@ -95,9 +95,13 @@ func (h *handlers) searchSemanticHandler(ctx context.Context, req *mcp.CallToolR
 		server = h.defaultEmbeddingServer
 	}
 
-	threshold := in.Threshold
-	if threshold == 0 {
-		threshold = 0.5
+	// Nil (omitted) → the 0.5 default. An explicit value — INCLUDING 0 —
+	// is honoured, so callers can pass threshold:0 for "no floor"
+	// (issue #349). Mirrors the CLI's --similarity-threshold, which
+	// already honours 0, and the timeout_seconds nil-vs-0 distinction.
+	threshold := 0.5
+	if in.Threshold != nil {
+		threshold = *in.Threshold
 	}
 	limit := in.Limit
 	if limit == 0 {

--- a/internal/mcpserver/server_ann_test.go
+++ b/internal/mcpserver/server_ann_test.go
@@ -45,7 +45,7 @@ func semCall(t *testing.T, ctx context.Context, cs *mcp.ClientSession, dir strin
 	t.Helper()
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "search_semantic",
-		Arguments: SearchSemanticInput{Query: "anything", Dir: dir, Threshold: fptr(0.4), Limit: 50},
+		Arguments: SearchSemanticInput{Query: "anything", Dir: dir, Threshold: new(0.4), Limit: 50},
 	})
 	if err != nil {
 		t.Fatalf("CallTool: %v", err)
@@ -95,8 +95,8 @@ func TestSearchSemantic_AnnInvalidatedByNewFile(t *testing.T) {
 
 	ctx, cs := annSession(t)
 
-	_ = semCall(t, ctx, cs, dir)        // cold, warms
-	warm := semCall(t, ctx, cs, dir)    // warm
+	_ = semCall(t, ctx, cs, dir)     // cold, warms
+	warm := semCall(t, ctx, cs, dir) // warm
 	if !warm.AnnUsed {
 		t.Fatalf("expected warm fast path before the new file")
 	}

--- a/internal/mcpserver/server_ann_test.go
+++ b/internal/mcpserver/server_ann_test.go
@@ -45,7 +45,7 @@ func semCall(t *testing.T, ctx context.Context, cs *mcp.ClientSession, dir strin
 	t.Helper()
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "search_semantic",
-		Arguments: SearchSemanticInput{Query: "anything", Dir: dir, Threshold: 0.4, Limit: 50},
+		Arguments: SearchSemanticInput{Query: "anything", Dir: dir, Threshold: fptr(0.4), Limit: 50},
 	})
 	if err != nil {
 		t.Fatalf("CallTool: %v", err)

--- a/internal/mcpserver/server_bm25_test.go
+++ b/internal/mcpserver/server_bm25_test.go
@@ -110,7 +110,7 @@ func TestSearchSemanticTool_Hybrid(t *testing.T) {
 			Query:     marker + " attention mechanism",
 			Dir:       dir,
 			Hybrid:    true,
-			Threshold: 0.0, // keep both files so RRF has two to fuse
+			Threshold: fptr(0.0), // keep both files so RRF has two to fuse
 			Limit:     10,
 		},
 	})

--- a/internal/mcpserver/server_bm25_test.go
+++ b/internal/mcpserver/server_bm25_test.go
@@ -110,7 +110,7 @@ func TestSearchSemanticTool_Hybrid(t *testing.T) {
 			Query:     marker + " attention mechanism",
 			Dir:       dir,
 			Hybrid:    true,
-			Threshold: fptr(0.0), // keep both files so RRF has two to fuse
+			Threshold: new(0.0), // keep both files so RRF has two to fuse
 			Limit:     10,
 		},
 	})

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -38,6 +38,10 @@ func newSession(t *testing.T) (context.Context, *mcp.ClientSession) {
 	return ctx, cs
 }
 
+// fptr returns a pointer to f — for the nullable SearchSemanticInput.Threshold
+// (#349), where nil means "default 0.5" and an explicit value (incl 0) is honoured.
+func fptr(f float64) *float64 { return &f }
+
 func TestSearchTool(t *testing.T) {
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "a.md"), "# hello\n\nbody body body body body\n")

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -38,10 +38,6 @@ func newSession(t *testing.T) (context.Context, *mcp.ClientSession) {
 	return ctx, cs
 }
 
-// fptr returns a pointer to f — for the nullable SearchSemanticInput.Threshold
-// (#349), where nil means "default 0.5" and an explicit value (incl 0) is honoured.
-func fptr(f float64) *float64 { return &f }
-
 func TestSearchTool(t *testing.T) {
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "a.md"), "# hello\n\nbody body body body body\n")

--- a/internal/mcpserver/server_threshold_test.go
+++ b/internal/mcpserver/server_threshold_test.go
@@ -78,7 +78,7 @@ func TestSearchSemantic_ThresholdZeroIsNoFloor(t *testing.T) {
 	}
 
 	// Explicit threshold:0 → no floor → both files returned.
-	zero := call(SearchSemanticInput{Query: marker, Dir: dir, Threshold: fptr(0), Limit: 10})
+	zero := call(SearchSemanticInput{Query: marker, Dir: dir, Threshold: new(0.0), Limit: 10})
 	if zero.SimilarityThreshold != 0 {
 		t.Errorf("threshold:0: similarity_threshold=%v want 0 (not coerced to 0.5) — #349", zero.SimilarityThreshold)
 	}

--- a/internal/mcpserver/server_threshold_test.go
+++ b/internal/mcpserver/server_threshold_test.go
@@ -1,0 +1,88 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/richardwooding/file-search-on/internal/index"
+)
+
+// TestSearchSemantic_ThresholdZeroIsNoFloor is the #349 regression: an
+// OMITTED threshold defaults to 0.5 (drops weak matches), while an
+// EXPLICIT threshold:0 means "no floor" and returns every ranked file —
+// previously 0 was coerced to 0.5 so callers couldn't express it.
+func TestSearchSemantic_ThresholdZeroIsNoFloor(t *testing.T) {
+	dir := t.TempDir()
+	const marker = "transformer"
+	mustWrite(t, filepath.Join(dir, "match.md"), "# p\n\n"+strings.Repeat(marker+" attention ", 20))
+	mustWrite(t, filepath.Join(dir, "other.md"), "# m\n\n"+strings.Repeat("gardening compost ", 20))
+
+	// match.md → query-aligned [1,0,0] (sim 1.0); other.md → orthogonal
+	// [0,1,0] (sim 0.0). With the 0.5 default, only match.md survives; with
+	// no floor, both do.
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		vec := []float32{0, 1, 0}
+		if strings.Contains(req.Input, marker) {
+			vec = []float32{1, 0, 0}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": [][]float32{vec}})
+	}))
+	t.Cleanup(ollama.Close)
+
+	ctx := t.Context()
+	server := New("test", index.NewMemory(), 0, EmbedDefaults{Server: ollama.URL, Model: "mock"})
+	t1, t2 := mcp.NewInMemoryTransports()
+	ss, err := server.Connect(ctx, t1, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	t.Cleanup(func() { _ = ss.Close() })
+	client := mcp.NewClient(&mcp.Implementation{Name: "c", Version: "0"}, nil)
+	cs, err := client.Connect(ctx, t2, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	call := func(in SearchSemanticInput) SearchSemanticOutput {
+		t.Helper()
+		res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: "search_semantic", Arguments: in})
+		if err != nil {
+			t.Fatalf("CallTool: %v", err)
+		}
+		if res.IsError {
+			t.Fatalf("tool error: %v", res.GetError())
+		}
+		var out SearchSemanticOutput
+		mustDecodeStructured(t, res, &out)
+		return out
+	}
+
+	// Omitted threshold → default 0.5 → only match.md (sim 1.0) survives.
+	def := call(SearchSemanticInput{Query: marker, Dir: dir, Limit: 10})
+	if def.SimilarityThreshold != 0.5 {
+		t.Errorf("omitted threshold: similarity_threshold=%v want 0.5", def.SimilarityThreshold)
+	}
+	if def.Count != 1 {
+		t.Errorf("omitted threshold (0.5): count=%d want 1 (orthogonal file dropped); %+v", def.Count, def.Matches)
+	}
+
+	// Explicit threshold:0 → no floor → both files returned.
+	zero := call(SearchSemanticInput{Query: marker, Dir: dir, Threshold: fptr(0), Limit: 10})
+	if zero.SimilarityThreshold != 0 {
+		t.Errorf("threshold:0: similarity_threshold=%v want 0 (not coerced to 0.5) — #349", zero.SimilarityThreshold)
+	}
+	if zero.Count != 2 {
+		t.Errorf("threshold:0 (no floor): count=%d want 2 (both files) — #349", zero.Count)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #349 (P3, found in the round-3 EPUB dogfood). The MCP `search_semantic` tool coerced `threshold == 0` to the 0.5 default (`if threshold == 0 { threshold = 0.5 }`), so an agent couldn't ask for **"no floor / return every ranked result"** — passing `0` silently became `0.5`. The CLI `--similarity-threshold 0` already honors 0 (the round-1 #7 fix), so the two surfaces disagreed.

## Fix

Make `Threshold` a `*float64`: **nil (omitted) → default 0.5**; an **explicit value including 0 is honored**. Mirrors the CLI and the existing `timeout_seconds` nil-vs-0 distinction.

## Testing

- `TestSearchSemantic_ThresholdZeroIsNoFloor` (discriminating mock embedder): omitted threshold → `similarity_threshold=0.5`, drops a sim-0 file (count 1); explicit `threshold:0` → `similarity_threshold=0`, returns it (count 2).
- Existing semantic tests updated to the pointer (`fptr` helper).
- `go vet`, `golangci-lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)