### PR TITLE
chore: stop tracking the built file-search-on binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 *.so
 *.dylib
 
+# The CLI binary built via `go build -o file-search-on ./cmd/file-search-on`
+# (root-anchored so it doesn't match the cmd/file-search-on/ source dir).
+/file-search-on
+
 # But the binary content-type fixtures are committed.
 !internal/content/testdata/fixtures/sample.exe
 !internal/content/testdata/fixtures/sample.macho


### PR DESCRIPTION
## What

The `file-search-on` CLI binary was accidentally committed in `77593a1`. It's a build artifact produced by `go build -o file-search-on ./cmd/file-search-on` and shouldn't be in version control.

## How

- `git rm --cached file-search-on` — removes it from tracking without deleting anyone's local build
- Adds a root-anchored `/file-search-on` entry to `.gitignore` (anchored with a leading `/` so it does **not** match the `cmd/file-search-on/` source directory)

## Verification

- `git check-ignore file-search-on` → matches (ignored)
- `cmd/file-search-on/` source directory is unaffected by the anchored pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)