### PR TITLE
fix(schema): is_source doc string omitted C# and 10 other languages

### DIFF
--- a/internal/celexpr/schema.go
+++ b/internal/celexpr/schema.go
@@ -54,7 +54,7 @@ func Schema() SchemaDoc {
 			{"is_archive", "bool", "true if archive file (ZIP, TAR, TAR.GZ, GZIP — content_type starts with 'archive/')"},
 			{"is_binary", "bool", "true if compiled binary (ELF, Mach-O, PE — content_type starts with 'binary/')"},
 			{"is_email", "bool", "true if email message or mbox archive (.eml, .mbox — content_type starts with 'email/')"},
-			{"is_source", "bool", "true if source code (Go, Python, JS/TS, Rust, C/C++, Java, Ruby, Swift, Kotlin, Scala, Shell, Lua, Elixir, Clojure, Haskell, OCaml, Zig — content_type starts with 'source/')"},
+			{"is_source", "bool", "true if source code (Go, Python, JS/TS, Rust, C/C++, Java, Ruby, Swift, Kotlin, Scala, C#, PHP, Perl, R, MATLAB, Shell, Lua, Elixir, Clojure, Haskell, OCaml, Zig, Ada, SQL, Visual Basic, Fortran, Assembly, Pascal — content_type starts with 'source/')"},
 			{"is_notebook", "bool", "true if computational notebook (Jupyter .ipynb or Zeppelin .zpln — content_type starts with 'notebook/')"},
 			{"is_yaml", "bool", "true if YAML file (.yaml, .yml — covers CI configs, K8s manifests, GoReleaser, Docker Compose)"},
 			{"is_toml", "bool", "true if TOML file (.toml — covers pyproject.toml, Cargo.toml, etc.). Also fires for Cargo.toml/Cargo.lock alongside is_cargo_manifest"},

--- a/internal/celexpr/schema_is_source_test.go
+++ b/internal/celexpr/schema_is_source_test.go
@@ -1,0 +1,130 @@
+package celexpr_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+	"github.com/richardwooding/file-search-on/internal/content"
+)
+
+// sourceDisplayToken maps each registered `source/<slug>` language to the
+// exact token the is_source doc string uses for it. Several slugs share a
+// token on purpose (javascript+typescript -> "JS/TS", c+cpp -> "C/C++").
+//
+// This map is the forcing function: when you `registerSource(...)` a new
+// language, TestIsSourceDocCoversEveryRegisteredLanguage fails until you
+// (a) add the slug here and (b) add its token to the is_source description
+// in Schema() (schema.go). The is_source string feeds both the CLI --list
+// output and the MCP list_attributes tool, and it has silently drifted
+// before (C# and several others were missing) — this test pins it shut.
+var sourceDisplayToken = map[string]string{
+	"go":         "Go",
+	"javascript": "JS/TS",
+	"typescript": "JS/TS",
+	"rust":       "Rust",
+	"c":          "C/C++",
+	"cpp":        "C/C++",
+	"java":       "Java",
+	"swift":      "Swift",
+	"kotlin":     "Kotlin",
+	"scala":      "Scala",
+	"zig":        "Zig",
+	"python":     "Python",
+	"shell":      "Shell",
+	"elixir":     "Elixir",
+	"ruby":       "Ruby",
+	"lua":        "Lua",
+	"haskell":    "Haskell",
+	"ocaml":      "OCaml",
+	"clojure":    "Clojure",
+	"csharp":     "C#",
+	"php":        "PHP",
+	"perl":       "Perl",
+	"r":          "R",
+	"ada":        "Ada",
+	"sql":        "SQL",
+	"vb":         "Visual Basic",
+	"fortran":    "Fortran",
+	"matlab":     "MATLAB",
+	"assembly":   "Assembly",
+	"pascal":     "Pascal",
+}
+
+// registeredSourceSlugs returns the language slug for every registered
+// `source/<slug>` content type (e.g. "csharp" for "source/csharp").
+func registeredSourceSlugs(t *testing.T) []string {
+	t.Helper()
+	var slugs []string
+	for _, ct := range content.DefaultRegistry().Types() {
+		if slug, ok := strings.CutPrefix(ct.Name(), "source/"); ok {
+			slugs = append(slugs, slug)
+		}
+	}
+	if len(slugs) == 0 {
+		t.Fatal("no source/* content types registered; importing internal/content should trigger their init()")
+	}
+	return slugs
+}
+
+// isSourceDocTokens parses the comma-separated language tokens out of the
+// is_source attribute description, i.e. the bit before the em dash in
+// "true if source code (Go, Python, ... Pascal — content_type ...)".
+func isSourceDocTokens(t *testing.T) map[string]bool {
+	t.Helper()
+	var desc string
+	for _, a := range celexpr.Schema().Common {
+		if a.Name == "is_source" {
+			desc = a.Description
+			break
+		}
+	}
+	if desc == "" {
+		t.Fatal("is_source attribute not found in Schema().Common")
+	}
+	open := strings.IndexByte(desc, '(')
+	dash := strings.Index(desc, "—")
+	if open < 0 || dash < 0 || dash < open {
+		t.Fatalf("is_source description not in expected '(... — ...)' form: %q", desc)
+	}
+	tokens := map[string]bool{}
+	for tok := range strings.SplitSeq(desc[open+1:dash], ",") {
+		if tok = strings.TrimSpace(tok); tok != "" {
+			tokens[tok] = true
+		}
+	}
+	return tokens
+}
+
+// TestIsSourceDocCoversEveryRegisteredLanguage guards against the
+// is_source doc string drifting out of sync with the registered source
+// languages. Both directions are checked so adding or removing a language
+// without updating the doc string fails CI.
+func TestIsSourceDocCoversEveryRegisteredLanguage(t *testing.T) {
+	slugs := registeredSourceSlugs(t)
+	docTokens := isSourceDocTokens(t)
+
+	// Forward: every registered language must have a mapping and its token
+	// must appear in the doc string.
+	claimed := map[string]bool{}
+	for _, slug := range slugs {
+		token, ok := sourceDisplayToken[slug]
+		if !ok {
+			t.Errorf("registered source language %q has no entry in sourceDisplayToken; add it here and to the is_source description in schema.go", slug)
+			continue
+		}
+		if !docTokens[token] {
+			t.Errorf("source language %q (token %q) is missing from the is_source description in schema.go", slug, token)
+		}
+		claimed[token] = true
+	}
+
+	// Reverse: every token in the doc string must be claimed by some
+	// registered language — catches a language that was removed but left
+	// dangling in the doc string.
+	for token := range docTokens {
+		if !claimed[token] {
+			t.Errorf("is_source description lists %q but no registered source language maps to it; remove it from schema.go (or add the language)", token)
+		}
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -165,7 +165,7 @@ Use these boolean type predicates directly in your CEL expression — no need to
   is_deb        .deb (Debian binary package, ar archive)
   is_rpm        .rpm (Red Hat Package Manager — surfaces package_name/version/release/arch from the legacy Lead)
   is_appimage   .appimage (Linux portable ELF + appended SquashFS)
-  is_test_file  source/* file whose basename matches its language's test convention (*_test.go for Go, test_*.py / *_test.py for Python, *.test.{js,ts,tsx} / *.spec.{...} for JS/TS, *Test.java / *Tests.java / *IT.java for Java, *_spec.rb / *_test.rb for Ruby, *Tests.swift / *Test.kt / *Spec.scala for Swift/Kotlin/Scala, tests/*.rs for Rust integration tests)
+  is_test_file  source/* file whose basename matches its language's test convention (*_test.go for Go, test_*.py / *_test.py for Python, *.test.{js,ts,tsx} / *.spec.{...} for JS/TS, *Test.java / *Tests.java / *IT.java for Java, *_spec.rb / *_test.rb for Ruby, *Tests.swift / *Test.kt / *Spec.scala for Swift/Kotlin/Scala, *Test.cs / *Tests.cs for C#, tests/*.rs for Rust integration tests)
   is_bytecode   .class (Java), .pyc / .pyo (Python), .wasm (WebAssembly) — umbrella across all VM bytecode formats
   is_class      Java .class file (CAFEBABE magic) — surfaces class_name, super_class, interfaces, method_count, field_count, access_flags
   is_pyc        Python compiled bytecode (.pyc / .pyo) — surfaces python_version, source_mtime


### PR DESCRIPTION
## Problem

An MCP client concluded that C# wasn't a tree-sitter / source language. The cause: the `is_source` `AttributeDoc` in `celexpr.Schema()` listed only **17 of the 30** registered source languages. Missing: **C#, PHP, Perl, R, MATLAB, Ada, SQL, Visual Basic, Fortran, Assembly, Pascal**.

That string is the single source for both the CLI `--list` output and the MCP `list_attributes` tool, so a client discovering support via `list_attributes` saw no C# — even though tree-sitter symbol extraction has covered it since #365. The authoritative `tsDetectFile` map and the MCP instructions blob (`server.go:154`) were already correct; only this doc string had drifted.

## Changes

- **`internal/celexpr/schema.go`** — `is_source` description now lists all 30 registered source languages.
- **`internal/mcpserver/server.go`** — added the missing C# test convention (`*Test.cs / *Tests.cs`) to the `is_test_file` description.
- **`internal/celexpr/schema_is_source_test.go`** (new) — `TestIsSourceDocCoversEveryRegisteredLanguage` diffs the `is_source` doc string against every registered `source/*` content type **in both directions**, so adding or removing a language without updating the doc string fails CI. Verified it bites: temporarily dropping `C#` fails with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)