### PR TITLE
feat(content): type-usage refs for JavaScript (new) and Ruby (superclass/constant) (#444)

### DIFF
--- a/internal/content/source_symbols_treesitter.go
+++ b/internal/content/source_symbols_treesitter.go
@@ -178,7 +178,18 @@ var tsTypeRefQuery = map[string]string{
 (let_declaration (type_identifier) @typeref)
 (reference_type (type_identifier) @typeref)`,
 	"typescript": `(type_annotation (type_identifier) @typeref)
-(type_arguments (type_identifier) @typeref)`,
+(type_arguments (type_identifier) @typeref)
+(new_expression constructor: (identifier) @typeref)`,
+	// JavaScript has no type annotations, but a class used only via
+	// `new Foo()` would otherwise never appear as a reference and read as
+	// dead. Capture the constructor identifier as a type usage (#444).
+	"javascript": `(new_expression constructor: (identifier) @typeref)`,
+	// Ruby is dynamically typed; "type usage" is a superclass in a class
+	// definition (`class Widget < Base`) or a constant receiver
+	// (`Helper.go`) — neither captured by the call/ref query, so a
+	// referenced-only-as-a-base class read as dead before this (#444).
+	"ruby": `(superclass (constant) @typeref)
+(call receiver: (constant) @typeref)`,
 	"python": `(type (identifier) @typeref)`,
 	"java": `(field_declaration (type_identifier) @typeref)
 (formal_parameter (type_identifier) @typeref)
@@ -208,6 +219,11 @@ var tsTypeRefQuery = map[string]string{
 (function_definition (type_identifier) @typeref)
 (val_definition (type_identifier) @typeref)`,
 	"php": `(named_type (name) @typeref)`,
+	// Perl / R / MATLAB intentionally have no typeref query: they have no
+	// static type-annotation syntax, and their "types" (packages / S4
+	// classes / classdefs) are referenced through the ordinary call path
+	// already captured by tsRefQuery — so there's no type-only-usage gap
+	// to close for dead-code accuracy.
 }
 
 // tsExportedQuery captures the names of PUBLIC function/type definitions as

--- a/internal/content/source_symbols_treesitter_test.go
+++ b/internal/content/source_symbols_treesitter_test.go
@@ -221,6 +221,13 @@ func build(c: Cog) -> Sprocket { let b: Bolt = make() }`,
 			[]string{"Widget", "Cog", "Sprocket", "Bolt"}},
 		{"php", `<?php class Holder { public Widget $w; function build(Cog $c): Sprocket {} }`,
 			[]string{"Widget", "Cog", "Sprocket"}},
+		// JavaScript: no annotations, but a class used only via `new Foo()`
+		// must surface as a reference (#444) or it reads as dead.
+		{"javascript", "class Holder {}\nfunction build(){ return new Widget(); }\n",
+			[]string{"Widget"}},
+		// Ruby: superclass + constant receiver are the "type usages".
+		{"ruby", "class Widget < Base\n  def m; Helper.go; end\nend\n",
+			[]string{"Base", "Helper"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.language, func(t *testing.T) {


### PR DESCRIPTION
**Phase 0** of #443 (continues #450, #451). The type-ref coverage half.

## Problem
`tsTypeRefQuery` had no entry for JavaScript or Ruby, so type *usages* in those languages never counted as references and the types read as dead:
- JS: a class used only via `new Foo()` → `Foo` never referenced.
- Ruby: a class used only as a superclass (`class X < Base`) or constant receiver (`Helper.go`) → `Base` / `Helper` never referenced.

## Change
- **javascript**: `(new_expression constructor: (identifier) @typeref)`
- **typescript**: also capture `new_expression` (class-via-`new`), alongside its existing type-annotation refs
- **ruby**: `(superclass (constant) @typeref)` + `(call receiver: (constant) @typeref)`

typerefs merge into `references` (`source_symbols_treesitter.go:450`), so this feeds `dead_code` / `who_calls` directly.

### Verified
- JS `new Widget()` → `refs=[Widget]` (was `[]`)
- Ruby `class Widget < Base; Helper.go` → `refs=[go Base Helper]` (was `[go]`)

## Deliberately omitted
**Perl / R / MATLAB** get no typeref query (documented in the map): they have no static type-annotation syntax, and their packages / S4 classes / classdefs are referenced through the ordinary call path already captured by `tsRefQuery` — so there's no type-only-usage gap to close.

Regression cases added to `TestExtractTreeSitterTypeRefs` for js + ruby.

## Phase 0 status (#444)
With this + #450 (benchmark) + #451 (refExtractionLangs + Perl method calls), Phase 0 is complete: a regression-gated cross-language benchmark, `dead_code`/`test_gaps` enabled for all 17 wired languages, and the reference/type-ref under-extraction gaps (Perl method calls, JS/Ruby type usage) closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)