### PR TITLE
feat(dead_code): --ignore-exported / ignore_exported to hide public API

### DIFF
--- a/cmd/file-search-on/codegraph_cmd.go
+++ b/cmd/file-search-on/codegraph_cmd.go
@@ -268,8 +268,9 @@ func (c *WhoCallsCmd) Run(ctx context.Context) error {
 type DeadCodeCmd struct {
 	Expr string `arg:"" optional:"" help:"CEL pre-filter for which files enter the graph. Defaults to is_source."`
 	codeGraphWalkFlags
-	Output  string `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table | json."`
-	Resolve bool   `name:"resolve" help:"Type-resolve Go via go/packages for precise dead-code (distinguishes same-named methods, counts cross-package usage) instead of name-based matching. Requires the 'go' toolchain and a buildable module — falls back to name-based otherwise. Dev-environment only; the first -d root is resolved. Issue #447."`
+	Output         string `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table | json."`
+	Resolve        bool   `name:"resolve" help:"Type-resolve Go via go/packages for precise dead-code (distinguishes same-named methods, counts cross-package usage) instead of name-based matching. Requires the 'go' toolchain and a buildable module — falls back to name-based otherwise. Dev-environment only; the first -d root is resolved. Issue #447."`
+	IgnoreExported bool   `name:"ignore-exported" help:"Drop exported/public symbols (funcs, methods, types) from the candidates — exported API used only by external callers is the dominant dead-code false positive. Visibility is known for name-convention (Go / Python) and keyword (Rust / TS / JS / Java / C# / Kotlin / Scala) languages; symbols in languages without a visibility signal are kept."`
 }
 
 type TestGapsCmd struct {
@@ -335,6 +336,9 @@ func (c *DeadCodeCmd) Run(ctx context.Context) error {
 			resolved = true
 		}
 	}
+	if c.IgnoreExported {
+		candidates = search.FilterExported(candidates)
+	}
 	dcPaths := make([]string, len(candidates))
 	for i, d := range candidates {
 		dcPaths[i] = d.Path
@@ -361,7 +365,11 @@ func (c *DeadCodeCmd) Run(ctx context.Context) error {
 		if resolved {
 			mode = "Go type-resolved + name-based for other languages"
 		}
-		_, _ = fmt.Fprintf(os.Stderr, "%d candidate(s) — %s; exported API / entry points / dynamic dispatch may be false positives\n", len(candidates), mode)
+		fp := "exported API / entry points / dynamic dispatch may be false positives"
+		if c.IgnoreExported {
+			fp = "exported symbols hidden (--ignore-exported); entry points / dynamic dispatch may still be false positives"
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "%d candidate(s) — %s; %s\n", len(candidates), mode, fp)
 		if hint != "" {
 			_, _ = fmt.Fprintln(os.Stderr, hint)
 		}

--- a/internal/goresolve/resolve.go
+++ b/internal/goresolve/resolve.go
@@ -26,11 +26,12 @@ import (
 
 // Symbol is a resolved Go function or method definition.
 type Symbol struct {
-	Pkg   string // package import path
-	Owner string // receiver type name for methods; "" for plain funcs
-	Name  string
-	Path  string // file containing the definition
-	Line  int
+	Pkg      string // package import path
+	Owner    string // receiver type name for methods; "" for plain funcs
+	Name     string
+	Path     string // file containing the definition
+	Line     int
+	Exported bool // Go export convention (capitalised); for --ignore-exported
 }
 
 // Qualified renders the disambiguated name: "Owner.Name" for methods,
@@ -208,7 +209,7 @@ func Resolve(ctx context.Context, dir string) (*Result, bool, error) {
 			seenDef[id] = true
 			sym := Symbol{
 				Pkg: fn.Pkg().Path(), Owner: owner, Name: fn.Name(),
-				Path: pos.Filename, Line: pos.Line,
+				Path: pos.Filename, Line: pos.Line, Exported: fn.Exported(),
 			}
 			res.Defs = append(res.Defs, sym)
 			res.defByID[id] = sym

--- a/internal/goresolve/resolve_test.go
+++ b/internal/goresolve/resolve_test.go
@@ -59,6 +59,31 @@ func TestResolve_CrossPackageUsageCounted(t *testing.T) {
 	}
 }
 
+// TestResolve_ExportedFlag: DeadFuncs carry Go export visibility so the
+// --ignore-exported filter can drop public API (#447).
+func TestResolve_ExportedFlag(t *testing.T) {
+	dir := writeModule(t, map[string]string{
+		"a/a.go": "package a\n\nfunc Exported() {}\nfunc unexported() {}\n",
+	})
+	res, ok, err := Resolve(t.Context(), dir)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Skip("type resolution unavailable")
+	}
+	got := map[string]bool{}
+	for _, d := range res.DeadFuncs() {
+		got[d.Name] = d.Exported
+	}
+	if !got["Exported"] {
+		t.Errorf("Exported should be flagged exported; got %v", got)
+	}
+	if v, ok := got["unexported"]; !ok || v {
+		t.Errorf("unexported should be dead and not exported; got %v", got)
+	}
+}
+
 // TestResolve_SameNameMethodsDisambiguated: two methods named Foo on
 // different types — only the called one is alive. Name-based matching keeps
 // both alive (a call to bare "Foo" covers both); type resolution doesn't.

--- a/internal/mcpserver/codegraph_tools.go
+++ b/internal/mcpserver/codegraph_tools.go
@@ -299,7 +299,8 @@ func (h *handlers) whoCallsHandler(ctx context.Context, _ *mcp.CallToolRequest, 
 // DeadCodeInput is the JSON-schema input for the `dead_code` tool.
 type DeadCodeInput struct {
 	codeGraphWalkInput
-	Resolve bool `json:"resolve,omitempty" jsonschema:"When true, type-resolve Go via go/packages for precise dead-code — distinguishes same-named methods on different types and counts cross-package usage, instead of the default name-based matching (which over-matches same names). Requires the 'go' toolchain and a buildable Go module; degrades to name-based otherwise (see 'resolved' in the output). Dev-environment only — unavailable in toolchain-less hosts. Heavier (~seconds). Issue #447."`
+	Resolve        bool `json:"resolve,omitempty" jsonschema:"When true, type-resolve Go via go/packages for precise dead-code — distinguishes same-named methods on different types and counts cross-package usage, instead of the default name-based matching (which over-matches same names). Requires the 'go' toolchain and a buildable Go module; degrades to name-based otherwise (see 'resolved' in the output). Dev-environment only — unavailable in toolchain-less hosts. Heavier (~seconds). Issue #447."`
+	IgnoreExported bool `json:"ignore_exported,omitempty" jsonschema:"When true, drop exported/public symbols (functions, methods, types) from the candidates. Exported API used only by EXTERNAL callers is the dominant dead-code false positive, so this focuses results on genuinely-internal dead code. Visibility is determined for the name-convention (Go / Python) and keyword (Rust / TypeScript / JavaScript / Java / C# / Kotlin / Scala) languages; symbols in languages with no visibility signal are kept."`
 }
 
 // DeadCodeOutput lists candidate unreferenced definitions.
@@ -345,6 +346,9 @@ func (h *handlers) deadCodeHandler(ctx context.Context, _ *mcp.CallToolRequest, 
 			candidates = search.MergeResolvedGoDead(candidates, rdead)
 			resolved = true
 		}
+	}
+	if in.IgnoreExported {
+		candidates = search.FilterExported(candidates)
 	}
 	dcPaths := make([]string, len(candidates))
 	for i, c := range candidates {

--- a/internal/mcpserver/codegraph_tools_test.go
+++ b/internal/mcpserver/codegraph_tools_test.go
@@ -244,6 +244,26 @@ func TestDeadCodeTool(t *testing.T) {
 	}
 }
 
+func TestDeadCodeTool_IgnoreExported(t *testing.T) {
+	dir := seedCodeGraphTree(t)
+	ctx, cs := newSession(t)
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "dead_code",
+		Arguments: DeadCodeInput{codeGraphWalkInput: codeGraphWalkInput{Dir: dir}, IgnoreExported: true},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	var out DeadCodeOutput
+	mustDecodeStructured(t, res, &out)
+	// Gamma is exported (capitalised Go name) — must be filtered out.
+	for _, d := range out.Candidates {
+		if d.Symbol == "Gamma" {
+			t.Errorf("ignore_exported should drop exported Gamma: %+v", out.Candidates)
+		}
+	}
+}
+
 func TestCallsTool(t *testing.T) {
 	dir := seedCodeGraphTree(t)
 	ctx, cs := newSession(t)

--- a/internal/search/codegraph.go
+++ b/internal/search/codegraph.go
@@ -31,6 +31,13 @@ type SymbolDef struct {
 	// (*Buffer).String. Empty for plain functions and types. Lets callers
 	// tell apart same-named methods on different types. Go plus the class-based tree-sitter languages (#445).
 	Owner string `json:"owner,omitempty"`
+	// Exported is true when the symbol is exported/public — known for the
+	// name-convention (Go / Python) and keyword-visibility (Rust / TS / JS /
+	// Java / C# / Kotlin / Scala via exported_symbols) languages; false for
+	// languages where visibility isn't determined. Drives dead_code's
+	// --ignore-exported / ignore_exported filter (public API used only by
+	// external callers is the dominant dead-code false positive).
+	Exported bool `json:"exported,omitempty"`
 }
 
 // ModuleFanIn is a module ranked by how many files import it.
@@ -77,6 +84,7 @@ type symbolEntry struct {
 	language string
 	kind     string
 	owner    string // owning type for a method (#445); empty for funcs/types
+	exported bool   // exported/public visibility, when determinable for the language
 }
 
 // CodeGraph is the in-memory cross-file index built from the per-file
@@ -201,6 +209,24 @@ func BuildCodeGraph(ctx context.Context, opts Options, registry *content.Registr
 			set[r.Path] = lang
 		}
 
+		// Exportedness (#447 dead_code --ignore-exported): keyword-visibility
+		// languages carry their public set in exported_symbols (#409); Go /
+		// Python derive it by name. Languages with neither leave isExported
+		// false (treated as not exported, so never filtered).
+		var expSet map[string]bool
+		if exp, ok := r.Attrs.Extra["exported_symbols"].([]string); ok {
+			expSet = make(map[string]bool, len(exp))
+			for _, e := range exp {
+				expSet[e] = true
+			}
+		}
+		isExported := func(name string) bool {
+			if expSet != nil {
+				return expSet[name]
+			}
+			return exportedInLang(name, lang)
+		}
+
 		if funcs, ok := r.Attrs.Extra["functions"].([]string); ok {
 			// method_owners (#445): "method\x00owner" pairs for this file,
 			// so a method's defining entry carries its owning type and
@@ -214,12 +240,12 @@ func BuildCodeGraph(ctx context.Context, opts Options, registry *content.Registr
 				}
 			}
 			for _, fn := range funcs {
-				g.definedIn[fn] = append(g.definedIn[fn], symbolEntry{path: r.Path, language: lang, kind: "function", owner: owners[fn]})
+				g.definedIn[fn] = append(g.definedIn[fn], symbolEntry{path: r.Path, language: lang, kind: "function", owner: owners[fn], exported: isExported(fn)})
 			}
 		}
 		if types, ok := r.Attrs.Extra["type_names"].([]string); ok {
 			for _, t := range types {
-				g.definedIn[t] = append(g.definedIn[t], symbolEntry{path: r.Path, language: lang, kind: "type"})
+				g.definedIn[t] = append(g.definedIn[t], symbolEntry{path: r.Path, language: lang, kind: "type", exported: isExported(t)})
 			}
 		}
 		if refs, ok := r.Attrs.Extra["references"].([]string); ok {
@@ -591,7 +617,7 @@ func (g *CodeGraph) DeadCode() []SymbolDef {
 				continue
 			}
 			seen[key] = true
-			out = append(out, SymbolDef{Path: e.path, Language: e.language, Kind: e.kind, Symbol: name, Owner: e.owner})
+			out = append(out, SymbolDef{Path: e.path, Language: e.language, Kind: e.kind, Symbol: name, Owner: e.owner, Exported: e.exported})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/internal/search/codegraph_test.go
+++ b/internal/search/codegraph_test.go
@@ -233,6 +233,57 @@ func TestCodeGraph_OwnersOf_AndDeadCodeOwner(t *testing.T) {
 	}
 }
 
+// TestDeadCode_Exported pins the exportedness bit + FilterExported (#447):
+// an exported and an unexported func, both unreferenced, are both dead
+// candidates; FilterExported drops only the exported one. Covers Go
+// (name-convention) and Rust (pub via exported_symbols).
+func TestDeadCode_Exported(t *testing.T) {
+	dir := t.TempDir()
+	mk := func(rel, body string) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("g/g.go", "package g\n\nfunc Orphan() {}\nfunc orphan() {}\n")
+	mk("r/lib.rs", "pub fn pub_orphan() {}\nfn priv_orphan() {}\n")
+	g, err := search.BuildCodeGraph(t.Context(), search.Options{Root: dir, Expr: "is_source"}, content.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("BuildCodeGraph: %v", err)
+	}
+
+	all := map[string]bool{}   // symbol -> exported?
+	for _, d := range g.DeadCode() {
+		all[d.Symbol] = d.Exported
+	}
+	for sym, wantExp := range map[string]bool{
+		"Orphan": true, "orphan": false, "pub_orphan": true, "priv_orphan": false,
+	} {
+		got, ok := all[sym]
+		if !ok {
+			t.Errorf("%q should be a dead candidate; got %v", sym, all)
+			continue
+		}
+		if got != wantExp {
+			t.Errorf("%q Exported=%v, want %v", sym, got, wantExp)
+		}
+	}
+
+	kept := map[string]bool{}
+	for _, d := range search.FilterExported(g.DeadCode()) {
+		kept[d.Symbol] = true
+	}
+	if kept["Orphan"] || kept["pub_orphan"] {
+		t.Errorf("FilterExported should drop exported symbols; kept %v", kept)
+	}
+	if !kept["orphan"] || !kept["priv_orphan"] {
+		t.Errorf("FilterExported should keep unexported symbols; kept %v", kept)
+	}
+}
+
 // buildCallFixture has clear intra-repo call edges:
 //
 //	a.go    — func Helper(); func Used() { Helper() }   (Helper is called)

--- a/internal/search/resolve.go
+++ b/internal/search/resolve.go
@@ -77,9 +77,24 @@ func ResolveGoDead(ctx context.Context, root string) ([]SymbolDef, bool, error) 
 			Kind:     "function",
 			Symbol:   s.Name,
 			Owner:    s.Owner,
+			Exported: s.Exported,
 		})
 	}
 	return dead, true, nil
+}
+
+// FilterExported drops exported/public symbols from a dead-code candidate
+// list — the dead_code --ignore-exported / ignore_exported filter. Symbols
+// in languages without a visibility signal have Exported=false and are kept.
+func FilterExported(defs []SymbolDef) []SymbolDef {
+	out := make([]SymbolDef, 0, len(defs))
+	for _, d := range defs {
+		if d.Exported {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out
 }
 
 // MergeResolvedGoDead replaces the Go entries of a name-based dead-code


### PR DESCRIPTION
## Why
Exported API used only by external callers is `dead_code`'s dominant false positive — a library's public surface looks unused from inside the analysed tree — in both the name-based and the `--resolve` Go path. This adds an opt-in filter to drop exported/public symbols (functions, methods, types) so results focus on genuinely-internal dead code.

## How (reuses existing visibility machinery — no new logic)
- **keyword languages** (Rust `pub`, TS/JS `export`, Java/C# `public`, Kotlin/Scala negation) via the `#409` `exported_symbols` attribute;
- **Go / Python** via name convention (`isExportedName` / `exportedInLang`).
- Languages with no visibility signal leave `Exported=false` and are **kept**.

Threaded uniformly: `SymbolDef` gains `Exported`; `BuildCodeGraph` sets it on `symbolEntry` (from `exported_symbols`, else name convention) and `DeadCode` copies it; the resolved path sets `goresolve.Symbol.Exported` from `*types.Func.Exported()` and `ResolveGoDead` maps it across. Both CLI (`--ignore-exported`) and MCP (`ignore_exported`) filter via the shared `search.FilterExported` after candidates are produced, so it behaves identically for name-based and resolved results. **Off by default.**

## Effect (this repo)
name-based `3 → 0`, `--resolve` `24 → 0` — the dead set here is entirely exported API / kong reflection handlers, so it all filters out (as intended).

## Tests
- `TestDeadCode_Exported` — Go (name) + Rust (`pub` via exported_symbols): both an exported and unexported unreferenced func are dead candidates with the right `Exported` bit; `FilterExported` drops only the exported ones.
- `goresolve` `TestResolve_ExportedFlag` — resolved Go carries export visibility.
- MCP `TestDeadCodeTool_IgnoreExported` — `ignore_exported:true` drops the exported seed symbol.

Full `go test ./...`, vet, `go fix` clean. (Note: `TestWatchLoopDebounceCoalesces` is a pre-existing timing-flaky fsnotify test, unrelated — passes 3/3 in isolation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)