### PR TITLE
fix(content): honor ctx cancellation in the C2PA scan loops (#337)

### DIFF
--- a/internal/content/c2pa.go
+++ b/internal/content/c2pa.go
@@ -1,6 +1,7 @@
 package content
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/binary"
@@ -61,7 +62,14 @@ type c2paInfo struct {
 // container ("jpeg" / "png"), locates + parses the JUMBF manifest. Returns
 // a zero c2paInfo (Present=false) when there's no manifest. Never errors —
 // provenance is best-effort metadata, like EXIF.
-func extractC2PA(container string, rs io.Reader) c2paInfo {
+//
+// ctx is honoured at entry and inside the input-scaled scan loops (up to
+// maxC2PAScan = 16 MiB), so a cancelled search surrenders promptly mid-scan
+// rather than parsing a full adversarial header (issue #337).
+func extractC2PA(ctx context.Context, container string, rs io.Reader) c2paInfo {
+	if ctx.Err() != nil {
+		return c2paInfo{}
+	}
 	data, err := io.ReadAll(io.LimitReader(rs, maxC2PAScan))
 	if err != nil || len(data) == 0 {
 		return c2paInfo{}
@@ -69,25 +77,28 @@ func extractC2PA(container string, rs io.Reader) c2paInfo {
 	var jumbf []byte
 	switch container {
 	case "jpeg":
-		jumbf = jpegJUMBF(data)
+		jumbf = jpegJUMBF(ctx, data)
 	case "png":
-		jumbf = pngJUMBF(data)
+		jumbf = pngJUMBF(ctx, data)
 	default:
 		return c2paInfo{}
 	}
 	if len(jumbf) == 0 {
 		return c2paInfo{}
 	}
-	return parseC2PAManifest(jumbf)
+	return parseC2PAManifest(ctx, jumbf)
 }
 
 // jpegJUMBF reassembles the JUMBF box from APP11 (0xFFEB) marker segments,
 // stopping at start-of-scan. Packet 1 of a box keeps its LBox+TBox; later
 // packets repeat them and are skipped (ISO 19566-5 JPEG embedding).
-func jpegJUMBF(data []byte) []byte {
+func jpegJUMBF(ctx context.Context, data []byte) []byte {
 	var out []byte
 	i := 2 // skip SOI
 	for i < len(data)-1 {
+		if ctx.Err() != nil {
+			return out
+		}
 		if data[i] != 0xFF {
 			i++
 			continue
@@ -125,13 +136,16 @@ func jpegJUMBF(data []byte) []byte {
 
 // pngJUMBF concatenates the data of all `caBX` chunks (PNG's C2PA carrier),
 // stopping at IDAT. PNG: 8-byte signature, then [len(4)][type(4)][data][crc(4)].
-func pngJUMBF(data []byte) []byte {
+func pngJUMBF(ctx context.Context, data []byte) []byte {
 	if len(data) < 8 {
 		return nil
 	}
 	var out []byte
 	i := 8
 	for i+8 <= len(data) {
+		if ctx.Err() != nil {
+			return out
+		}
 		ln := int(binary.BigEndian.Uint32(data[i : i+4]))
 		typ := string(data[i+4 : i+8])
 		if ln < 0 || i+12+ln > len(data) {
@@ -150,9 +164,9 @@ func pngJUMBF(data []byte) []byte {
 
 // parseC2PAManifest walks the JUMBF box tree, decodes the c2pa.claim and
 // c2pa.actions CBOR, and returns the surfaced fields.
-func parseC2PAManifest(jumbf []byte) c2paInfo {
+func parseC2PAManifest(ctx context.Context, jumbf []byte) c2paInfo {
 	info := c2paInfo{}
-	walkJUMBFBoxes(jumbf, "", func(label string, tbox string, content []byte) {
+	walkJUMBFBoxes(ctx, jumbf, "", func(label string, tbox string, content []byte) {
 		switch {
 		case tbox != "cbor":
 			return
@@ -343,15 +357,18 @@ const maxJUMBFDepth = 64
 // walkJUMBFBoxes recursively walks JUMBF boxes, invoking fn(label, tbox,
 // content) for every box. label is the nearest enclosing superbox's jumd
 // label.
-func walkJUMBFBoxes(b []byte, label string, fn func(label, tbox string, content []byte)) {
-	walkJUMBFBoxesDepth(b, label, 0, fn)
+func walkJUMBFBoxes(ctx context.Context, b []byte, label string, fn func(label, tbox string, content []byte)) {
+	walkJUMBFBoxesDepth(ctx, b, label, 0, fn)
 }
 
-func walkJUMBFBoxesDepth(b []byte, label string, depth int, fn func(label, tbox string, content []byte)) {
+func walkJUMBFBoxesDepth(ctx context.Context, b []byte, label string, depth int, fn func(label, tbox string, content []byte)) {
 	if depth > maxJUMBFDepth {
 		return
 	}
 	for len(b) >= 8 {
+		if ctx.Err() != nil {
+			return
+		}
 		lbox := int(binary.BigEndian.Uint32(b[:4]))
 		tbox := string(b[4:8])
 		if lbox < 8 || lbox > len(b) {
@@ -360,7 +377,7 @@ func walkJUMBFBoxesDepth(b []byte, label string, depth int, fn func(label, tbox 
 		content := b[8:lbox]
 		if tbox == "jumb" {
 			childLabel, rest := jumdLabel(content)
-			walkJUMBFBoxesDepth(rest, childLabel, depth+1, fn)
+			walkJUMBFBoxesDepth(ctx, rest, childLabel, depth+1, fn)
 		} else {
 			fn(label, tbox, content)
 		}

--- a/internal/content/c2pa_fuzz_test.go
+++ b/internal/content/c2pa_fuzz_test.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"testing"
 )
@@ -38,8 +39,8 @@ func FuzzExtractC2PA(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		_ = extractC2PA("jpeg", bytes.NewReader(data))
-		_ = extractC2PA("png", bytes.NewReader(data))
+		_ = extractC2PA(context.Background(), "jpeg", bytes.NewReader(data))
+		_ = extractC2PA(context.Background(), "png", bytes.NewReader(data))
 	})
 }
 
@@ -72,7 +73,7 @@ func FuzzWalkJUMBFBoxes(f *testing.F) {
 	})
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		walkJUMBFBoxes(data, "", func(string, string, []byte) {})
+		walkJUMBFBoxes(context.Background(), data, "", func(string, string, []byte) {})
 	})
 }
 

--- a/internal/content/c2pa_test.go
+++ b/internal/content/c2pa_test.go
@@ -19,7 +19,7 @@ func TestExtractC2PA_SignedJPEG(t *testing.T) {
 	}
 	defer func() { _ = f.Close() }()
 
-	c := extractC2PA("jpeg", f)
+	c := extractC2PA(context.Background(), "jpeg", f)
 	if !c.Present {
 		t.Fatal("expected a C2PA manifest")
 	}
@@ -45,7 +45,7 @@ func TestExtractC2PA_SignedJPEG(t *testing.T) {
 // TestExtractC2PA_NoManifest returns Present=false for content with no
 // C2PA manifest.
 func TestExtractC2PA_NoManifest(t *testing.T) {
-	if c := extractC2PA("jpeg", bytes.NewReader([]byte("\xff\xd8\xff\xe0 not a real manifest"))); c.Present {
+	if c := extractC2PA(context.Background(), "jpeg", bytes.NewReader([]byte("\xff\xd8\xff\xe0 not a real manifest"))); c.Present {
 		t.Errorf("expected no manifest, got %+v", c)
 	}
 }
@@ -68,6 +68,23 @@ func TestExtractC2PA_Integration(t *testing.T) {
 	}
 	if at, _ := attrs["c2pa_signed_at"].(time.Time); at.IsZero() {
 		t.Errorf("c2pa_signed_at not set")
+	}
+}
+
+// TestExtractC2PA_Cancellation pins issue #337: a cancelled context must be
+// honoured by the C2PA scan, not run to completion. With a pre-cancelled
+// ctx, extractC2PA bails at entry and parses nothing.
+func TestExtractC2PA_Cancellation(t *testing.T) {
+	f, err := os.Open("testdata/fixtures/c2pa_signed.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if c := extractC2PA(ctx, "jpeg", f); c.Present {
+		t.Errorf("cancelled ctx should yield no manifest, got %+v", c)
 	}
 }
 

--- a/internal/content/imagetype.go
+++ b/internal/content/imagetype.go
@@ -87,7 +87,7 @@ func (i *imageType) Attributes(ctx context.Context, fsys fs.FS, path string) (At
 	// Surfaces the file's CLAIMED provenance, unverified (see c2pa.go).
 	if container := c2paContainer(i.name); container != "" {
 		if _, err := rs.Seek(0, io.SeekStart); err == nil {
-			if c := extractC2PA(container, rs); c.Present {
+			if c := extractC2PA(ctx, container, rs); c.Present {
 				attrs["is_c2pa"] = true
 				if c.ClaimGenerator != "" {
 					attrs["c2pa_claim_generator"] = c.ClaimGenerator


### PR DESCRIPTION
Answers "is context cancellation supported on all paths, especially around for loops?" — for the C2PA reader, it wasn't. This fixes it.

## The gap

The C2PA reader shipped in v0.90.0 (#374 / #375) **threaded no context at all**. `extractC2PA` took only `(container, io.Reader)`, and its input-scaled loops ran over up to **16 MiB** (`maxC2PAScan`) with no `ctx.Err()` check:

- `jpegJUMBF` — APP11 (0xFFEB) marker scan
- `pngJUMBF` — `caBX` chunk scan
- `walkJUMBFBoxes` / `walkJUMBFBoxesDepth` — the recursive box-tree walker

So a search cancelled (Ctrl-C / MCP timeout) **mid-scan of a large or adversarial JPEG/PNG header** would not surrender promptly — a violation of the robustness invariant in `internal/search/doc.go` (issue #337).

**Why the pinning tests missed it:** `TestOrchestrators_PreCancelledCtxReturnPromptly` cancels *before* the walk (caught by `imageType.Attributes`' entry check), and `TestWalk_GracefulDegradation_EveryType` only asserts malformed files survive. Neither exercises *mid-scan* cancellation.

## The fix

Thread `ctx` through `extractC2PA → jpegJUMBF / pngJUMBF / parseC2PAManifest → walkJUMBFBoxes(Depth)`, checking `ctx.Err()` at entry and at the top of each scan loop — the exact pattern `walkBoxes` (`mp4_box.go`) and `walkEBML` (`video_mkv.go`) already use. `imageType.Attributes` now passes its `ctx` down.

The bounded range-loops over *already-decoded* manifest structures (cert chain, RFC 3161 token list, actions, COSE header stores) are scoped by manifest shape, not input size, so they stay as-is — consistent with the "any **unbounded** loop" wording of the invariant.

## Scope check

Audited the rest of `internal/content`: the only other `ctx`-taking functions with loops are the SQLite FTS readers (loops are `for rows.Next()` over `db.QueryContext(ctx, …)` cursors — ctx-bound by the driver) and `readMKVTrackEntry` (delegates every loop to `walkEBML(ctx, …)`). Both already correct. **C2PA was the sole genuine violation.**

## Verification

- New `TestExtractC2PA_Cancellation` pins it: a pre-cancelled ctx yields no manifest (passes under `-race`).
- Existing C2PA tests + the #337 pinning tests still green.
- Mutate-fuzz of the now-ctx-threaded walkers: no crashes.
- `go test -race ./...`, `vet`, `fix`, `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)