### PR TITLE
fix(cli): unused-exports table hid all output for non-Go projects

### DIFF
--- a/cmd/file-search-on/unused_exports_cmd.go
+++ b/cmd/file-search-on/unused_exports_cmd.go
@@ -74,16 +74,16 @@ func (c *UnusedExportsCmd) Run(ctx context.Context) error {
 }
 
 func printUnusedExportsTable(w *os.File, res *search.UnusedExportsResult) {
-	if res.Module == "" {
-		_, _ = fmt.Fprintln(w, "no go.mod found at the root — unused-exports resolves first-party Go packages only")
-		return
-	}
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "KIND\tSYMBOL\tPATH")
+	_, _ = fmt.Fprintln(tw, "KIND\tSYMBOL\tPACKAGE\tPATH")
 	for _, c := range res.Candidates {
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\n", c.Kind, c.Symbol, c.Path)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", c.Kind, c.Symbol, c.Package, c.Path)
 	}
 	_ = tw.Flush()
-	_, _ = fmt.Fprintf(w, "\n%d unexport candidate(s) in %s — referenced only intra-package. HEURISTIC; review before unexporting.\n",
-		len(res.Candidates), res.Module)
+	scope := "across the tree"
+	if res.Module != "" {
+		scope = "in " + res.Module
+	}
+	_, _ = fmt.Fprintf(w, "\n%d unexport candidate(s) %s — referenced only intra-package. HEURISTIC; review before unexporting.\n",
+		len(res.Candidates), scope)
 }


### PR DESCRIPTION
## Bug (found dogfooding 0.100.0 on real C#/Java/Python/Rust projects)

The cross-language rollout (#409) generalized `unused_exports` to 9 languages, but the CLI **table printer** kept a Go-era early-return: when there's no go.mod (`res.Module == ""`) it printed *"no go.mod found … resolves first-party Go packages only"* and returned. So for every Python / Rust / TS / Java / C# / Kotlin / Scala project the default table output showed **nothing**, even though the candidates were computed (`-o json` had them all).

## Fix

Drop the early-return; always print the candidate table (now with a `PACKAGE` column), and word the footer `in <module>` for Go or `across the tree` otherwise.

Verified on real projects:
- **C#** (`GitMeta-csharp`): flags `RunAsync` + test helpers
- **Java** (`cel2sql4j`): flags `ConvertOptions` accessors (plus the expected interface-override heuristics on `getMessage`/`getUserMessage`)

`vet`, `golangci-lint`, cmd tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)