### PR TITLE
refactor(search): remove dead ValidGroupBys accessor

### DIFF
--- a/internal/search/stats.go
+++ b/internal/search/stats.go
@@ -94,17 +94,6 @@ var validGroupBys = map[string]struct{}{
 	"date_day":                 {},
 }
 
-// ValidGroupBys returns the curated set of group_by keys ComputeStats
-// supports. Useful for CLI help text and the MCP tool description.
-func ValidGroupBys() []string {
-	out := make([]string, 0, len(validGroupBys))
-	for k := range validGroupBys {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
-}
-
 // detectorOnlyGroupBys are the group_by keys whose bucket value can be
 // read straight off the search.Result without parsing per-format
 // attributes. content_type / ext / dir come from Result fields; mtime_*

--- a/internal/search/walker.go
+++ b/internal/search/walker.go
@@ -332,7 +332,7 @@ type Options struct {
 	NearDupGroupLimit int
 
 	// GroupBy controls the bucketing key used by ComputeStats. See
-	// stats.go ValidGroupBys for the recognised set. Ignored by
+	// the validGroupBys set in stats.go for the recognised keys. Ignored by
 	// Walk/WalkStream — it only affects ComputeStats's aggregation.
 	GroupBy string
 


### PR DESCRIPTION
Self-dogfooding with v0.101.1 — `dead_code` is now accurate (init/main exclusion, value-refs, type usages), and the one genuine candidate it surfaced was `search.ValidGroupBys()`: an exported accessor over the `validGroupBys` map, **referenced only in a doc comment, never called**.

Its own doc claimed it was "useful for CLI help / the MCP tool description", but both hardcode the key list — the accessor was never wired up. It's in an internal package, so there are no external consumers. Removed it and repointed the `walker.go` comment at the `validGroupBys` map.

No behaviour change. `dead_code` on the repo drops 9 → 8 (the remaining 8 are all confirmed false positives: `cel.Activation`/`fs.FileInfo` interface methods, test-used/external-API exports, and the test fixture).

`go test ./internal/search`, `vet`, `go fix`, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)