### PR TITLE
feat(who_calls,impact): opt-in type-resolved Go call graph (--resolve) (#447)

### DIFF
--- a/cmd/file-search-on/codegraph_cmd.go
+++ b/cmd/file-search-on/codegraph_cmd.go
@@ -214,10 +214,11 @@ func writeJSON(w *os.File, v any) error {
 
 // WhoCallsCmd — reverse call lookup.
 type WhoCallsCmd struct {
-	Symbol string `arg:"" help:"Exact function/method name to find callers of."`
+	Symbol string `arg:"" help:"Function/method to find callers of. With --resolve, qualify a method as 'Owner.Method' (e.g. Buffer.String) to find callers of exactly that; a bare name matches any owner."`
 	codeGraphWalkFlags
-	Expr   string `name:"expr" help:"CEL pre-filter. Defaults to is_source."`
-	Output string `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table | json."`
+	Expr    string `name:"expr" help:"CEL pre-filter. Defaults to is_source."`
+	Output  string `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table | json."`
+	Resolve bool   `name:"resolve" help:"Type-resolve Go via go/packages so only callers of the EXACT symbol are returned (distinguishes same-named methods on different types) instead of name-based matching. Requires the 'go' toolchain + a buildable module; falls back to name-based otherwise. First -d root. Issue #447."`
 }
 
 func (c *WhoCallsCmd) Run(ctx context.Context) error {
@@ -231,9 +232,16 @@ func (c *WhoCallsCmd) Run(ctx context.Context) error {
 	}
 	callers := g.WhoCalls(c.Symbol)
 	definedOn := g.OwnersOf(c.Symbol)
+	resolved := false
+	if c.Resolve && len(c.Dir) > 0 {
+		if rc, ok, _ := search.ResolveGoWhoCalls(effectiveCtx, c.Dir[0], c.Symbol); ok {
+			callers = rc
+			resolved = true
+		}
+	}
 	if c.Output == "json" {
 		_ = writeJSON(os.Stdout, map[string]any{
-			"symbol": c.Symbol, "defined_on": definedOn, "callers": callers, "count": len(callers), "total_files": g.TotalFiles,
+			"symbol": c.Symbol, "defined_on": definedOn, "callers": callers, "count": len(callers), "total_files": g.TotalFiles, "resolved": resolved,
 		})
 	} else {
 		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
@@ -241,10 +249,17 @@ func (c *WhoCallsCmd) Run(ctx context.Context) error {
 			_, _ = fmt.Fprintf(tw, "%s\t%s\n", im.Language, im.Path)
 		}
 		_ = tw.Flush()
-		if len(definedOn) > 0 {
-			_, _ = fmt.Fprintf(os.Stderr, "%q is a method on: %s\n", c.Symbol, strings.Join(definedOn, ", "))
+		if c.Resolve && !resolved {
+			_, _ = fmt.Fprintln(os.Stderr, "note: --resolve requested but type resolution unavailable (no go toolchain / not a buildable module); used name-based matching")
 		}
-		_, _ = fmt.Fprintf(os.Stderr, "%d file(s) call %q (of %d source files)\n", len(callers), c.Symbol, g.TotalFiles)
+		if !resolved && len(definedOn) > 0 {
+			_, _ = fmt.Fprintf(os.Stderr, "%q is a method on: %s (name-based — pass --resolve to disambiguate)\n", c.Symbol, strings.Join(definedOn, ", "))
+		}
+		mode := ""
+		if resolved {
+			mode = " (Go type-resolved — exact symbol)"
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "%d file(s) call %q%s (of %d source files)\n", len(callers), c.Symbol, mode, g.TotalFiles)
 	}
 	return codeGraphExit(c.Timeout, parentCtx, effectiveCtx, g, "who-calls")
 }
@@ -403,11 +418,12 @@ func (c *CallPathCmd) Run(ctx context.Context) error {
 }
 
 type ImpactCmd struct {
-	Symbol string `arg:"" help:"Exact function/method name whose transitive callers (blast radius) to list."`
+	Symbol string `arg:"" help:"Function/method whose transitive callers (blast radius) to list. With --resolve, qualify a method as 'Owner.Method'."`
 	codeGraphWalkFlags
 	Expr     string `name:"expr" help:"CEL pre-filter. Defaults to is_source."`
-	MaxDepth int    `name:"max-depth" default:"0" help:"Cap call hops in the closure. 0 = unbounded; 1 = direct callers only."`
+	MaxDepth int    `name:"max-depth" default:"0" help:"Cap call hops in the closure. 0 = unbounded; 1 = direct callers only. (Ignored under --resolve.)"`
 	Output   string `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table | json."`
+	Resolve  bool   `name:"resolve" help:"Type-resolve Go via go/packages for a precise blast radius (exact symbol, no same-name conflation) instead of name-based. Requires the 'go' toolchain + a buildable module; falls back to name-based otherwise. First -d root. Issue #447."`
 }
 
 func (c *ImpactCmd) Run(ctx context.Context) error {
@@ -420,9 +436,16 @@ func (c *ImpactCmd) Run(ctx context.Context) error {
 		return nil
 	}
 	deps := g.Impact(c.Symbol, c.MaxDepth)
+	resolved := false
+	if c.Resolve && len(c.Dir) > 0 {
+		if rd, ok, _ := search.ResolveGoImpact(effectiveCtx, c.Dir[0], c.Symbol); ok {
+			deps = rd
+			resolved = true
+		}
+	}
 	if c.Output == "json" {
 		_ = writeJSON(os.Stdout, map[string]any{
-			"symbol": c.Symbol, "dependents": deps, "count": len(deps), "total_files": g.TotalFiles,
+			"symbol": c.Symbol, "dependents": deps, "count": len(deps), "total_files": g.TotalFiles, "resolved": resolved,
 		})
 	} else {
 		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
@@ -431,7 +454,14 @@ func (c *ImpactCmd) Run(ctx context.Context) error {
 			_, _ = fmt.Fprintf(tw, "%d\t%s\t%s\n", d.Depth, d.Symbol, strings.Join(d.Paths, ", "))
 		}
 		_ = tw.Flush()
-		_, _ = fmt.Fprintf(os.Stderr, "%d function(s) transitively call %q (of %d source files)\n", len(deps), c.Symbol, g.TotalFiles)
+		if c.Resolve && !resolved {
+			_, _ = fmt.Fprintln(os.Stderr, "note: --resolve requested but type resolution unavailable; used name-based matching")
+		}
+		mode := "name-based"
+		if resolved {
+			mode = "Go type-resolved"
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "%d function(s) transitively call %q (%s; of %d source files)\n", len(deps), c.Symbol, mode, g.TotalFiles)
 	}
 	return codeGraphExit(c.Timeout, parentCtx, effectiveCtx, g, "impact")
 }

--- a/internal/goresolve/callgraph.go
+++ b/internal/goresolve/callgraph.go
@@ -1,0 +1,146 @@
+package goresolve
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// collectEdges records a call-graph edge for every call site in the package:
+// from the enclosing function (callerID; "" for calls in package-level
+// initialisers) to the precisely-resolved callee. A call through an
+// interface resolves to the interface method — correct for who_calls
+// ("who calls THIS exact symbol"), unlike the name-based tool which matches
+// every same-named symbol.
+func (r *Result) collectEdges(p *packages.Package) {
+	info := p.TypesInfo
+	record := func(callerID string, call *ast.CallExpr) {
+		var obj types.Object
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			obj = info.Uses[fn]
+		case *ast.SelectorExpr:
+			obj = info.Uses[fn.Sel]
+		}
+		fn, ok := obj.(*types.Func)
+		if !ok {
+			return
+		}
+		calleeID := funcID(fn)
+		if calleeID == "" {
+			return
+		}
+		set := r.callers[calleeID]
+		if set == nil {
+			set = map[string]bool{}
+			r.callers[calleeID] = set
+		}
+		set[callerID] = true
+		pos := p.Fset.Position(call.Pos())
+		caller := ""
+		if d, ok := r.defByID[callerID]; ok {
+			caller = d.Qualified()
+		}
+		r.sites[calleeID] = append(r.sites[calleeID], CallSite{Path: pos.Filename, Line: pos.Line, Caller: caller})
+	}
+
+	for _, f := range p.Syntax {
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Body == nil {
+				// Calls in package var initialisers etc. — caller "".
+				ast.Inspect(decl, func(n ast.Node) bool {
+					if call, ok := n.(*ast.CallExpr); ok {
+						record("", call)
+					}
+					return true
+				})
+				continue
+			}
+			// All calls in the body (including closures) attribute to fd —
+			// matches the name-based extractor's call attribution.
+			callerID := ""
+			if obj, ok := info.Defs[fd.Name].(*types.Func); ok {
+				callerID = funcID(obj)
+			}
+			ast.Inspect(fd.Body, func(n ast.Node) bool {
+				if call, ok := n.(*ast.CallExpr); ok {
+					record(callerID, call)
+				}
+				return true
+			})
+		}
+	}
+}
+
+// idsMatching returns the resolved symbol ids of every definition named
+// `name` whose owner matches (owner=="" matches any owner — so a bare query
+// covers a function and all same-named methods, each still resolved per
+// call site).
+func (r *Result) idsMatching(owner, name string) []string {
+	var ids []string
+	for id, d := range r.defByID {
+		if d.Name == name && (owner == "" || d.Owner == owner) {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// Callers returns the resolved call sites of the queried symbol — the
+// type-precise who_calls. owner may be "" to match any owner of `name`.
+func (r *Result) Callers(owner, name string) []CallSite {
+	var out []CallSite
+	seen := map[string]bool{}
+	for _, id := range r.idsMatching(owner, name) {
+		for _, s := range r.sites[id] {
+			key := s.Path + "\x00" + s.Caller
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// ImpactSym is a transitive caller plus its BFS distance (hops) from the
+// queried symbol.
+type ImpactSym struct {
+	Symbol
+	Depth int
+}
+
+// Impact returns the transitive reverse-call closure of the queried symbol:
+// every function that (in)directly calls it — the blast radius — each with
+// its hop distance. owner may be "" to match any owner of `name`.
+func (r *Result) Impact(owner, name string) []ImpactSym {
+	visited := map[string]bool{}
+	type qi struct {
+		id    string
+		depth int
+	}
+	var queue []qi
+	for _, id := range r.idsMatching(owner, name) {
+		visited[id] = true
+		queue = append(queue, qi{id, 0})
+	}
+	var out []ImpactSym
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for callerID := range r.callers[cur.id] {
+			if callerID == "" || visited[callerID] {
+				continue
+			}
+			visited[callerID] = true
+			queue = append(queue, qi{callerID, cur.depth + 1})
+			if d, ok := r.defByID[callerID]; ok {
+				out = append(out, ImpactSym{Symbol: d, Depth: cur.depth + 1})
+			}
+		}
+	}
+	return out
+}

--- a/internal/goresolve/callgraph_test.go
+++ b/internal/goresolve/callgraph_test.go
@@ -1,0 +1,76 @@
+package goresolve
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestCallers_TypePrecise: who_calls on a method resolves to the exact type.
+// A.Foo and B.Foo are distinct; callers of A.Foo must not include the caller
+// of B.Foo (the case name-based matching conflates).
+func TestCallers_TypePrecise(t *testing.T) {
+	dir := writeModule(t, map[string]string{
+		"a/a.go": `package a
+
+type A struct{}
+type B struct{}
+
+func (A) Foo() {}
+func (B) Foo() {}
+
+func CallA() { var x A; x.Foo() }
+func CallB() { var y B; y.Foo() }
+`,
+	})
+	res, ok, err := Resolve(t.Context(), dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Skip("type resolution unavailable")
+	}
+
+	callerNames := func(owner, name string) []string {
+		var out []string
+		for _, s := range res.Callers(owner, name) {
+			out = append(out, s.Caller)
+		}
+		slices.Sort(out)
+		return out
+	}
+	if got := callerNames("A", "Foo"); !slices.Equal(got, []string{"CallA"}) {
+		t.Errorf("Callers(A.Foo)=%v, want [CallA]", got)
+	}
+	if got := callerNames("B", "Foo"); !slices.Equal(got, []string{"CallB"}) {
+		t.Errorf("Callers(B.Foo)=%v, want [CallB]", got)
+	}
+}
+
+// TestImpact_TransitiveClosure: impact follows callers transitively.
+// leaf <- mid <- top; impact(leaf) = {mid, top}.
+func TestImpact_TransitiveClosure(t *testing.T) {
+	dir := writeModule(t, map[string]string{
+		"a/a.go": `package a
+
+func leaf() {}
+func mid()  { leaf() }
+func top()  { mid() }
+func Entry() { top() }
+`,
+	})
+	res, ok, err := Resolve(t.Context(), dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Skip("type resolution unavailable")
+	}
+	var names []string
+	for _, s := range res.Impact("", "leaf") {
+		names = append(names, s.Name)
+	}
+	slices.Sort(names)
+	if !slices.Equal(names, []string{"Entry", "mid", "top"}) {
+		t.Errorf("Impact(leaf)=%v, want [Entry mid top]", names)
+	}
+}

--- a/internal/goresolve/resolve.go
+++ b/internal/goresolve/resolve.go
@@ -56,6 +56,21 @@ func Available() bool {
 type Result struct {
 	Defs       []Symbol
 	referenced map[string]bool // id() of every used *types.Func
+	// Call graph (#447 who_calls/impact): per-callee call sites and the
+	// reverse edge set (callee id -> set of caller ids). callerID is "" for
+	// calls outside any function (package var initialisers). Callees are
+	// resolved precisely, so a call through an interface is attributed to
+	// the interface method, not the concrete impl.
+	callers map[string]map[string]bool // calleeID -> set of callerID
+	sites   map[string][]CallSite      // calleeID -> call-site locations
+	defByID map[string]Symbol          // id -> definition (for Impact output)
+}
+
+// CallSite is one resolved call to a queried symbol.
+type CallSite struct {
+	Path   string `json:"path"`
+	Line   int    `json:"line"`
+	Caller string `json:"caller,omitempty"` // qualified enclosing func; "" if file-level
 }
 
 // DeadFuncs returns the definitions whose resolved symbol is never
@@ -138,7 +153,12 @@ func Resolve(ctx context.Context, dir string) (*Result, bool, error) {
 		return nil, false, nil
 	}
 
-	res := &Result{referenced: map[string]bool{}}
+	res := &Result{
+		referenced: map[string]bool{},
+		callers:    map[string]map[string]bool{},
+		sites:      map[string][]CallSite{},
+		defByID:    map[string]Symbol{},
+	}
 	seenDef := map[string]bool{} // dedup defs across normal/test package variants
 	var loadedTypes bool
 	// ifaceMethodRefs collects interface methods that are used: a call
@@ -186,10 +206,12 @@ func Resolve(ctx context.Context, dir string) (*Result, bool, error) {
 				continue
 			}
 			seenDef[id] = true
-			res.Defs = append(res.Defs, Symbol{
+			sym := Symbol{
 				Pkg: fn.Pkg().Path(), Owner: owner, Name: fn.Name(),
 				Path: pos.Filename, Line: pos.Line,
-			})
+			}
+			res.Defs = append(res.Defs, sym)
+			res.defByID[id] = sym
 		}
 		// Concrete named types declared in this package (for interface
 		// satisfaction below).
@@ -225,6 +247,9 @@ func Resolve(ctx context.Context, dir string) (*Result, bool, error) {
 				}
 			}
 		}
+		// Call-graph edges: attribute each call site to its enclosing func
+		// and resolved callee (powers who_calls / impact).
+		res.collectEdges(p)
 	}
 	if !loadedTypes {
 		return nil, false, nil

--- a/internal/mcpserver/codegraph_tools.go
+++ b/internal/mcpserver/codegraph_tools.go
@@ -230,7 +230,8 @@ func (h *handlers) codeGraphHandler(ctx context.Context, _ *mcp.CallToolRequest,
 // WhoCallsInput is the JSON-schema input for the `who_calls` tool.
 type WhoCallsInput struct {
 	codeGraphWalkInput
-	Symbol string `json:"symbol" jsonschema:"The exact function / method name to find callers of (e.g. 'ServeHTTP', 'process'). Required. Name-based: a call pkg.Foo() or x.Method() is keyed by 'Foo' / 'Method'."`
+	Symbol  string `json:"symbol" jsonschema:"The function / method name to find callers of (e.g. 'ServeHTTP', 'process'). Required. Name-based by default: a call pkg.Foo() or x.Method() is keyed by 'Foo' / 'Method'. With resolve:true, qualify a method as 'Owner.Method' (e.g. 'Buffer.String') to find callers of exactly that type's method; a bare name matches any owner."`
+	Resolve bool   `json:"resolve,omitempty" jsonschema:"When true, type-resolve Go via go/packages so only callers of the EXACT symbol are returned (same-named methods on different types are NOT conflated), instead of name-based matching. Requires the 'go' toolchain and a buildable Go module; degrades to name-based otherwise (see 'resolved'). Dev-environment only. Issue #447."`
 }
 
 // WhoCallsOutput lists every file that calls/references the symbol.
@@ -241,6 +242,7 @@ type WhoCallsOutput struct {
 	// when any — a hint that these name-based caller results may mix calls
 	// to same-named methods on different types. Go plus the class-based tree-sitter languages (#445).
 	DefinedOn          []string          `json:"defined_on,omitempty"`
+	Resolved           bool              `json:"resolved"`
 	Callers            []search.Importer `json:"callers"`
 	Count              int               `json:"count"`
 	TotalFiles         int64             `json:"total_files"`
@@ -264,9 +266,24 @@ func (h *handlers) whoCallsHandler(ctx context.Context, _ *mcp.CallToolRequest, 
 		return nil, WhoCallsOutput{}, fmt.Errorf("who_calls: %w", err)
 	}
 	callers := g.WhoCalls(in.Symbol)
+	resolved := false
+	if in.Resolve {
+		root := in.Dir
+		if len(in.Dirs) > 0 {
+			root = in.Dirs[0]
+		}
+		if root == "" {
+			root = "."
+		}
+		if rc, ok, _ := search.ResolveGoWhoCalls(ctx, root, in.Symbol); ok {
+			callers = rc
+			resolved = true
+		}
+	}
 	out := WhoCallsOutput{
 		Symbol:             in.Symbol,
 		DefinedOn:          g.OwnersOf(in.Symbol),
+		Resolved:           resolved,
 		Callers:            callers,
 		Count:              len(callers),
 		TotalFiles:         g.TotalFiles,
@@ -351,14 +368,16 @@ func (h *handlers) deadCodeHandler(ctx context.Context, _ *mcp.CallToolRequest, 
 // ImpactInput is the JSON-schema input for the `impact` tool.
 type ImpactInput struct {
 	codeGraphWalkInput
-	Symbol   string `json:"symbol" jsonschema:"The exact function/method name to assess. Returns every function that transitively calls it — the blast radius of changing it. Required."`
-	MaxDepth int    `json:"max_depth,omitempty" jsonschema:"Cap the number of call hops in the closure. 0 (default) is unbounded. 1 = direct callers only (same set as who_calls, but symbol-level)."`
+	Symbol   string `json:"symbol" jsonschema:"The function/method to assess. Returns every function that transitively calls it — the blast radius of changing it. Required. With resolve:true, qualify a method as 'Owner.Method'."`
+	MaxDepth int    `json:"max_depth,omitempty" jsonschema:"Cap the number of call hops in the closure. 0 (default) is unbounded. 1 = direct callers only (same set as who_calls, but symbol-level). Ignored when resolve:true."`
+	Resolve  bool   `json:"resolve,omitempty" jsonschema:"When true, type-resolve Go via go/packages for a precise blast radius (exact symbol, no same-name conflation) instead of name-based. Requires the 'go' toolchain and a buildable module; degrades to name-based otherwise (see 'resolved'). Dev-environment only. Issue #447."`
 }
 
 // ImpactOutput is the transitive caller closure of the queried symbol.
 type ImpactOutput struct {
 	CommonOutput
 	Symbol             string              `json:"symbol"`
+	Resolved           bool                `json:"resolved"`
 	Dependents         []search.ImpactNode `json:"dependents"`
 	Count              int                 `json:"count"`
 	MaxDepthReached    int                 `json:"max_depth_reached"`
@@ -383,6 +402,20 @@ func (h *handlers) impactHandler(ctx context.Context, _ *mcp.CallToolRequest, in
 		return nil, ImpactOutput{}, fmt.Errorf("impact: %w", err)
 	}
 	deps := g.Impact(in.Symbol, in.MaxDepth)
+	resolved := false
+	if in.Resolve {
+		root := in.Dir
+		if len(in.Dirs) > 0 {
+			root = in.Dirs[0]
+		}
+		if root == "" {
+			root = "."
+		}
+		if rd, ok, _ := search.ResolveGoImpact(ctx, root, in.Symbol); ok {
+			deps = rd
+			resolved = true
+		}
+	}
 	maxDepth := 0
 	for _, d := range deps {
 		if d.Depth > maxDepth {
@@ -391,6 +424,7 @@ func (h *handlers) impactHandler(ctx context.Context, _ *mcp.CallToolRequest, in
 	}
 	out := ImpactOutput{
 		Symbol:             in.Symbol,
+		Resolved:           resolved,
 		Dependents:         deps,
 		Count:              len(deps),
 		MaxDepthReached:    maxDepth,

--- a/internal/search/resolve.go
+++ b/internal/search/resolve.go
@@ -2,9 +2,57 @@ package search
 
 import (
 	"context"
+	"strings"
 
 	"github.com/richardwooding/file-search-on/internal/goresolve"
 )
+
+// splitQualified parses a who_calls/impact query symbol: "Owner.Method"
+// scopes to that type's method; a bare "Name" matches any owner (a function
+// and all same-named methods, each still resolved per call site).
+func splitQualified(symbol string) (owner, name string) {
+	if i := strings.LastIndexByte(symbol, '.'); i > 0 {
+		return symbol[:i], symbol[i+1:]
+	}
+	return "", symbol
+}
+
+// ResolveGoWhoCalls returns the precise caller files of a Go symbol via type
+// resolution — only callers of the EXACT symbol (e.g. Buffer.String, not
+// every "String"). ok is false when resolution can't run (degrade to
+// name-based). Issue #447.
+func ResolveGoWhoCalls(ctx context.Context, root, symbol string) ([]Importer, bool, error) {
+	res, ok, err := goresolve.Resolve(ctx, root)
+	if err != nil || !ok {
+		return nil, false, err
+	}
+	owner, name := splitQualified(symbol)
+	seen := map[string]bool{}
+	var out []Importer
+	for _, s := range res.Callers(owner, name) {
+		if seen[s.Path] {
+			continue
+		}
+		seen[s.Path] = true
+		out = append(out, Importer{Path: s.Path, Language: "go"})
+	}
+	return out, true, nil
+}
+
+// ResolveGoImpact returns the precise transitive caller closure of a Go
+// symbol as ImpactNodes. ok is false when resolution can't run.
+func ResolveGoImpact(ctx context.Context, root, symbol string) ([]ImpactNode, bool, error) {
+	res, ok, err := goresolve.Resolve(ctx, root)
+	if err != nil || !ok {
+		return nil, false, err
+	}
+	owner, name := splitQualified(symbol)
+	var out []ImpactNode
+	for _, s := range res.Impact(owner, name) {
+		out = append(out, ImpactNode{Symbol: s.Qualified(), Depth: s.Depth, Paths: []string{s.Path}})
+	}
+	return out, true, nil
+}
 
 // ResolveGoDead computes precise dead Go functions/methods via type
 // resolution (goresolve → go/packages), returned as SymbolDefs. ok is false


### PR DESCRIPTION
**Phase 3 follow-up** (#447), reusing the `goresolve` engine from #456 for the remaining lookups.

## Change
Extends `goresolve` with a precise **call graph**: every call site is attributed to its enclosing function and its type-resolved callee, so a call through an interface is credited to the exact symbol — no same-name conflation.

- **`who_calls --resolve` / `resolve:true`** — callers of the EXACT symbol. Qualify a method as `Owner.Method` (e.g. `Buffer.String`); a bare name matches any owner. Distinguishes `A.Foo` callers from `B.Foo` callers, which name-based can't.
- **`impact --resolve` / `resolve:true`** — precise transitive caller closure (BFS with hop depth), qualified symbols, no same-name blow-up.

New `goresolve.Result.Callers` / `Impact` + `search.ResolveGoWhoCalls` / `ResolveGoImpact` bridges; wired through CLI (`--resolve`) and MCP (`resolve` input + `resolved` output flag). Same **dev-only constraint** and graceful name-based fallback as dead_code's `--resolve` (gated by `goresolve.Available`).

## Verified e2e
- `who-calls Indicator.String --resolve` → the one exact caller (`detect.go`), vs name-based which can't disambiguate.
- `impact Indicator.String --resolve` → transitive closure with depths and qualified caller symbols.

## Tests
`TestCallers_TypePrecise` (callers of `A.Foo` ≠ callers of `B.Foo`) and `TestImpact_TransitiveClosure`, against self-contained fixture modules.

## #447 status
With #456 (dead_code) + this (who_calls/impact), the Go resolved-mode surface is complete. TypeScript-via-LSP remains the issue's stretch goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)