### PR TITLE
fix(content): bound tree-sitter parse time so a pathological grammar can't hang the walk (#432)

### DIFF
--- a/internal/content/source_symbols_treesitter.go
+++ b/internal/content/source_symbols_treesitter.go
@@ -20,6 +20,13 @@ import (
 // `grammar_subset_<lang>` build tags (see CLAUDE.md / .goreleaser.yaml);
 // a build without those tags embeds all ~206 grammars (~+22 MB).
 
+// tsParseTimeoutMicros caps a single tree-sitter parse (issue #432). A
+// pathological grammar parse (notably Swift) can run for minutes on a small
+// file and isn't cancellable; this bounds it so the offending file is
+// skipped (no symbols) rather than hanging the walk. 5 s is far above any
+// healthy parse (milliseconds) yet well under a per-call timeout.
+const tsParseTimeoutMicros = 5_000_000
+
 // tsDetectFile maps our canonical `language` string to a representative
 // filename so grammars.DetectLanguage resolves the right LangEntry.
 var tsDetectFile = map[string]string{
@@ -343,7 +350,16 @@ func buildTSLang(language string) *tsLang {
 	if lang == nil {
 		return nil
 	}
-	tl := &tsLang{pool: ts.NewParserPool(lang)}
+	// Bound every parse with a hard time budget (issue #432). The
+	// tree-sitter Swift grammar — and potentially any grammar — can parse
+	// catastrophically slowly on certain real constructs (e.g. Alamofire's
+	// AFError.swift: 3+ minutes for 37 KB, not size-related), and the parse
+	// loop isn't cancellable, so one bad file would otherwise hang the whole
+	// walk past any --timeout. On expiry Parse returns early; every consumer
+	// already treats a nil/short tree as "no symbols", so the file degrades
+	// gracefully (the #337 invariant) instead of stalling. Normal files
+	// parse in milliseconds, so the cap only ever trips on pathological ones.
+	tl := &tsLang{pool: ts.NewParserPool(lang, ts.WithParserPoolTimeoutMicros(tsParseTimeoutMicros))}
 	// Bundled tags query is optional — some grammars (PHP, Perl) ship an
 	// empty one, in which case definitions come entirely from tsDefQuery.
 	if tagsSrc := grammars.ResolveTagsQuery(*entry); tagsSrc != "" {

--- a/internal/content/source_symbols_treesitter_test.go
+++ b/internal/content/source_symbols_treesitter_test.go
@@ -315,6 +315,28 @@ func TestTSNonExportedSymbols(t *testing.T) {
 	}
 }
 
+// TestParseTimeoutBudget guards the #432 fix: the tree-sitter parse budget
+// must stay a positive, sane value. Zero would mean "no timeout" in
+// gotreesitter, re-opening the door to a pathological grammar parse (Swift)
+// hanging the whole walk. (The behavioural proof — AFError.swift going from
+// 3+ min to ~7s — is verified manually against real Swift; it can't be
+// reproduced deterministically with a synthetic input.)
+func TestParseTimeoutBudget(t *testing.T) {
+	if tsParseTimeoutMicros <= 0 {
+		t.Fatalf("tsParseTimeoutMicros = %d; must be > 0 to bound pathological parses (#432)", tsParseTimeoutMicros)
+	}
+	// Healthy files parse in milliseconds, so the budget must be far above
+	// that (sanity: at least 1s) yet finite.
+	if tsParseTimeoutMicros < 1_000_000 {
+		t.Errorf("tsParseTimeoutMicros = %d (<1s) risks skipping healthy files", tsParseTimeoutMicros)
+	}
+	// A normal file still extracts fine under the cap.
+	funcs, _, _, _, _, _ := extractTreeSitterSymbols("swift", []byte("func greet() -> String { return \"hi\" }\n"))
+	if !slices.Contains(funcs, "greet") {
+		t.Errorf("normal swift file should still extract under the parse cap; got %v", funcs)
+	}
+}
+
 // TestExtractTreeSitterCallEdges checks per-function call attribution
 // (caller\x00callee pairs) via span-containment — the data behind calls().
 func TestExtractTreeSitterCallEdges(t *testing.T) {


### PR DESCRIPTION
Closes #432.

## Bug (found via cross-language OSS dogfooding)

Every code-graph tool **hung** on real Swift (`Alamofire` → all tools exit 124). Timed root cause on `AFError.swift` (37 KB / 874 lines): `gotreesitter` Swift `pool.Parse` took **3 m 5 s**; every query was ~3 ms. Not size-related (the 1441-line `Session.swift` parses fast); the parse loop isn't cancellable, so one bad file blocked the whole walk past any `--timeout`.

## Fix

Build each per-language `ParserPool` with **`WithParserPoolTimeoutMicros`** (5 s budget) in `buildTSLang`. On expiry the parse returns early; every consumer already treats a nil/short tree as "no symbols", so the offending file **degrades gracefully** (the #337 invariant) instead of stalling. Covers every tree-sitter language, not just Swift. Healthy files parse in milliseconds, so the cap only ever trips on pathological ones.

## Verification

- **Real Swift**: `AFError.swift` extraction **3 m 5 s → ~7 s**; `complexity` over the full Alamofire repo **200 s+ timeout → 20 s** (exit 0), skipping the few slow files.
- Regression test guards the budget constant (>0 and ≥1 s — zero would disable the cap) and that a normal Swift file still extracts under it. A deterministic synthetic blowup isn't reproducible (the pathology is grammar-specific to real Swift), so the behavioural proof is the manual Alamofire run.
- `go test -race ./internal/content ./internal/search` green; `vet`, `go fix`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)