### PR TITLE
feat(content): method-owner qualification for the tree-sitter languages (#445)

### DIFF
--- a/internal/content/source_symbols_method_owner.go
+++ b/internal/content/source_symbols_method_owner.go
@@ -1,0 +1,140 @@
+package content
+
+import (
+	ts "github.com/odvcencio/gotreesitter"
+)
+
+// methodOwnerSpec describes, for one tree-sitter language, how to find a
+// method's owning type: the node types that are method definitions, the
+// enclosing container node types (class / struct / impl / …), and the
+// field that names the container. Empty containerField means "the first
+// named child that is a (type_)identifier".
+type methodOwnerSpec struct {
+	methodNodes   []string
+	containerNode []string
+	containerName string // field name on the container giving its name node
+}
+
+// tsMethodOwnerSpec drives tsMethodOwners (#445). Covers the class-based
+// languages where "a method belongs to a type" is a clean syntactic
+// nesting. Languages absent here (C — no methods; Perl / R / MATLAB — no
+// class-method nesting we model) simply produce no owners, and their
+// methods stay bare, exactly as before.
+var tsMethodOwnerSpec = map[string]methodOwnerSpec{
+	"java":       {methodNodes: []string{"method_declaration", "constructor_declaration"}, containerNode: []string{"class_declaration", "interface_declaration", "enum_declaration", "record_declaration"}, containerName: "name"},
+	"csharp":     {methodNodes: []string{"method_declaration", "constructor_declaration"}, containerNode: []string{"class_declaration", "struct_declaration", "interface_declaration", "record_declaration"}, containerName: "name"},
+	// Kotlin names its function_declaration / class_declaration with a bare
+	// simple_identifier / type_identifier child (no `name` field) — handled
+	// by the first-name-child fallback in symbolName.
+	"kotlin":     {methodNodes: []string{"function_declaration"}, containerNode: []string{"class_declaration", "object_declaration"}, containerName: "name"},
+	"scala":      {methodNodes: []string{"function_definition"}, containerNode: []string{"class_definition", "object_definition", "trait_definition"}, containerName: "name"},
+	"php":        {methodNodes: []string{"method_declaration"}, containerNode: []string{"class_declaration", "interface_declaration", "trait_declaration", "enum_declaration"}, containerName: "name"},
+	"python":     {methodNodes: []string{"function_definition"}, containerNode: []string{"class_definition"}, containerName: "name"},
+	"ruby":       {methodNodes: []string{"method"}, containerNode: []string{"class", "module"}, containerName: "name"},
+	"typescript": {methodNodes: []string{"method_definition"}, containerNode: []string{"class_declaration", "class"}, containerName: "name"},
+	"javascript": {methodNodes: []string{"method_definition"}, containerNode: []string{"class_declaration", "class"}, containerName: "name"},
+	"swift":      {methodNodes: []string{"function_declaration"}, containerNode: []string{"class_declaration", "protocol_declaration"}, containerName: "name"},
+	// Rust methods live in `impl Type { fn … }`; the owner is the impl's
+	// `type` field, not a `name`.
+	"rust": {methodNodes: []string{"function_item"}, containerNode: []string{"impl_item"}, containerName: "type"},
+	// C++ is intentionally omitted: a method's name is buried in a
+	// function_declarator (function_definition → declarator → declarator),
+	// not a direct field/child, so the parent-walk model doesn't capture it
+	// cleanly. C++ methods stay bare for now.
+}
+
+// tsMethodOwners returns "method\x00owner" pairs for every method nested in
+// a type container (#445), so the code graph can disambiguate same-named
+// methods across types in the tree-sitter languages — the cross-language
+// counterpart to goMethodOwners. Returns nil for languages without a spec
+// or when the parse yields nothing.
+func tsMethodOwners(language string, src []byte) []string {
+	spec, ok := tsMethodOwnerSpec[language]
+	if !ok {
+		return nil
+	}
+	tl := tsLangFor(language)
+	if tl == nil || tl.lang == nil {
+		return nil
+	}
+	tree, err := tl.pool.Parse(src)
+	if err != nil || tree == nil {
+		return nil
+	}
+	methodSet := sliceToSet(spec.methodNodes)
+	containerSet := sliceToSet(spec.containerNode)
+
+	var out []string
+	var walk func(n *ts.Node)
+	walk = func(n *ts.Node) {
+		if n == nil {
+			return
+		}
+		if methodSet[n.Type(tl.lang)] {
+			if name := symbolName(n, "name", src, tl.lang); name != "" {
+				if owner := enclosingOwner(n, containerSet, spec.containerName, src, tl.lang); owner != "" {
+					out = append(out, name+"\x00"+owner)
+				}
+			}
+		}
+		for i := 0; i < n.ChildCount(); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(tree.RootNode())
+	return out
+}
+
+// enclosingOwner walks up from a method node to the nearest container in
+// containerSet and returns its name (via the containerName field, base
+// identifier extracted), or "" if none.
+func enclosingOwner(method *ts.Node, containerSet map[string]bool, nameField string, src []byte, lang *ts.Language) string {
+	for p := method.Parent(); p != nil; p = p.Parent() {
+		if containerSet[p.Type(lang)] {
+			return baseTypeName(symbolName(p, nameField, src, lang))
+		}
+	}
+	return ""
+}
+
+// nameNodeTypes are the node types that name a definition when a grammar
+// exposes the name as a bare child rather than a `name` field (e.g. Kotlin
+// simple_identifier / type_identifier).
+var nameNodeTypes = map[string]bool{
+	"identifier": true, "simple_identifier": true, "type_identifier": true,
+	"field_identifier": true, "constant": true, "name": true,
+}
+
+// symbolName returns a node's name: the named `field` if present, else the
+// first direct child whose type is a recognised name node. "" when neither.
+func symbolName(n *ts.Node, field string, src []byte, lang *ts.Language) string {
+	if c := n.ChildByFieldName(field, lang); c != nil {
+		return c.Text(src)
+	}
+	for i := 0; i < n.ChildCount(); i++ {
+		ch := n.Child(i)
+		if ch != nil && nameNodeTypes[ch.Type(lang)] {
+			return ch.Text(src)
+		}
+	}
+	return ""
+}
+
+// baseTypeName strips a generic suffix and surrounding whitespace from a
+// type expression: "Gen<T>" / "Gen[T]" → "Gen". Leaves plain names intact.
+func baseTypeName(s string) string {
+	for i, r := range s {
+		if r == '<' || r == '[' || r == ' ' || r == '\n' || r == '\t' {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+func sliceToSet(xs []string) map[string]bool {
+	m := make(map[string]bool, len(xs))
+	for _, x := range xs {
+		m[x] = true
+	}
+	return m
+}

--- a/internal/content/source_symbols_method_owner_test.go
+++ b/internal/content/source_symbols_method_owner_test.go
@@ -1,0 +1,39 @@
+package content
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestTSMethodOwners(t *testing.T) {
+	cases := []struct {
+		language string
+		src      string
+		want     string // "method\x00owner"
+	}{
+		{"java", "class Widget { void run() {} }", "run\x00Widget"},
+		{"csharp", "class Widget { void Run() {} }", "Run\x00Widget"},
+		{"kotlin", "class Widget {\n    fun run() {}\n}\n", "run\x00Widget"},
+		{"scala", "class Widget { def run(): Unit = {} }", "run\x00Widget"},
+		{"php", "<?php class Widget { function run() {} }", "run\x00Widget"},
+		{"python", "class Widget:\n    def run(self):\n        pass\n", "run\x00Widget"},
+		{"ruby", "class Widget\n  def run; end\nend\n", "run\x00Widget"},
+		{"typescript", "class Widget { run(): void {} }", "run\x00Widget"},
+		{"javascript", "class Widget { run() {} }", "run\x00Widget"},
+		{"swift", "class Widget { func run() {} }", "run\x00Widget"},
+		{"rust", "struct Widget;\nimpl Widget { fn run(&self) {} }", "run\x00Widget"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.language, func(t *testing.T) {
+			got := tsMethodOwners(tc.language, []byte(tc.src))
+			if !slices.Contains(got, tc.want) {
+				pretty := make([]string, len(got))
+				for i, g := range got {
+					pretty[i] = strings.ReplaceAll(g, "\x00", ".")
+				}
+				t.Errorf("tsMethodOwners(%s)=%v, want %q", tc.language, pretty, strings.ReplaceAll(tc.want, "\x00", "."))
+			}
+		})
+	}
+}

--- a/internal/content/source_symbols_treesitter.go
+++ b/internal/content/source_symbols_treesitter.go
@@ -338,6 +338,7 @@ var tsDecisionQuery = map[string]string{
 // language on first use.
 type tsLang struct {
 	pool        *ts.ParserPool
+	lang        *ts.Language // the grammar; needed for Node.Type / ChildByFieldName
 	tagsQuery   *ts.Query
 	defQuery    *ts.Query // supplemental @function/@type; nil when none
 	importQuery *ts.Query // nil when none configured or compile failed
@@ -390,7 +391,7 @@ func buildTSLang(language string) *tsLang {
 	// already treats a nil/short tree as "no symbols", so the file degrades
 	// gracefully (the #337 invariant) instead of stalling. Normal files
 	// parse in milliseconds, so the cap only ever trips on pathological ones.
-	tl := &tsLang{pool: ts.NewParserPool(lang, ts.WithParserPoolTimeoutMicros(tsParseTimeoutMicros))}
+	tl := &tsLang{lang: lang, pool: ts.NewParserPool(lang, ts.WithParserPoolTimeoutMicros(tsParseTimeoutMicros))}
 	// Bundled tags query is optional — some grammars (PHP, Perl) ship an
 	// empty one, in which case definitions come entirely from tsDefQuery.
 	if tagsSrc := grammars.ResolveTagsQuery(*entry); tagsSrc != "" {

--- a/internal/content/sourcetype.go
+++ b/internal/content/sourcetype.go
@@ -189,12 +189,17 @@ func (s *sourceType) Attributes(ctx context.Context, fsys fs.FS, p string) (Attr
 		}
 		// method_owners (builder-internal, #445): "method\x00owner" pairs so
 		// the code graph can disambiguate same-named methods on different
-		// types (find_definition reports the owning type). Go-only for now;
-		// the tree-sitter languages are a follow-up.
+		// types (find_definition / who_calls / dead_code report the owning
+		// type). Go via stdlib AST; the class-based tree-sitter languages
+		// via tsMethodOwners (parent-walk to the enclosing type).
+		var owners []string
 		if s.language == "go" {
-			if owners := goMethodOwners(bodyBuf.Bytes()); len(owners) > 0 {
-				attrs["method_owners"] = owners
-			}
+			owners = goMethodOwners(bodyBuf.Bytes())
+		} else {
+			owners = tsMethodOwners(s.language, bodyBuf.Bytes())
+		}
+		if len(owners) > 0 {
+			attrs["method_owners"] = owners
 		}
 		// exported_symbols (builder-internal, #409): the public subset of
 		// defs for keyword-visibility languages, consumed by unused_exports.

--- a/internal/mcpserver/codegraph_tools.go
+++ b/internal/mcpserver/codegraph_tools.go
@@ -137,7 +137,8 @@ type FindDefinitionInput struct {
 
 // Each definition carries an optional 'owner' (the type a method belongs
 // to, e.g. 'Buffer' for (*Buffer).String) so same-named methods on
-// different types are distinguishable — Go only for now (#445).
+// different types are distinguishable — Go plus the class-based
+// tree-sitter languages (#445).
 
 // FindDefinitionOutput lists every file that defines the queried symbol.
 type FindDefinitionOutput struct {
@@ -238,7 +239,7 @@ type WhoCallsOutput struct {
 	Symbol string `json:"symbol"`
 	// DefinedOn lists the types the queried symbol is a method on (#445),
 	// when any — a hint that these name-based caller results may mix calls
-	// to same-named methods on different types. Go only for now.
+	// to same-named methods on different types. Go plus the class-based tree-sitter languages (#445).
 	DefinedOn          []string          `json:"defined_on,omitempty"`
 	Callers            []search.Importer `json:"callers"`
 	Count              int               `json:"count"`

--- a/internal/search/codegraph.go
+++ b/internal/search/codegraph.go
@@ -29,7 +29,7 @@ type SymbolDef struct {
 	Symbol string `json:"symbol,omitempty"`
 	// Owner is the type a method belongs to (#445), e.g. "Buffer" for
 	// (*Buffer).String. Empty for plain functions and types. Lets callers
-	// tell apart same-named methods on different types. Go only for now.
+	// tell apart same-named methods on different types. Go plus the class-based tree-sitter languages (#445).
 	Owner string `json:"owner,omitempty"`
 }
 
@@ -377,7 +377,7 @@ func (g *CodeGraph) WhoCalls(name string) []Importer {
 // named `name` (#445), sorted. Empty when `name` names only plain
 // functions/types or isn't defined. Lets the name-based lookups
 // (who_calls / references) report "this name is a method on these types",
-// surfacing the ambiguity behind a same-name query. Go only for now.
+// surfacing the ambiguity behind a same-name query. Go plus the class-based tree-sitter languages (#445).
 func (g *CodeGraph) OwnersOf(name string) []string {
 	seen := map[string]bool{}
 	var out []string


### PR DESCRIPTION
**Phase 1** of #443, completing the breadth (after #453 find_definition + #454 who_calls/dead_code/references, both Go-only).

## Change
Owner qualification now spans **Go** (stdlib AST) **plus the class-based tree-sitter languages**. New `tsMethodOwners` walks each method-definition node up to its enclosing type container (parent-walk over the parse tree; per-language node-type spec in `tsMethodOwnerSpec`) and emits `method\x00owner` pairs into the same builder-internal `Extra["method_owners"]` the Go path uses — so `find_definition` / `who_calls` / `dead_code` / `references` report owning types across languages with **no further wiring**.

**Covered:** java, csharp, kotlin, scala, php, python, ruby, typescript, javascript, swift, rust (`impl Type`).
**Deliberately omitted:** C (no methods); C++ (method name buried in a `function_declarator`, not a clean field/child); Perl / R / MATLAB (no class-method nesting we model) — methods stay bare, as before.

Supporting changes: `tsLang` now carries its `*Language` (for `Node.Type` / `ChildByFieldName`); `symbolName` resolves a name via the `name` field or a first-name-child fallback (Kotlin names with a bare `simple_identifier`).

## Verified on the OSS corpus
- gson `find-definition toString` → `Event.toString` / `Gson.toString` / `JsonElement.toString`
- flask `__init__` → `Flask.__init__` / `Blueprint.__init__`
- sinatra `call` → `Wrapper.call` / `Logger.call` / `Base.call`

## Tests
`TestTSMethodOwners` validates owner extraction per covered language — wrong node names fail loudly rather than silently yielding no owners (which is how the Kotlin single-line-parse and C++ declarator-nesting issues surfaced during development).

## Phase 1 status (#445)
With #453 + #454 + this, qualified-name *reporting* is complete across the lookup tools and all class-based languages. The precision/over-matching reduction remains Phase 3 (#447, type resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)