### PR TITLE
feat(codegraph): enable dead_code/test_gaps for 8 more languages + fix Perl method-call refs (#444)

### DIFF
--- a/internal/content/source_symbols_migrate_test.go
+++ b/internal/content/source_symbols_migrate_test.go
@@ -47,12 +47,16 @@ func TestMigratedLanguages(t *testing.T) {
 			wantRefs:    []string{"helper"},
 		},
 		{
-			language:    "perl",
-			src:         "use strict;\nuse List::Util;\npackage Widget;\n\nsub greet { helper(); }\nsub other { }\n",
+			language: "perl",
+			// `$self->process()` is a method_call_expression — captured as a
+			// reference since the refExtractionLangs expansion (#444). Without
+			// it, Perl method calls were invisible and dead_code over-reported
+			// (mojo dead ratio 84% -> 23% once method calls counted).
+			src:         "use strict;\nuse List::Util;\npackage Widget;\n\nsub greet { my $self = shift; helper(); $self->process(); }\nsub other { }\n",
 			wantFuncs:   []string{"greet", "other"},
 			wantTypes:   []string{"Widget"},
 			wantImports: []string{"strict", "List::Util"},
-			wantRefs:    []string{"helper"},
+			wantRefs:    []string{"helper", "process"},
 		},
 		{
 			language:    "r",

--- a/internal/content/source_symbols_treesitter.go
+++ b/internal/content/source_symbols_treesitter.go
@@ -148,7 +148,8 @@ var tsRefQuery = map[string]string{
 	"php":    `(function_call_expression (name) @reference)
 (member_call_expression name: (name) @reference)
 (scoped_call_expression name: (name) @reference)`,
-	"perl":   `(ambiguous_function_call_expression (function) @reference)`,
+	"perl": `(ambiguous_function_call_expression (function) @reference)
+(method_call_expression (method) @reference)`,
 	"r":      `(call function: (identifier) @reference)`,
 	"scala":  `(call_expression (identifier) @reference)`,
 	"matlab":  `(function_call (identifier) @reference)`,

--- a/internal/search/codegraph.go
+++ b/internal/search/codegraph.go
@@ -125,6 +125,13 @@ func (g *CodeGraph) GeneratedHint(paths []string) string {
 var refExtractionLangs = map[string]bool{
 	"go": true, "rust": true, "typescript": true, "javascript": true,
 	"ruby": true, "swift": true, "kotlin": true, "c": true, "cpp": true,
+	// #365-migrated tree-sitter languages — all carry a tsRefQuery, so
+	// their call sites ARE extracted; they were simply never enabled for
+	// the dead_code / test_gaps definition set, which made every symbol in
+	// these languages invisible to those tools. Validated against the OSS
+	// corpus (dead-code ratios comparable to Go/Rust). Part of #444 / #443.
+	"python": true, "java": true, "csharp": true, "php": true,
+	"perl": true, "r": true, "matlab": true, "scala": true,
 }
 
 type fileFanOut struct {


### PR DESCRIPTION
**Phase 0** of #443 (continues #450).

## Problem
`dead_code` and `test_gaps` only consider definitions in `refExtractionLangs` — **9 languages**. A definition in any other language is silently excluded (it would always look "dead" since calls aren't scanned). But **all 16 tree-sitter languages carry a `tsRefQuery`** — their call sites are already extracted; they were just never enabled. So `dead_code`/`test_gaps` returned *nothing* for Python, Java, C#, PHP, Perl, R, MATLAB, Scala.

## Change
Enable the 8 `#365`-migrated languages in `refExtractionLangs`, **validated against the `~/Code/OpenSource` corpus** by comparing dead-code ratios (dead ÷ total definitions) to the established baseline:

| lang | dead ratio | | lang | dead ratio |
|---|---|---|---|---|
| go (baseline) | 6% | | scala | 60% |
| rust (baseline) | 36% | | csharp | 63% |
| r | 30% | | python | 66% |
| matlab | 47% | | php | 67% |
| java | 55% | | | |

All sit in the same regime as Rust — the higher numbers are library public-API surface (gson/flask/guzzle are libraries; public API called only externally legitimately reads as "dead", a documented heuristic caveat). If method calls weren't captured, ratios would be ~95%+.

## Perl fix (real under-extraction)
Perl was the outlier at **84%**: its ref query captured only bareword calls (`ambiguous_function_call_expression`), **missing `$obj->method()`**. Added `(method_call_expression (method) @reference)` → mojo **84% → 23%**, libwww-perl → **31%**. That confirms it was genuine under-extraction, not a library effect, and brings Perl in line.

## Tests
The Perl migrate case now exercises a `$self->process()` method call in `wantRefs` — regression-guarding the fix. Full `go test ./...`, vet, modernizer clean.

Next in Phase 0: add the missing `tsTypeRefQuery` coverage (JS / Ruby / Perl / R / MATLAB) to cut dead-code false positives for type-only uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)