### PR TITLE
refactor(search): remove dead matchesSkipPrefix helper

### DIFF
--- a/internal/search/profile.go
+++ b/internal/search/profile.go
@@ -48,18 +48,3 @@ func skipPrefixesForProfile(profile string) []string {
 	}
 	return nil
 }
-
-// matchesSkipPrefix reports whether contentTypeName starts with any
-// of the prefixes — the per-file gate inside BuildAttributesWith.
-// Empty prefixes / empty content type → false (no skip).
-func matchesSkipPrefix(contentTypeName string, prefixes []string) bool {
-	if contentTypeName == "" || len(prefixes) == 0 {
-		return false
-	}
-	for _, p := range prefixes {
-		if len(contentTypeName) >= len(p) && contentTypeName[:len(p)] == p {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/search/profile_test.go
+++ b/internal/search/profile_test.go
@@ -23,25 +23,3 @@ func TestSkipPrefixesForProfile(t *testing.T) {
 		}
 	}
 }
-
-func TestMatchesSkipPrefix(t *testing.T) {
-	prefixes := []string{"image/", "audio/", "video/"}
-	cases := map[string]bool{
-		"image/jpeg": true,
-		"video/mp4":  true,
-		"audio/mpeg": true,
-		"source/go":  false,
-		"markdown":   false,
-		"":           false,
-		"image":      false, // no slash → not a prefix match for "image/"
-	}
-	for ct, want := range cases {
-		if got := matchesSkipPrefix(ct, prefixes); got != want {
-			t.Errorf("matchesSkipPrefix(%q) = %v, want %v", ct, got, want)
-		}
-	}
-	// Empty prefix list never skips.
-	if matchesSkipPrefix("image/jpeg", nil) {
-		t.Error("nil prefixes should never skip")
-	}
-}


### PR DESCRIPTION
`dead_code` — now accurate after the #418 index fix and #421 value-ref capture — flagged `search.matchesSkipPrefix` as referenced only by its own test.

It's a genuine orphan: the profile-skip gate is actually implemented inline as `strings.HasPrefix(contentTypeName, p)` in `celexpr/evaluator.go:907`, and this helper (whose doc still claimed it was "the per-file gate inside `BuildAttributesWith`") was left behind by that refactor. Removed the function and its test.

No behaviour change — a small cleanup payoff from dogfooding the freshly-fixed code-graph tooling. `dead_code` on the repo drops 10 → 9 (the remaining 9 are all explicable false positives: interface methods, externally-used exports, the test fixture).

`go test -race ./...`, `vet`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)