### PR TITLE
fix(index): surface dropped-oversize Puts via a dedicated counter (#348)

### DIFF
--- a/cmd/file-search-on/search_cmd.go
+++ b/cmd/file-search-on/search_cmd.go
@@ -254,6 +254,13 @@ func (s *SearchCmd) Run(ctx context.Context) error {
 		st := idx.Stats()
 		fmt.Fprintf(os.Stderr, "index: %d hits, %d misses, %d stored, %d stale, %d errors\n",
 			st.Hits, st.Misses, st.Puts, st.Stales, st.Errors)
+		// Surface dropped-oversize Puts when any occur — a non-zero count
+		// means a payload (e.g. chunked embedding vectors) won't persist
+		// and re-computes every run. Silent before #348.
+		if st.EntryOversize > 0 {
+			fmt.Fprintf(os.Stderr, "index: %d entr%s dropped (encoded size over the cap; will re-compute each run)\n",
+				st.EntryOversize, map[bool]string{true: "y", false: "ies"}[st.EntryOversize == 1])
+		}
 		// Print body-cache line only when body caching actually fired
 		// — keeps the footer clean for callers that don't use --body.
 		if st.BodyHits+st.BodyMisses+st.BodyPuts+st.BodyStales+st.BodyEvictions+st.BodyOversize+st.BodyErrors > 0 {

--- a/internal/index/bbolt.go
+++ b/internal/index/bbolt.go
@@ -239,7 +239,16 @@ func (b *boltIndex) Put(path string, e *Entry) error {
 	}
 	val, err := encodeEntry(e)
 	if err != nil {
-		b.stats.errors.Add(1)
+		// An entry over maxEntryBytes is dropped — recoverable as a cache
+		// miss, but track it on a DEDICATED counter (not the generic
+		// errors bucket) so a silently-undersized cap is diagnosable via
+		// index_stats. This is how #346 (chunked 768-d vectors > the old
+		// 256 KiB cap → never persist) stayed invisible. Issue #348.
+		if errors.Is(err, errEntryTooLarge) {
+			b.stats.entryOversize.Add(1)
+		} else {
+			b.stats.errors.Add(1)
+		}
 		return nil
 	}
 	// Non-blocking enqueue — never throttle the walker on the cache.
@@ -340,6 +349,7 @@ func (b *boltIndex) Stats() Stats {
 		Puts:                 b.stats.puts.Load(),
 		Stales:               b.stats.stales.Load(),
 		Errors:               b.stats.errors.Load(),
+		EntryOversize:        b.stats.entryOversize.Load(),
 		BodyHits:             b.stats.bodyHits.Load(),
 		BodyMisses:           b.stats.bodyMisses.Load(),
 		BodyPuts:             b.stats.bodyPuts.Load(),

--- a/internal/index/bbolt_test.go
+++ b/internal/index/bbolt_test.go
@@ -172,3 +172,39 @@ func TestBoltRejectsRelativePath(t *testing.T) {
 		t.Errorf("expected Errors>0 for relative path; got %+v", st)
 	}
 }
+
+// TestBoltEntryOversizeCounter is the #348 regression: an entry whose
+// encoded form exceeds the cap is dropped on a DEDICATED EntryOversize
+// counter, not the generic Errors bucket — so a too-small cap (the #346
+// class of bug) is diagnosable via index_stats instead of silent.
+func TestBoltEntryOversizeCounter(t *testing.T) {
+	dir := t.TempDir()
+	idx, err := Open(filepath.Join(dir, "idx.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = idx.Close() }()
+
+	// An Extra value guaranteed to blow past maxEntryBytes.
+	huge := make([]byte, 0, maxEntryBytes+1024)
+	for len(huge) < maxEntryBytes+1024 {
+		huge = append(huge, 'x')
+	}
+	e := &Entry{
+		Size:            1,
+		ModTimeUnixNano: 1,
+		ContentType:     "text",
+		Extra:           map[string]any{"title": string(huge)},
+	}
+	if err := idx.Put("/abs/oversize.txt", e); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	st := idx.Stats()
+	if st.EntryOversize != 1 {
+		t.Errorf("EntryOversize = %d, want 1 (oversize Put must hit the dedicated counter, #348)", st.EntryOversize)
+	}
+	if st.Errors != 0 {
+		t.Errorf("Errors = %d, want 0 (an oversize drop is NOT a generic error)", st.Errors)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -188,6 +188,13 @@ type Stats struct {
 	Puts   uint64
 	Stales uint64
 	Errors uint64
+	// EntryOversize counts Puts dropped because the encoded Entry exceeded
+	// maxEntryBytes — a recoverable cache miss, but a non-zero value means
+	// a real payload (e.g. chunked high-dim embedding vectors, #346) can't
+	// persist and is re-computed every run. Distinct from Errors so the
+	// silent drop is visible in index_stats. bbolt-only (the in-memory
+	// backend stores *Entry without encoding, so it has no size cap). #348.
+	EntryOversize uint64
 
 	BodyHits      uint64 // successful LookupBody
 	BodyMisses    uint64 // LookupBody with no entry

--- a/internal/index/memory.go
+++ b/internal/index/memory.go
@@ -17,11 +17,12 @@ type memoryIndex struct {
 }
 
 type memoryStats struct {
-	hits   atomic.Uint64
-	misses atomic.Uint64
-	puts   atomic.Uint64
-	stales atomic.Uint64
-	errors atomic.Uint64
+	hits          atomic.Uint64
+	misses        atomic.Uint64
+	puts          atomic.Uint64
+	stales        atomic.Uint64
+	errors        atomic.Uint64
+	entryOversize atomic.Uint64 // Put dropped: encoded Entry > maxEntryBytes (#346/#348)
 
 	bodyHits      atomic.Uint64
 	bodyMisses    atomic.Uint64
@@ -127,6 +128,7 @@ func (m *memoryIndex) Stats() Stats {
 		Puts:                 m.stats.puts.Load(),
 		Stales:               m.stats.stales.Load(),
 		Errors:               m.stats.errors.Load(),
+		EntryOversize:        m.stats.entryOversize.Load(),
 		BodyHits:             m.stats.bodyHits.Load(),
 		BodyMisses:           m.stats.bodyMisses.Load(),
 		BodyPuts:             m.stats.bodyPuts.Load(),

--- a/internal/mcpserver/index_stats_tool.go
+++ b/internal/mcpserver/index_stats_tool.go
@@ -20,6 +20,11 @@ type IndexStatsOutput struct {
 	Puts   uint64 `json:"puts"`
 	Stales uint64 `json:"stales"`
 	Errors uint64 `json:"errors"`
+	// EntryOversize: attribute Puts dropped because the encoded entry
+	// exceeded the index size cap. Non-zero means a real payload (e.g.
+	// chunked embedding vectors) isn't persisting and re-computes every
+	// run. bbolt-only. Issue #348.
+	EntryOversize uint64 `json:"entry_oversize,omitempty"`
 
 	BodyHits      uint64 `json:"body_hits"`
 	BodyMisses    uint64 `json:"body_misses"`
@@ -57,6 +62,7 @@ func (h *handlers) indexStatsHandler(_ context.Context, _ *mcp.CallToolRequest, 
 		Puts:          st.Puts,
 		Stales:        st.Stales,
 		Errors:        st.Errors,
+		EntryOversize: st.EntryOversize,
 		BodyHits:      st.BodyHits,
 		BodyMisses:    st.BodyMisses,
 		BodyPuts:      st.BodyPuts,


### PR DESCRIPTION
## Summary

Closes #348 (P3 observability, found in the round-3 EPUB dogfood). When an encoded `Entry` exceeds `maxEntryBytes` the Put is dropped and only the generic `Stats.Errors` was bumped — no detail. That's exactly how **#346** (chunked 768-d vectors over the old 256 KiB cap → never persist → re-embed every run) stayed invisible: `index_stats` showed a number with no cause.

## Fix

Add a dedicated **`EntryOversize`** counter (mirroring the existing `BodyOversize`), incremented on `errEntryTooLarge` instead of the generic `errors` bucket. Surfaced in:
- the **`index_stats`** MCP tool (`entry_oversize` field)
- the **CLI footer** — `"N entries dropped (encoded size over the cap; will re-compute each run)"`, only when non-zero

bbolt-only — the in-memory backend stores `*Entry` without encoding, so it has no size cap. A non-zero `entry_oversize` now points straight at "a real payload isn't persisting" instead of hiding in `errors`.

## Testing

- `TestBoltEntryOversizeCounter` — an oversize Put bumps `EntryOversize`, leaves `Errors` at 0.
- `go test ./internal/index ./internal/mcpserver ./cmd/...`, `go vet`, `go fix` (idempotent), `golangci-lint` — clean.

## Deferred

The issue also mentioned a **progress indicator for long cold CLI semantic walks**. That needs a progress callback threaded through the walker (more than this observability counter) — left as a separate enhancement so this PR stays focused on the silent-error half (the part that made #346 hard to find).

🤖 Generated with [Claude Code](https://claude.com/claude-code)