### PR TITLE
fix(index): invalidate caches across binary versions; rebuild instead of erroring (#418)

### DIFF
--- a/cmd/file-search-on/index_path.go
+++ b/cmd/file-search-on/index_path.go
@@ -163,7 +163,23 @@ func resolveIndexBackend(cwd, path string, noIndex bool, bodyCap index.BodyCache
 		return index.NewMemory(), IndexBackend{Mode: BackendInMemory, Reason: ReasonLockContention}, nil
 	}
 	if errors.Is(err, index.ErrSchemaMismatch) {
-		return nil, IndexBackend{}, fmt.Errorf("index file at %s has an incompatible schema; delete it or pass a new --index-path", path)
+		// The file is a stale cache from a different schema / binary
+		// version (issue #418). It's pure cache — discard and rebuild
+		// rather than erroring out, so an upgrade Just Works instead of
+		// forcing the user to hunt down and delete the file.
+		fmt.Fprintf(os.Stderr, "file-search-on: index cache at %s is from a different version; rebuilding it\n", path)
+		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) {
+			return nil, IndexBackend{}, fmt.Errorf("rebuild stale index at %s: %w", path, rmErr)
+		}
+		idx, err = index.OpenWith(path, bodyCap)
+		if err == nil {
+			return idx, IndexBackend{Mode: BackendPersistent, Path: path}, nil
+		}
+		if isBoltLockTimeout(err) {
+			fmt.Fprintf(os.Stderr, "file-search-on: index file %s is held by another instance; this session will use in-memory cache (use --no-index to silence this warning)\n", path)
+			return index.NewMemory(), IndexBackend{Mode: BackendInMemory, Reason: ReasonLockContention}, nil
+		}
+		return nil, IndexBackend{}, fmt.Errorf("rebuild stale index at %s: %w", path, err)
 	}
 	return nil, IndexBackend{}, fmt.Errorf("open index: %w", err)
 }

--- a/cmd/file-search-on/index_path_test.go
+++ b/cmd/file-search-on/index_path_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/richardwooding/file-search-on/internal/index"
 )
 
@@ -134,6 +136,45 @@ func TestResolveIndexBackend_ExplicitPath_HappyPath(t *testing.T) {
 	}
 	if backend.Reason != "" {
 		t.Errorf("backend.Reason = %q, want empty for happy-path persistent open", backend.Reason)
+	}
+}
+
+// TestResolveIndexBackend_StaleSchemaRebuilds pins the #418 fix: a cache
+// file from an incompatible schema/version is transparently rebuilt rather
+// than erroring out the process (the old behaviour forced the user to find
+// and delete the file). Seeds a bbolt file with a stale meta payload, then
+// asserts resolveIndexBackend returns a working persistent index.
+func TestResolveIndexBackend_StaleSchemaRebuilds(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stale.db")
+
+	// Seed a file whose meta claims an old schema version — the same
+	// shape an older binary would have left behind.
+	db, err := bolt.Open(path, 0o600, nil)
+	if err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	if err := db.Update(func(tx *bolt.Tx) error {
+		bk, err := tx.CreateBucket([]byte("meta"))
+		if err != nil {
+			return err
+		}
+		return bk.Put([]byte("schema"), []byte(`{"schema_version":1,"encoding":"gob"}`))
+	}); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	_ = db.Close()
+
+	idx, backend, err := resolveIndexBackend("", path, false, index.BodyCacheCap{})
+	if err != nil {
+		t.Fatalf("resolveIndexBackend should rebuild a stale cache, got error: %v", err)
+	}
+	defer func() { _ = idx.Close() }()
+	if backend.Mode != BackendPersistent {
+		t.Errorf("backend.Mode = %q, want %q (rebuilt persistent index)", backend.Mode, BackendPersistent)
+	}
+	// The rebuilt index must be usable.
+	if err := idx.Put("/x/a.go", &index.Entry{ContentType: "source/go", Size: 1, ModTimeUnixNano: 1}); err != nil {
+		t.Errorf("rebuilt index Put failed: %v", err)
 	}
 }
 

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -117,6 +117,12 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Stamp this binary's version as the on-disk index cache identity so a
+	// cache written by a different version is discarded rather than served
+	// stale — guards the #418 class of bug (attributes added between
+	// releases silently missing for unchanged files).
+	index.SetSchemaID(version)
+
 	kctx := kong.Parse(&CLI,
 		kong.Name("file-search-on"),
 		kong.Description("Content-type aware file search with CEL attribute filtering."),

--- a/internal/index/bbolt.go
+++ b/internal/index/bbolt.go
@@ -17,7 +17,17 @@ import (
 )
 
 const (
-	schemaVersion     = 1
+	// schemaVersion gates the on-disk gob/bucket layout. Bump it on any
+	// CHANGE to that layout. Note: you do NOT need to bump it merely
+	// because the *attribute set* grew — entries also carry the writing
+	// binary's version (metaPayload.AttrSchemaID), so a newer binary
+	// automatically invalidates a cache an older binary wrote. (This guard
+	// was added after issue #418: the counter sat at 1 through #363 / #364 /
+	// #368 / #398, so caches written before those silently served entries
+	// missing references / call_edges / complexity / type-usage refs, which
+	// broke every code-graph tool on a warm index.) Bumped to 2 to discard
+	// all pre-#418 v1 caches that lack the version stamp.
+	schemaVersion     = 2
 	bucketAttrs       = "attrs_v1"
 	bucketBodies      = "bodies_v1"
 	bucketBodyAccess  = "body_access_v1"
@@ -51,6 +61,13 @@ const (
 type metaPayload struct {
 	SchemaVersion int    `json:"schema_version"`
 	Encoding      string `json:"encoding"`
+	// AttrSchemaID is the version string of the binary that created the
+	// cache. A newer binary (different version) invalidates the cache, so
+	// attributes added between releases are never served stale — the
+	// automatic guard against the #418 class of bug. Empty on pre-#418
+	// caches (json-additive); current binaries write a non-empty id, so an
+	// empty stored value never matches and those caches are discarded.
+	AttrSchemaID string `json:"attr_schema_id,omitempty"`
 }
 
 type boltIndex struct {
@@ -81,7 +98,7 @@ type bodyPutReq struct {
 	ts  int64  // AccessedUnixNano
 }
 
-func openBoltIndex(path string, cap BodyCacheCap) (*boltIndex, error) {
+func openBoltIndex(path string, cap BodyCacheCap, schemaID string) (*boltIndex, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("resolve index path: %w", err)
@@ -91,7 +108,7 @@ func openBoltIndex(path string, cap BodyCacheCap) (*boltIndex, error) {
 		return nil, fmt.Errorf("open index file: %w", err)
 	}
 
-	if err := initOrValidateSchema(db); err != nil {
+	if err := initOrValidateSchema(db, schemaID); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
@@ -130,7 +147,7 @@ func openBoltIndex(path string, cap BodyCacheCap) (*boltIndex, error) {
 	return idx, nil
 }
 
-func initOrValidateSchema(db *bbolt.DB) error {
+func initOrValidateSchema(db *bbolt.DB, schemaID string) error {
 	return db.Update(func(tx *bbolt.Tx) error {
 		meta := tx.Bucket([]byte(bucketMeta))
 		if meta == nil {
@@ -143,6 +160,7 @@ func initOrValidateSchema(db *bbolt.DB) error {
 			payload, err := json.Marshal(metaPayload{
 				SchemaVersion: schemaVersion,
 				Encoding:      "gob",
+				AttrSchemaID:  schemaID,
 			})
 			if err != nil {
 				return err
@@ -170,6 +188,12 @@ func initOrValidateSchema(db *bbolt.DB) error {
 			return ErrSchemaMismatch
 		}
 		if got.SchemaVersion != schemaVersion || got.Encoding != "gob" {
+			return ErrSchemaMismatch
+		}
+		// Attributes added between binary versions would otherwise be
+		// served stale (issue #418): a cache written by a different binary
+		// version is discarded so the current extractor re-runs.
+		if got.AttrSchemaID != schemaID {
 			return ErrSchemaMismatch
 		}
 		if tx.Bucket([]byte(bucketAttrs)) == nil {

--- a/internal/index/bbolt_test.go
+++ b/internal/index/bbolt_test.go
@@ -121,6 +121,45 @@ func errIsSchemaMismatch(err error) bool {
 	return err == ErrSchemaMismatch
 }
 
+// TestBoltAttrSchemaIDInvalidatesAcrossVersions pins the #418 fix: a cache
+// written by one binary version is rejected when opened by another, so a
+// newer binary never serves attributes the cache predates. (Before the
+// fix, validity was (size, mtime) only and a stale entry survived forever.)
+func TestBoltAttrSchemaIDInvalidatesAcrossVersions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "idx.db")
+
+	// Binary "v1" writes an entry.
+	idx, err := openBoltIndex(path, BodyCacheCap{}, "v1")
+	if err != nil {
+		t.Fatalf("open v1: %v", err)
+	}
+	mtime := time.Unix(1700000000, 0)
+	if err := idx.Put("/x/a.go", &Entry{ContentType: "source/go", Size: 10, ModTimeUnixNano: mtime.UnixNano(),
+		Extra: map[string]any{"functions": []string{"A"}}}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if err := idx.Close(); err != nil {
+		t.Fatalf("close v1: %v", err)
+	}
+
+	// A different binary version must reject the cache rather than serve
+	// its (now potentially incomplete) entries.
+	if _, err := openBoltIndex(path, BodyCacheCap{}, "v2"); !errIsSchemaMismatch(err) {
+		t.Fatalf("v2 opening a v1 cache: got %v, want ErrSchemaMismatch", err)
+	}
+
+	// Re-opening with the SAME id round-trips normally.
+	idx2, err := openBoltIndex(path, BodyCacheCap{}, "v1")
+	if err != nil {
+		t.Fatalf("reopen v1: %v", err)
+	}
+	defer func() { _ = idx2.Close() }()
+	if _, ok := idx2.Lookup("/x/a.go", 10, mtime); !ok {
+		t.Error("same-id reopen should find the entry")
+	}
+}
+
 func TestBoltPutThenLookupSameSession(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "idx.db")

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -390,10 +390,24 @@ type BodyCacheCap struct {
 }
 
 // ErrSchemaMismatch is returned by Open when the on-disk index file
-// belongs to a different (older or newer) schema version than this
-// binary understands. The CLI surfaces a "delete or pass a new
-// --index-path" message; we never auto-delete user data.
-var ErrSchemaMismatch = errors.New("index: schema version mismatch (delete the file or pass a new --index-path)")
+// belongs to a different schema version OR was written by a different
+// binary version than this one (issue #418 — a newer binary may extract
+// attributes the cache predates). The index is a cache, so callers should
+// treat this as "rebuild from scratch" (delete + reopen), not a fatal
+// error; the CLI / MCP openIndex wrapper does exactly that.
+var ErrSchemaMismatch = errors.New("index: schema/version mismatch (stale cache — delete the file to rebuild)")
+
+// schemaID is the current binary's cache identity, stamped into new
+// on-disk indexes and compared on open. Set once at startup via
+// SetSchemaID(version); an empty default keeps tests / library callers on
+// a single stable identity (no spurious invalidation within one binary).
+var schemaID string
+
+// SetSchemaID records the running binary's version as the on-disk cache
+// identity. A cache written under a different id is discarded on open so a
+// newer binary never serves attributes the cache predates (issue #418).
+// Call once from main() before opening any index.
+func SetSchemaID(id string) { schemaID = id }
 
 // NewMemory returns an in-memory Index. It is concurrent-safe and has
 // no persistence; suitable for the MCP server's auto-on cache.
@@ -414,5 +428,5 @@ func OpenWith(path string, cap BodyCacheCap) (Index, error) {
 	if path == "" {
 		return NewMemory(), nil
 	}
-	return openBoltIndex(path, cap)
+	return openBoltIndex(path, cap, schemaID)
 }


### PR DESCRIPTION
Closes #418.

## Problem

The index validated a cached entry by **`(size, mtime)` only**, and `schemaVersion` sat at **1** through every additive-attribute change — `references` (#363), `call_edges` (#368), `max_complexity` (#364), type-usage refs (#398), and many content-type attrs. An entry written by an **older binary** passed validation forever and was served verbatim by a newer one, **silently missing every attribute added since it was cached**.

The entire code-graph family (`who_calls` / `dead_code` / `impact` / `call_path` / `calls` / `complexity` / `unused_exports` / `coupling` / `test_gaps`) then ran on incomplete data with **no error**: `who_calls` returned empty, `dead_code` flooded with false positives.

**Reproduced** on this repo via the MCP server (warm on-disk index): `who_calls commafy` → 0 callers, `dead_code` cmd/ → **78** vs the CLI's correct **2**; `read_attributes` showed `functions` present but `references`/`call_edges`/`max_complexity` **absent** (an entry written before #363, never re-extracted because size+mtime still matched).

## Fix

1. **Bump `schemaVersion` 1 → 2** — discards all pre-fix v1 caches.
2. **Stamp the binary version into meta (`AttrSchemaID`)** and reject a cache written under a different id. This is the *recurrence* fix: a newer release auto-invalidates an older release's cache without anyone remembering to bump a counter (the exact failure mode here). Threaded via `index.SetSchemaID(version)` from `main()`. The in-memory index is unaffected (cleared per process, always written by the current binary).
3. **Auto-rebuild on `ErrSchemaMismatch`** — `openIndex` now deletes the stale cache and reopens (with a stderr notice) instead of erroring "delete the file". An upgrade Just Works; the cost is a one-time reparse.

## Verification

- bbolt-level: a cache written under id `"v1"` is rejected when opened as `"v2"`; same id round-trips and finds its entry.
- cmd-level: `resolveIndexBackend` transparently rebuilds a stale-schema file into a working persistent index (no error).
- End-to-end: the fixed binary's on-disk index now gives correct `who_calls` (finds commafy) and `dead_code` (2, not 78).
- `go test -race ./...` green; `vet`, `go fix`, `golangci-lint` clean.

> Note for users: the fix takes effect when the MCP server restarts on the binary containing it — the bumped schema version rebuilds the stale cache on that first open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)