### PR TITLE
feat(codegraph): surface method owners in dead_code / who_calls / references (#445)

### DIFF
--- a/cmd/file-search-on/codegraph_cmd.go
+++ b/cmd/file-search-on/codegraph_cmd.go
@@ -230,9 +230,10 @@ func (c *WhoCallsCmd) Run(ctx context.Context) error {
 		return nil
 	}
 	callers := g.WhoCalls(c.Symbol)
+	definedOn := g.OwnersOf(c.Symbol)
 	if c.Output == "json" {
 		_ = writeJSON(os.Stdout, map[string]any{
-			"symbol": c.Symbol, "callers": callers, "count": len(callers), "total_files": g.TotalFiles,
+			"symbol": c.Symbol, "defined_on": definedOn, "callers": callers, "count": len(callers), "total_files": g.TotalFiles,
 		})
 	} else {
 		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
@@ -240,6 +241,9 @@ func (c *WhoCallsCmd) Run(ctx context.Context) error {
 			_, _ = fmt.Fprintf(tw, "%s\t%s\n", im.Language, im.Path)
 		}
 		_ = tw.Flush()
+		if len(definedOn) > 0 {
+			_, _ = fmt.Fprintf(os.Stderr, "%q is a method on: %s\n", c.Symbol, strings.Join(definedOn, ", "))
+		}
 		_, _ = fmt.Fprintf(os.Stderr, "%d file(s) call %q (of %d source files)\n", len(callers), c.Symbol, g.TotalFiles)
 	}
 	return codeGraphExit(c.Timeout, parentCtx, effectiveCtx, g, "who-calls")

--- a/cmd/file-search-on/references_cmd.go
+++ b/cmd/file-search-on/references_cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -81,5 +82,8 @@ func printReferencesTable(w *os.File, res *search.ReferencesResult) {
 		_, _ = fmt.Fprintf(tw, "%s:%d\t%s\n", r.Path, r.Line, r.Kind)
 	}
 	_ = tw.Flush()
+	if len(res.DefinedOn) > 0 {
+		_, _ = fmt.Fprintf(os.Stderr, "%q is a method on: %s\n", res.Symbol, strings.Join(res.DefinedOn, ", "))
+	}
 	_, _ = fmt.Fprintf(os.Stderr, "%d usage(s) of %q (of %d source files)\n", res.Count, res.Symbol, res.TotalFiles)
 }

--- a/internal/mcpserver/codegraph_tools.go
+++ b/internal/mcpserver/codegraph_tools.go
@@ -235,7 +235,11 @@ type WhoCallsInput struct {
 // WhoCallsOutput lists every file that calls/references the symbol.
 type WhoCallsOutput struct {
 	CommonOutput
-	Symbol             string            `json:"symbol"`
+	Symbol string `json:"symbol"`
+	// DefinedOn lists the types the queried symbol is a method on (#445),
+	// when any — a hint that these name-based caller results may mix calls
+	// to same-named methods on different types. Go only for now.
+	DefinedOn          []string          `json:"defined_on,omitempty"`
 	Callers            []search.Importer `json:"callers"`
 	Count              int               `json:"count"`
 	TotalFiles         int64             `json:"total_files"`
@@ -261,6 +265,7 @@ func (h *handlers) whoCallsHandler(ctx context.Context, _ *mcp.CallToolRequest, 
 	callers := g.WhoCalls(in.Symbol)
 	out := WhoCallsOutput{
 		Symbol:             in.Symbol,
+		DefinedOn:          g.OwnersOf(in.Symbol),
 		Callers:            callers,
 		Count:              len(callers),
 		TotalFiles:         g.TotalFiles,

--- a/internal/mcpserver/references_tool.go
+++ b/internal/mcpserver/references_tool.go
@@ -22,6 +22,7 @@ type ReferencesOutput struct {
 	CommonOutput
 	Symbol             string                 `json:"symbol"`
 	Kind               string                 `json:"kind,omitempty"`
+	DefinedOn          []string               `json:"defined_on,omitempty"` // method owner types of the queried symbol (#445)
 	References         []search.ReferenceSite `json:"references"`
 	Count              int                    `json:"count"`
 	TotalFiles         int64                  `json:"total_files"`
@@ -50,6 +51,7 @@ func (h *handlers) referencesHandler(ctx context.Context, _ *mcp.CallToolRequest
 	out := ReferencesOutput{
 		Symbol:             res.Symbol,
 		Kind:               in.Kind,
+		DefinedOn:          res.DefinedOn,
 		References:         res.References,
 		Count:              res.Count,
 		TotalFiles:         res.TotalFiles,

--- a/internal/search/codegraph.go
+++ b/internal/search/codegraph.go
@@ -373,6 +373,24 @@ func (g *CodeGraph) WhoCalls(name string) []Importer {
 	return out
 }
 
+// OwnersOf returns the distinct owning types of every method definition
+// named `name` (#445), sorted. Empty when `name` names only plain
+// functions/types or isn't defined. Lets the name-based lookups
+// (who_calls / references) report "this name is a method on these types",
+// surfacing the ambiguity behind a same-name query. Go only for now.
+func (g *CodeGraph) OwnersOf(name string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, e := range g.definedIn[name] {
+		if e.owner != "" && !seen[e.owner] {
+			seen[e.owner] = true
+			out = append(out, e.owner)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 // Calls returns the distinct callee names that any function named `name`
 // invokes, sorted. Name-based and unioned across every file that defines
 // a function with that name. Covers Go + the tree-sitter languages whose
@@ -568,12 +586,12 @@ func (g *CodeGraph) DeadCode() []SymbolDef {
 			if isReflectionDispatchedEntry(e.kind, name, e.path, e.language) {
 				continue
 			}
-			key := e.kind + "\x00" + name + "\x00" + e.path
+			key := e.kind + "\x00" + name + "\x00" + e.path + "\x00" + e.owner
 			if seen[key] {
 				continue
 			}
 			seen[key] = true
-			out = append(out, SymbolDef{Path: e.path, Language: e.language, Kind: e.kind, Symbol: name})
+			out = append(out, SymbolDef{Path: e.path, Language: e.language, Kind: e.kind, Symbol: name, Owner: e.owner})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/internal/search/codegraph_test.go
+++ b/internal/search/codegraph_test.go
@@ -197,6 +197,42 @@ func TestCodeGraph_FindDefinition_Owner(t *testing.T) {
 	}
 }
 
+// TestCodeGraph_OwnersOf_AndDeadCodeOwner pins owner surfacing on the
+// name-based lookups (#445): OwnersOf reports the types a method name is
+// defined on, and DeadCode carries the owning type on a dead method.
+func TestCodeGraph_OwnersOf_AndDeadCodeOwner(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(rel, body string) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Lonely.Unused is defined but never referenced anywhere -> dead.
+	mk("a/a.go", "package a\n\ntype Lonely struct{}\n\nfunc (l *Lonely) Unused() {}\n")
+	g := mustBuildGraph(t, dir)
+
+	if got := g.OwnersOf("Unused"); len(got) != 1 || got[0] != "Lonely" {
+		t.Errorf("OwnersOf(Unused)=%v, want [Lonely]", got)
+	}
+	dead := g.DeadCode()
+	var found bool
+	for _, d := range dead {
+		if d.Symbol == "Unused" {
+			found = true
+			if d.Owner != "Lonely" {
+				t.Errorf("dead Unused owner=%q, want Lonely", d.Owner)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("DeadCode did not report Unused; got %+v", dead)
+	}
+}
+
 // buildCallFixture has clear intra-repo call edges:
 //
 //	a.go    — func Helper(); func Used() { Helper() }   (Helper is called)

--- a/internal/search/references.go
+++ b/internal/search/references.go
@@ -19,7 +19,11 @@ type ReferenceSite struct {
 
 // ReferencesResult is the find-all-usages report for a symbol.
 type ReferencesResult struct {
-	Symbol             string          `json:"symbol"`
+	Symbol string `json:"symbol"`
+	// DefinedOn lists the types the queried symbol is a method on (#445),
+	// when any — a disambiguation hint that these name-based results may
+	// mix usages of same-named methods on different types. Go only for now.
+	DefinedOn          []string        `json:"defined_on,omitempty"`
 	References         []ReferenceSite `json:"references"`
 	Count              int             `json:"count"`
 	TotalFiles         int64           `json:"total_files"`
@@ -53,6 +57,7 @@ func References(ctx context.Context, opts Options, symbol, kind string, registry
 	if symbol == "" {
 		return res, nil
 	}
+	res.DefinedOn = g.OwnersOf(symbol)
 	for _, c := range g.WhoCalls(symbol) {
 		if err := ctx.Err(); err != nil {
 			res.Cancelled = true


### PR DESCRIPTION
**Phase 1** of #443, continuing #453 (find_definition owners) across the rest of the Go lookup tools.

## Change
- **dead_code**: `SymbolDef` now carries `Owner` (the dead symbol's owning type), and owner is part of the dedup identity — a dead method reports `Owner="Lonely"`.
- **who_calls / references**: add a `defined_on` field listing the types the queried symbol is a method on (new `CodeGraph.OwnersOf` helper). These tools are name-based, so `defined_on` surfaces the ambiguity — *"String" is a method on [Indicator]* — telling callers the results may mix same-named methods on different types.

Wired through the CLI (who-calls / references print `"X" is a method on: …`) and MCP (`who_calls` / `references` outputs gain `defined_on`; dead_code's `SymbolDef.Owner` flows via JSON).

## Scope
Still **Go-only** (`method_owners` is populated only for Go); tree-sitter languages are the next PR. Reporting-only — the over-matching reduction is Phase 3.

## Tests
`TestCodeGraph_OwnersOf_AndDeadCodeOwner` (OwnersOf + dead-method owner). Verified e2e on this repo: who-calls/references report `"String" is a method on: Indicator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)