### PR TITLE
test(content): fuzz the C2PA parsers + cap JUMBF recursion depth

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -51,6 +51,15 @@ jobs:
           - name: ReadMP4VideoInfo
             pkg: ./internal/content/
             func: FuzzReadMP4VideoInfo
+          - name: ExtractC2PA
+            pkg: ./internal/content/
+            func: FuzzExtractC2PA
+          - name: WalkJUMBFBoxes
+            pkg: ./internal/content/
+            func: FuzzWalkJUMBFBoxes
+          - name: RFC3161GenTime
+            pkg: ./internal/content/
+            func: FuzzRFC3161GenTime
           - name: ExtractXMLText
             pkg: ./internal/content/
             func: FuzzExtractXMLText

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Empty `Expr` defaults to `"true"` (matches all files). Worker count defaults to 
 
 ### Fuzz testing
 
-High-risk parsers (frontmatter, MP3 ID3v2 + Xing, MKV EBML, MP4 box walker, office/EPUB/email/PDF body extractors, CEL compile, index gob decoder, every hand-rolled binary header walker) have `FuzzXxx` targets in `*_fuzz_test.go`.
+High-risk parsers (frontmatter, MP3 ID3v2 + Xing, MKV EBML, MP4 box walker, C2PA JUMBF box walker + COSE_Sign1 + RFC 3161 ASN.1 timestamp, office/EPUB/email/PDF body extractors, CEL compile, index gob decoder, every hand-rolled binary header walker) have `FuzzXxx` targets in `*_fuzz_test.go`.
 
 - **Regular CI** (`ci.yml`): `go test ./...` runs each target's seed corpus — a seed panic fails the build.
 - **Scheduled fuzz** (`fuzz.yml`): 5 min/target nightly at 03:30 UTC. Crashes land in `testdata/fuzz/<FuzzName>/<hash>` — commit those to lock in regression coverage. Manual `workflow_dispatch` accepts a `fuzztime` input for bug-hunt sessions.

--- a/internal/content/c2pa.go
+++ b/internal/content/c2pa.go
@@ -332,10 +332,25 @@ func rfc3161GenTime(der []byte) time.Time {
 	return tst.GenTime
 }
 
+// maxJUMBFDepth caps superbox nesting. Real C2PA manifests nest only a few
+// levels (store → manifest → c2pa.assertions → assertion ≈ 4); 64 is far
+// above that yet well below a stack-overflow threshold. Without this an
+// adversarial input — a chain of nested `jumb` boxes, each stripping only
+// the 8-byte header — could nest ~maxC2PAScan/8 levels deep and exhaust the
+// goroutine stack. We degrade gracefully (stop descending) instead.
+const maxJUMBFDepth = 64
+
 // walkJUMBFBoxes recursively walks JUMBF boxes, invoking fn(label, tbox,
 // content) for every box. label is the nearest enclosing superbox's jumd
 // label.
 func walkJUMBFBoxes(b []byte, label string, fn func(label, tbox string, content []byte)) {
+	walkJUMBFBoxesDepth(b, label, 0, fn)
+}
+
+func walkJUMBFBoxesDepth(b []byte, label string, depth int, fn func(label, tbox string, content []byte)) {
+	if depth > maxJUMBFDepth {
+		return
+	}
 	for len(b) >= 8 {
 		lbox := int(binary.BigEndian.Uint32(b[:4]))
 		tbox := string(b[4:8])
@@ -345,7 +360,7 @@ func walkJUMBFBoxes(b []byte, label string, fn func(label, tbox string, content 
 		content := b[8:lbox]
 		if tbox == "jumb" {
 			childLabel, rest := jumdLabel(content)
-			walkJUMBFBoxes(rest, childLabel, fn)
+			walkJUMBFBoxesDepth(rest, childLabel, depth+1, fn)
 		} else {
 			fn(label, tbox, content)
 		}

--- a/internal/content/c2pa_fuzz_test.go
+++ b/internal/content/c2pa_fuzz_test.go
@@ -1,0 +1,98 @@
+package content
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+// FuzzExtractC2PA targets the full C2PA extraction pipeline (c2pa.go):
+// jpegJUMBF (APP11 marker-segment reassembly) / pngJUMBF (caBX chunk
+// concatenation) → walkJUMBFBoxes (recursive LBox/TBox box tree) →
+// parseC2PAManifest (CBOR claim/actions decode) → c2paSignerIdentity
+// (COSE_Sign1 → x509) → rfc3161GenTime (ASN.1 timestamp). Every stage
+// walks attacker-controlled bytes pulled from arbitrary files.
+//
+// Contract: never panic, never loop forever. We don't assert on outputs —
+// corrupt input legitimately yields a zero c2paInfo (Present=false).
+func FuzzExtractC2PA(f *testing.F) {
+	f.Add([]byte{})
+	// JPEG SOI + a minimal APP11 "JP" packet (CI+En+Z headers, Z=1) wrapping
+	// one empty `jumb` box — exercises jpegJUMBF reassembly + the walker.
+	f.Add([]byte{
+		0xFF, 0xD8, // SOI
+		0xFF, 0xEB, 0x00, 0x12, // APP11, length 18
+		0x4A, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // "JP" + En + Z=1
+		0x00, 0x00, 0x00, 0x08, 'j', 'u', 'm', 'b', // empty jumb box
+	})
+	// PNG signature + an empty `caBX` chunk — exercises pngJUMBF.
+	f.Add([]byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+		0x00, 0x00, 0x00, 0x00, 'c', 'a', 'B', 'X', // len 0, type caBX
+		0x00, 0x00, 0x00, 0x00, // crc
+	})
+	// The real signed fixture — gives the mutator a valid manifest (claim +
+	// actions + COSE signature + RFC 3161 timestamp) to corrupt from.
+	if b, err := os.ReadFile("testdata/fixtures/c2pa_signed.jpg"); err == nil {
+		f.Add(b)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_ = extractC2PA("jpeg", bytes.NewReader(data))
+		_ = extractC2PA("png", bytes.NewReader(data))
+	})
+}
+
+// FuzzWalkJUMBFBoxes targets the recursive JUMBF box-tree walker and
+// jumdLabel directly. Boxes are length-prefixed (LBox) and `jumb`
+// superboxes nest, so this is the classic spot for integer-overflow on the
+// length field and stack growth on adversarial nesting — the latter guarded
+// by maxJUMBFDepth.
+//
+// Contract: never panic, never loop forever.
+func FuzzWalkJUMBFBoxes(f *testing.F) {
+	f.Add([]byte{})
+	// A `jumb` superbox holding a valid `jumd` description box (16-byte type
+	// UUID + 1 toggle byte, no label) plus one empty `cbor` child.
+	f.Add([]byte{
+		0x00, 0x00, 0x00, 0x2A, 'j', 'u', 'm', 'b', // jumb, lbox 42
+		0x00, 0x00, 0x00, 0x19, 'j', 'u', 'm', 'd', // jumd, lbox 25
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // type UUID
+		0x00,                                        // toggles (no label)
+		0x00, 0x00, 0x00, 0x09, 'c', 'b', 'o', 'r', 0xA0, // cbor child {}
+	})
+	// LBox claiming far more than the buffer holds — must bail, not index OOB.
+	f.Add([]byte{0x00, 0x00, 0xFF, 0xFF, 'j', 'u', 'm', 'b'})
+	// Self-nesting `jumb` chain (no valid jumd at any level) — exercises the
+	// depth guard rather than recursing per stripped header.
+	f.Add([]byte{
+		0x00, 0x00, 0x00, 0x18, 'j', 'u', 'm', 'b', // lbox 24
+		0x00, 0x00, 0x00, 0x10, 'j', 'u', 'm', 'b', // lbox 16
+		0x00, 0x00, 0x00, 0x08, 'j', 'u', 'm', 'b', // lbox 8 (empty)
+	})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		walkJUMBFBoxes(data, "", func(string, string, []byte) {})
+	})
+}
+
+// FuzzRFC3161GenTime targets the hand-rolled ASN.1 descent that walks an
+// RFC 3161 timestamp (TimeStampResp → CMS SignedData → TSTInfo) down to
+// genTime. Nested encoding/asn1.Unmarshal calls over attacker bytes.
+//
+// Contract: never panic, never loop forever; any structural surprise yields
+// the zero time.
+func FuzzRFC3161GenTime(f *testing.F) {
+	f.Add([]byte{})
+	// SEQUENCE { INTEGER 0 } — a PKIStatusInfo-shaped prefix with no token.
+	f.Add([]byte{0x30, 0x03, 0x02, 0x01, 0x00})
+	// A bare GeneralizedTime TLV ("20240806215337Z") — not a ContentInfo.
+	f.Add([]byte{
+		0x18, 0x0F,
+		'2', '0', '2', '4', '0', '8', '0', '6', '2', '1', '5', '3', '3', '7', 'Z',
+	})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_ = rfc3161GenTime(data)
+	})
+}


### PR DESCRIPTION
Answers "is the new C2PA feature covered by fuzz testing?" — it wasn't. This closes the gap.

## Why

v0.90.0's C2PA support (#374 / #375) added a cluster of **hand-rolled binary parsers that walk untrusted bytes from arbitrary files**, but none had a `FuzzXxx` target — against [CLAUDE.md's convention](../blob/main/CLAUDE.md) that "every hand-rolled binary header walker" be fuzzed. Uncovered surfaces in `internal/content/c2pa.go`:

- `jpegJUMBF` — JPEG APP11 marker-segment reassembly
- `pngJUMBF` — PNG `caBX` chunk concatenation
- `walkJUMBFBoxes` + `jumdLabel` — recursive LBox/TBox box-tree walker
- `parseC2PAManifest` → CBOR decode → `c2paSignerIdentity` (COSE) → `rfc3161GenTime` (hand-rolled ASN.1)

## What

**Three fuzz targets** (`internal/content/c2pa_fuzz_test.go`), following the `video_mp4_fuzz_test.go` template:

| target | surface | seeds |
|---|---|---|
| `FuzzExtractC2PA` | whole pipeline, both `jpeg`/`png` containers | empty, JPEG/PNG stubs, **the real signed fixture** |
| `FuzzWalkJUMBFBoxes` | the recursive walker + `jumdLabel` directly | valid superbox, oversized LBox, self-nesting chain |
| `FuzzRFC3161GenTime` | the ASN.1 `TimeStampResp → TSTInfo.genTime` descent | truncated SEQUENCE, bare GeneralizedTime |

Registered all three in `fuzz.yml`'s nightly matrix; extended the CLAUDE.md parser inventory.

## Latent bug fixed

Writing `FuzzWalkJUMBFBoxes` surfaced a real issue: `walkJUMBFBoxes` recursed **once per nested `jumb` box with no depth cap**. Each level strips only the 8-byte header, so a 16 MB input (the `maxC2PAScan` cap) could nest ~2M levels and exhaust the goroutine stack — a DoS on any file fed to the search. Added `maxJUMBFDepth = 64` (real manifests nest ~4 deep) so the walker stops descending instead of overflowing. No behavior change for valid files.

## Verification

- Seed corpus passes as normal tests (what `ci.yml` runs).
- **~1M+ execs per target over 25s each, zero crashes** — the depth guard holds on adversarial nesting.
- `go test -race ./...`, `go vet`, `go fix`, `golangci-lint` all clean; existing `TestExtractC2PA*` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)