### PR TITLE
refactor(content): split extractTreeSitterSymbols + table-ize isSourceTestFile (#372)

### DIFF
--- a/internal/content/source_symbols_treesitter.go
+++ b/internal/content/source_symbols_treesitter.go
@@ -276,10 +276,29 @@ func extractTreeSitterSymbols(language string, src []byte) (functions, types, im
 		return nil, nil, nil, nil, nil, nil
 	}
 
-	// funcSpans: named function definitions with their byte span, for
-	// per-function call attribution by containment (#368).
-	var funcSpans []tsFuncSpan
+	// funcSpans (named function definitions + byte/line span) are shared
+	// by call attribution (#368) and complexity (#364).
+	functions, types, funcSpans := tsCollectDefs(tl, tree, src)
+	imports = tsCollectImports(tl, tree, src)
+	references, callEdges = tsCollectReferences(tl, tree, src, funcSpans)
+	complexityRows = tsComplexityRows(tl, tree, funcSpans)
 
+	return dedupeStrings(functions), dedupeStrings(types), dedupeStrings(imports),
+		dedupeStrings(references), dedupeStrings(callEdges), complexityRows
+}
+
+// newFuncSpan builds a tsFuncSpan from a definition node (byte + 1-based
+// line span).
+func newFuncSpan(name string, n *ts.Node) tsFuncSpan {
+	return tsFuncSpan{
+		name: name, start: n.StartByte(), end: n.EndByte(),
+		startLine: n.StartPoint().Row + 1, endLine: n.EndPoint().Row + 1,
+	}
+}
+
+// tsCollectDefs gathers function / type names from the bundled tags query
+// plus the supplemental def + span queries, and the function spans.
+func tsCollectDefs(tl *tsLang, tree *ts.Tree, src []byte) (functions, types []string, funcSpans []tsFuncSpan) {
 	for _, m := range tagsMatches(tl, tree) {
 		var name, kind string
 		var defNode *ts.Node
@@ -299,15 +318,15 @@ func extractTreeSitterSymbols(language string, src []byte) (functions, types, im
 		case "function", "method", "macro", "constructor":
 			functions = append(functions, name)
 			if defNode != nil {
-				funcSpans = append(funcSpans, tsFuncSpan{name: name, start: defNode.StartByte(), end: defNode.EndByte(), startLine: defNode.StartPoint().Row + 1, endLine: defNode.EndPoint().Row + 1})
+				funcSpans = append(funcSpans, newFuncSpan(name, defNode))
 			}
 		case "class", "struct", "interface", "enum", "trait", "type", "module", "union", "protocol", "namespace":
 			types = append(types, name)
 		}
 	}
 
-	// Supplemental definition query for languages with weak bundled tags
-	// (ruby / swift / kotlin): captures @function / @type directly.
+	// Supplemental def query for languages with weak/empty bundled tags
+	// (php / perl / ruby / swift / kotlin): captures @function / @type.
 	if tl.defQuery != nil {
 		for _, m := range tl.defQuery.Execute(tree) {
 			for _, c := range m.Captures {
@@ -321,24 +340,8 @@ func extractTreeSitterSymbols(language string, src []byte) (functions, types, im
 		}
 	}
 
-	if tl.importQuery != nil {
-		for _, m := range tl.importQuery.Execute(tree) {
-			for _, c := range m.Captures {
-				if c.Name == "import" {
-					p := strings.Trim(c.Text(src), "\"'`<>")
-					// Some grammars (Scala) have no single import-path node,
-					// so we capture the whole declaration; strip the keyword.
-					p = strings.TrimSpace(strings.TrimPrefix(p, "import "))
-					if p != "" {
-						imports = append(imports, p)
-					}
-				}
-			}
-		}
-	}
-
-	// Supplemental function-span query (ruby/swift/kotlin) for languages
-	// whose bundled tags query doesn't carry a function span.
+	// Supplemental function-span query for grammars whose tags query
+	// carries no function span (ruby / swift / kotlin).
 	if tl.spanQuery != nil {
 		for _, m := range tl.spanQuery.Execute(tree) {
 			var name string
@@ -352,60 +355,81 @@ func extractTreeSitterSymbols(language string, src []byte) (functions, types, im
 				}
 			}
 			if name != "" && defNode != nil {
-				funcSpans = append(funcSpans, tsFuncSpan{name: name, start: defNode.StartByte(), end: defNode.EndByte(), startLine: defNode.StartPoint().Row + 1, endLine: defNode.EndPoint().Row + 1})
+				funcSpans = append(funcSpans, newFuncSpan(name, defNode))
 			}
 		}
 	}
+	return functions, types, funcSpans
+}
 
-	// Call sites (callee name + position), for both the flat references
-	// list and per-function call attribution.
-	type callSite struct {
-		name string
-		pos  uint32
+// tsCollectImports gathers import paths via the per-language import query.
+func tsCollectImports(tl *tsLang, tree *ts.Tree, src []byte) (imports []string) {
+	if tl.importQuery == nil {
+		return nil
 	}
-	var calls []callSite
-	if tl.refQuery != nil {
-		for _, m := range tl.refQuery.Execute(tree) {
-			for _, c := range m.Captures {
-				if c.Name == "reference" {
-					if r := c.Text(src); r != "" {
-						references = append(references, r)
-						calls = append(calls, callSite{name: r, pos: c.Node.StartByte()})
-					}
-				}
+	for _, m := range tl.importQuery.Execute(tree) {
+		for _, c := range m.Captures {
+			if c.Name != "import" {
+				continue
+			}
+			p := strings.Trim(c.Text(src), "\"'`<>")
+			// Some grammars (Scala) have no single import-path node, so we
+			// capture the whole declaration; strip the keyword.
+			if p = strings.TrimSpace(strings.TrimPrefix(p, "import ")); p != "" {
+				imports = append(imports, p)
 			}
 		}
 	}
+	return imports
+}
 
-	// Attribute each call to the innermost enclosing function span.
-	for _, cs := range calls {
-		caller := innermostFuncSpan(funcSpans, cs.pos)
-		if caller != "" {
-			callEdges = append(callEdges, caller+"\x00"+cs.name)
-		}
+// tsCollectReferences gathers call-site callee names (the flat references
+// list) and attributes each to the innermost enclosing function span as a
+// "caller\x00callee" edge.
+func tsCollectReferences(tl *tsLang, tree *ts.Tree, src []byte, funcSpans []tsFuncSpan) (references, callEdges []string) {
+	if tl.refQuery == nil {
+		return nil, nil
 	}
-
-	// Cyclomatic complexity per function: 1 + decision points contained
-	// in the innermost enclosing span (#364).
-	if tl.decisionQuery != nil && len(funcSpans) > 0 {
-		decisionCount := make([]int, len(funcSpans))
-		for _, m := range tl.decisionQuery.Execute(tree) {
-			for _, c := range m.Captures {
-				if c.Name != "decision" {
-					continue
-				}
-				if i := innermostFuncSpanIndex(funcSpans, c.Node.StartByte()); i >= 0 {
-					decisionCount[i]++
-				}
+	for _, m := range tl.refQuery.Execute(tree) {
+		for _, c := range m.Captures {
+			if c.Name != "reference" {
+				continue
+			}
+			r := c.Text(src)
+			if r == "" {
+				continue
+			}
+			references = append(references, r)
+			if caller := innermostFuncSpan(funcSpans, c.Node.StartByte()); caller != "" {
+				callEdges = append(callEdges, caller+"\x00"+r)
 			}
 		}
-		for i, s := range funcSpans {
-			complexityRows = append(complexityRows,
-				fmt.Sprintf("%s\x00%d\x00%d\x00%d", s.name, 1+decisionCount[i], s.startLine, s.endLine))
+	}
+	return references, callEdges
+}
+
+// tsComplexityRows computes per-function cyclomatic complexity (1 +
+// decision points contained in the innermost enclosing span) as
+// "name\x00complexity\x00startLine\x00endLine" rows (#364).
+func tsComplexityRows(tl *tsLang, tree *ts.Tree, funcSpans []tsFuncSpan) (rows []string) {
+	if tl.decisionQuery == nil || len(funcSpans) == 0 {
+		return nil
+	}
+	decisionCount := make([]int, len(funcSpans))
+	for _, m := range tl.decisionQuery.Execute(tree) {
+		for _, c := range m.Captures {
+			if c.Name != "decision" {
+				continue
+			}
+			if i := innermostFuncSpanIndex(funcSpans, c.Node.StartByte()); i >= 0 {
+				decisionCount[i]++
+			}
 		}
 	}
-
-	return dedupeStrings(functions), dedupeStrings(types), dedupeStrings(imports), dedupeStrings(references), dedupeStrings(callEdges), complexityRows
+	for i, s := range funcSpans {
+		rows = append(rows, fmt.Sprintf("%s\x00%d\x00%d\x00%d", s.name, 1+decisionCount[i], s.startLine, s.endLine))
+	}
+	return rows
 }
 
 // tagsMatches runs the bundled tags query, or returns nil when the

--- a/internal/content/sourcetype.go
+++ b/internal/content/sourcetype.go
@@ -227,87 +227,88 @@ func symbolExtractorWired(language string) bool {
 //	Scala      *Spec.scala, *Test.scala
 //	Shell      *_test.sh, test_*.sh
 //	Elixir     *_test.exs
+// testConvention is a per-language test-filename rule: a basename matches
+// if it ends with any suffix, OR (when prefixExt is set) it starts with a
+// prefix AND ends with prefixExt. All values are lowercase.
+type testConvention struct {
+	suffixes  []string
+	prefixes  []string
+	prefixExt string
+}
+
+// jsTestSuffixes is the `.test.<ext>` / `.spec.<ext>` set shared by JS/TS.
+var jsTestSuffixes = func() []string {
+	var s []string
+	for _, ext := range []string{".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx"} {
+		s = append(s, ".test"+ext, ".spec"+ext)
+	}
+	return s
+}()
+
+// testFileConventions drives isSourceTestFile for the suffix/prefix-shaped
+// languages. Rust (tests/ directory) and C/C++ (stem-based) are handled
+// specially in isSourceTestFile. See the doc comment for the source of
+// each convention.
+var testFileConventions = map[string]testConvention{
+	"go":         {suffixes: []string{"_test.go"}},
+	"python":     {suffixes: []string{"_test.py"}, prefixes: []string{"test_"}, prefixExt: ".py"},
+	"javascript": {suffixes: jsTestSuffixes},
+	"typescript": {suffixes: jsTestSuffixes},
+	"java":       {suffixes: []string{"test.java", "tests.java", "it.java"}},
+	"ruby":       {suffixes: []string{"_spec.rb", "_test.rb"}},
+	"swift":      {suffixes: []string{"tests.swift", "test.swift"}},
+	"kotlin":     {suffixes: []string{"test.kt", "tests.kt"}},
+	"scala":      {suffixes: []string{"spec.scala", "test.scala"}},
+	"shell":      {suffixes: []string{"_test.sh"}, prefixes: []string{"test_"}, prefixExt: ".sh"},
+	"elixir":     {suffixes: []string{"_test.exs"}},
+	"csharp":     {suffixes: []string{"test.cs", "tests.cs"}},
+	"php":        {suffixes: []string{"test.php"}},
+	"perl":       {suffixes: []string{".t"}}, // Test::More: the .t extension IS the convention
+	"r":          {prefixes: []string{"test-", "test_"}, prefixExt: ".r"},
+	"vb":         {suffixes: []string{"test.vb", "tests.vb"}},
+	"matlab":     {suffixes: []string{"test.m", "tests.m"}},
+}
+
+// cTestExts are the C/C++ source extensions whose stem is checked for a
+// test prefix/suffix.
+var cTestExts = []string{".c", ".h", ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"}
+
 func isSourceTestFile(language, path string) bool {
 	base := strings.ToLower(filepathBase(path))
 	switch language {
-	case "go":
-		return strings.HasSuffix(base, "_test.go")
-	case "python":
-		return strings.HasPrefix(base, "test_") && strings.HasSuffix(base, ".py") ||
-			strings.HasSuffix(base, "_test.py")
-	case "javascript", "typescript":
-		// Order matters — check longest suffixes first to avoid
-		// claiming ".test.tsx" only by ".ts" stripping logic. Each
-		// supported extension gets a `.test.<ext>` and `.spec.<ext>`
-		// variant.
-		for _, ext := range []string{".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx"} {
-			if strings.HasSuffix(base, ".test"+ext) ||
-				strings.HasSuffix(base, ".spec"+ext) {
-				return true
-			}
-		}
-		return false
 	case "rust":
-		// Integration tests live under a `tests/` directory anywhere
-		// in the path. We can't tell from the basename alone — match
-		// either a leading "tests/" or a "/tests/" segment.
+		// Integration tests live under a `tests/` directory anywhere in
+		// the path — not detectable from the basename alone.
 		lp := strings.ToLower(path)
 		return strings.HasSuffix(base, ".rs") &&
 			(strings.Contains(lp, "/tests/") || strings.HasPrefix(lp, "tests/"))
 	case "c", "cpp":
-		exts := []string{".c", ".h", ".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"}
-		for _, ext := range exts {
-			if before, ok := strings.CutSuffix(base, ext); ok {
-				stem := before
+		// Stem-based: test_foo.c / foo_test.c / foo_tests.cpp.
+		for _, ext := range cTestExts {
+			if stem, ok := strings.CutSuffix(base, ext); ok {
 				if strings.HasPrefix(stem, "test_") ||
-					strings.HasSuffix(stem, "_test") ||
-					strings.HasSuffix(stem, "_tests") {
+					strings.HasSuffix(stem, "_test") || strings.HasSuffix(stem, "_tests") {
 					return true
 				}
 			}
 		}
 		return false
-	case "java":
-		return strings.HasSuffix(base, "test.java") ||
-			strings.HasSuffix(base, "tests.java") ||
-			strings.HasSuffix(base, "it.java")
-	case "ruby":
-		return strings.HasSuffix(base, "_spec.rb") ||
-			strings.HasSuffix(base, "_test.rb")
-	case "swift":
-		return strings.HasSuffix(base, "tests.swift") ||
-			strings.HasSuffix(base, "test.swift")
-	case "kotlin":
-		return strings.HasSuffix(base, "test.kt") ||
-			strings.HasSuffix(base, "tests.kt")
-	case "scala":
-		return strings.HasSuffix(base, "spec.scala") ||
-			strings.HasSuffix(base, "test.scala")
-	case "shell":
-		return strings.HasSuffix(base, "_test.sh") ||
-			(strings.HasPrefix(base, "test_") && strings.HasSuffix(base, ".sh"))
-	case "elixir":
-		return strings.HasSuffix(base, "_test.exs")
-	case "csharp":
-		return strings.HasSuffix(base, "test.cs") ||
-			strings.HasSuffix(base, "tests.cs")
-	case "php":
-		return strings.HasSuffix(base, "test.php")
-	case "perl":
-		// In Test::More / Test::Simple the .t extension IS the test
-		// convention — there is no library / test naming distinction.
-		return strings.HasSuffix(base, ".t")
-	case "r":
-		// testthat convention: test-foo.R or test_foo.R (both styles
-		// in the wild). lowercase basename already applied above.
-		return (strings.HasPrefix(base, "test-") || strings.HasPrefix(base, "test_")) &&
-			(strings.HasSuffix(base, ".r"))
-	case "vb":
-		return strings.HasSuffix(base, "test.vb") ||
-			strings.HasSuffix(base, "tests.vb")
-	case "matlab":
-		return strings.HasSuffix(base, "test.m") ||
-			strings.HasSuffix(base, "tests.m")
+	}
+	c, ok := testFileConventions[language]
+	if !ok {
+		return false
+	}
+	for _, s := range c.suffixes {
+		if strings.HasSuffix(base, s) {
+			return true
+		}
+	}
+	if c.prefixExt != "" && strings.HasSuffix(base, c.prefixExt) {
+		for _, p := range c.prefixes {
+			if strings.HasPrefix(base, p) {
+				return true
+			}
+		}
 	}
 	return false
 }


### PR DESCRIPTION
Closes #372.

## What

Behaviour-preserving refactor of the repo's two top cyclomatic-complexity hotspots (surfaced by dogfooding the `complexity` tool):

| Function | Before | After |
|---|---|---|
| `extractTreeSitterSymbols` | 43 | **4** |
| `isSourceTestFile` | 44 | **17** |

## How

- **`extractTreeSitterSymbols`** → thin orchestrator over focused helpers operating on the already-parsed tree: `tsCollectDefs` (21), `tsCollectImports` (6), `tsCollectReferences` (7), `tsComplexityRows` (8). New `newFuncSpan` helper removes the repeated span construction. It had accreted six concerns across #362/#365/#368/#364 in one 141-line pass.
- **`isSourceTestFile`** → a `testFileConventions` table (suffix / prefix+ext rules) replaces the giant per-language switch; Rust (`tests/` dir) and C/C++ (stem-based) remain the two genuine specials.

## Scope notes
- Kept the 6-tuple return (the `tsSymbols` struct idea was "consider" — the complexity win is the helper split; keeping the signature minimizes churn).
- Left `Attributes` (cc 35) untouched per the issue (lower priority; inherently branchy line-classifier).

## Verification
- `go test ./...` green — the extractor parity / regex-migration / call-graph / complexity / test-file-convention fixtures confirm **behaviour is identical**.
- `-race` clean on content; `go vet`; `go fix` idempotent; `golangci-lint` 0 issues.
- Re-ran `complexity` to confirm both targets dropped out of the hotspot tier.

Two-file diff, no behaviour change, no new deps, no public-surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)