### PR TITLE
fix(codegraph): exclude Go init/main from dead_code candidates (#385)

### DIFF
--- a/internal/search/codegraph.go
+++ b/internal/search/codegraph.go
@@ -547,10 +547,13 @@ func (g *CodeGraph) DeadCode() []SymbolDef {
 }
 
 // isReflectionDispatchedEntry reports whether a definition is an entry point
-// invoked by a framework via reflection rather than by a static call — so it
+// invoked by the runtime / a framework rather than by a static call — so it
 // never appears in the call-reference graph and would always be a dead-code
-// false positive (issue #385). Two well-known cases:
+// false positive (issue #385). Well-known cases:
 //
+//   - Go package-init / program entry points (`init`, `main`): run by the Go
+//     runtime, never statically called — reporting them is pure noise (they
+//     dominated dead_code output on real Go trees, e.g. 57 `init`s here).
 //   - Go test-runner entry points (TestXxx / BenchmarkXxx / FuzzXxx /
 //     ExampleXxx in a *_test.go file): run by `go test`, never called.
 //     Unused test *helpers* are still reported — only the runner entry
@@ -559,6 +562,9 @@ func (g *CodeGraph) DeadCode() []SymbolDef {
 //     struct-tag reflection, so they're referenced only as field types, which
 //     the call-reference graph doesn't track.
 func isReflectionDispatchedEntry(kind, name, path, language string) bool {
+	if language == "go" && kind == "function" && (name == "init" || name == "main") {
+		return true
+	}
 	if language == "go" && strings.HasSuffix(path, "_test.go") && isGoTestEntry(kind, name) {
 		return true
 	}

--- a/internal/search/codegraph_test.go
+++ b/internal/search/codegraph_test.go
@@ -264,6 +264,8 @@ func TestCodeGraph_DeadCode_ExcludesReflectionEntryPoints(t *testing.T) {
 	mustWriteFile(t, filepath.Join(dir, "app.go"), "package app\n\n"+
 		"type RunCmd struct{}\n"+ // kong command type → excluded
 		"func orphan() {}\n"+ // genuinely unreferenced → flagged
+		"func init() {}\n"+ // package init → runtime-dispatched, excluded
+		"func main() {}\n"+ // program entry point → excluded
 		"func Tester() {}\n") // Test-prefixed but NOT a test entry → flagged
 	mustWriteFile(t, filepath.Join(dir, "app_test.go"), "package app\n\n"+
 		"import \"testing\"\n\n"+
@@ -285,6 +287,12 @@ func TestCodeGraph_DeadCode_ExcludesReflectionEntryPoints(t *testing.T) {
 	}
 	if dead["RunCmd"] {
 		t.Error("DeadCode wrongly flagged RunCmd (a kong-style command type)")
+	}
+	if dead["init"] {
+		t.Error("DeadCode wrongly flagged init (Go runtime-dispatched package init)")
+	}
+	if dead["main"] {
+		t.Error("DeadCode wrongly flagged main (program entry point)")
 	}
 }
 


### PR DESCRIPTION
## What

`dead_code` flagged every package `init()` and program `main()` as a candidate — both are dispatched by the Go runtime, never statically called, so they can **never** be "dead" and are pure noise.

With the #418 index fix in place (so the reference graph is finally accurate), dogfooding this repo showed **57 of 130** candidates were `init` functions alone, plus `main`.

## Change

Extend `isReflectionDispatchedEntry` — which already excludes go-test entry points (`TestXxx`/…) and kong `…Cmd` types — to also drop Go `init` / `main`. Same category: runtime/framework-dispatched entry points that never appear in the call graph. Genuinely-unreferenced helpers are still reported.

## Verification

- The existing reflection-entry test now also asserts `init`/`main` are excluded while a real `orphan` is still flagged.
- On this repo: `dead-code` candidates **130 → 72**.
- `go test -race ./internal/search`, `vet`, `go fix`, `golangci-lint` clean.

> Follow-up (separate issue): the remaining ~53 candidates are handlers/bindings registered by passing a *method value* to `AddTool`/`HandleFunc`/`fuzzyFunctions` — references the call graph misses because they're passed as values, not called. Capturing function-value references would improve `dead_code`/`who_calls`/`impact` precision further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)