### PR TITLE
feat(playground): semantic search mode + scrollable attributes panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ file-search-on -d .                                   # empty expression matches
 | `archive-contents <path> [--expr]` | List or filter entries inside ZIP / TAR / TAR.GZ / GZIP — full CEL vocabulary on per-entry attributes | [examples/archive-search.md](./examples/archive-search.md) |
 | `archive-read <path> <entry>` | Read a single entry's bytes out of an archive without extracting | [examples/archive-search.md](./examples/archive-search.md) |
 | `find-matches <re> --expr <cel> -C N` | Line-level regex hits with context | [examples/find-matches.md](./examples/find-matches.md) |
-| `playground [expr] -d <dir>` | Interactive TUI — type a CEL expression and watch a directory's files filter live as you type; prints the final expression on exit | [examples/playground.md](./examples/playground.md) |
+| `playground [expr] -d <dir>` | Interactive TUI — type a CEL expression and watch a directory's files filter live as you type; prints the final expression on exit. Pass `--embedding-model` for **semantic mode**: a natural-language query box ranks files by `similarity` and the CEL box filters live | [examples/playground.md](./examples/playground.md) |
 | `watch [expr] -d <dir>` | Continuously watch directories; emit each new / changed file that matches — the inverse of `search` | [examples/watch.md](./examples/watch.md) |
 | `diff <tree-a> <tree-b> --op <set-op>` | Cross-tree set operations by sha256 — what's in A but not B, the intersection, content drift between same-named files | [examples/diff.md](./examples/diff.md) |
 | `organize <expr> --link-into <template>` | Build a templated symlink / copy tree from results — `{raw_vendor}/{taken_at_year}/{basename}` etc. | [examples/organize.md](./examples/organize.md) |
@@ -305,7 +305,7 @@ Focused recipe collections live under [`examples/`](./examples/):
 | [`examples/duplicates.md`](./examples/duplicates.md) | Find byte-identical files by sha256 — `file-search-on duplicates [--min-size N]` |
 | [`examples/near-duplicates.md`](./examples/near-duplicates.md) | Find SIMILAR files by SimHash fingerprint — `file-search-on near-duplicates --threshold 0.85` |
 | [`examples/organize.md`](./examples/organize.md) | Organize by query — templated symlink / copy trees from search results (`organize … --link-into '{raw_vendor}/{taken_at_year}/{basename}'`) |
-| [`examples/playground.md`](./examples/playground.md) | Interactive CEL playground TUI — author queries by watching a directory filter live as you type (`playground -d ./internal 'is_source'`) |
+| [`examples/playground.md`](./examples/playground.md) | Interactive CEL playground TUI — author queries by watching a directory filter live as you type (`playground -d ./internal 'is_source'`); `--embedding-model all-minilm` adds a semantic-search query box |
 
 A handful of representative one-liners:
 

--- a/cmd/file-search-on/playground_cmd.go
+++ b/cmd/file-search-on/playground_cmd.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	"github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/index"
 	"github.com/richardwooding/file-search-on/internal/playground"
 	"github.com/richardwooding/file-search-on/internal/search"
+	"github.com/richardwooding/ollamaembed"
 )
 
 // PlaygroundCmd launches the interactive CEL-filtering TUI: type a CEL
@@ -14,6 +16,12 @@ import (
 // filter live as you type, over the same attribute vocabulary search uses.
 // On exit it prints the final expression to stdout so a query built here is
 // directly reusable with `search`.
+//
+// Passing --embedding-model switches on semantic mode: a second input appears
+// for a natural-language query (embedded via Ollama and ranked by cosine
+// similarity), and the CEL box filters that ranked snapshot live
+// ("is_source && similarity > 0.6"). On exit it prints a reproducible
+// `file-search-on search --semantic-query …` command.
 type PlaygroundCmd struct {
 	Expr             string   `arg:"" optional:"" help:"Initial CEL expression to pre-fill the input with (optional). e.g. 'is_source && max_complexity > 15'."`
 	Dir              []string `short:"d" default:"." help:"Directory to search in. Repeatable — pass -d ./docs -d ./posts to snapshot multiple roots."`
@@ -24,9 +32,28 @@ type PlaygroundCmd struct {
 	Limit            int      `name:"limit" default:"5000" help:"Cap on the number of files snapshotted for in-memory filtering. Keeps eval instant on large trees; surfaced as 'first N shown' when hit."`
 	Body             bool     `name:"body" help:"Make file bodies available to the CEL expression as the 'body' string variable so body.contains(...) works. Expensive: reads every candidate file's body during the snapshot."`
 	BodyMaxBytes     int      `name:"body-max-bytes" default:"0" help:"Cap on the body string read per file in bytes. 0 uses the 1 MiB default."`
+
+	IndexPath string `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index. Caches file embeddings across semantic re-queries so changing the natural-language query only re-embeds the query, not every file."`
+	NoIndex   bool   `name:"no-index" help:"Disable the on-disk index entirely; use only the in-memory cache for the process lifetime."`
+
+	// Semantic mode (issue: semantic search TUI). Passing --embedding-model
+	// turns on the natural-language query box; mirrors the `search` flags.
+	SemanticQuery       string  `name:"semantic-query" help:"Initial natural-language query to pre-fill the semantic box (only used when --embedding-model is set)."`
+	EmbeddingModel      string  `name:"embedding-model" help:"Ollama embedding model name (e.g. all-minilm). Setting this enables semantic mode: a natural-language query box ranks files by cosine 'similarity' and the CEL box filters live."`
+	EmbeddingServer     string  `name:"embedding-server" env:"OLLAMA_HOST" default:"http://localhost:11434" help:"Ollama base URL for embedding requests. Resolution order: --embedding-server flag > $OLLAMA_HOST env var > http://localhost:11434."`
+	SimilarityThreshold float64 `name:"similarity-threshold" default:"0.5" help:"Default similarity floor carried into the reproducible 'search' command printed on exit. Filter interactively in the CEL box with 'similarity > X'."`
+	EmbedMaxBytes       int     `name:"embed-max-bytes" default:"0" help:"Cap on the body text handed to the embedding model (bytes). 0 uses an 8 KiB default that fits common models' context windows."`
 }
 
 func (p *PlaygroundCmd) Run(ctx context.Context) error {
+	// On-disk index is on by default (per-cwd file); caches embeddings across
+	// semantic re-queries. Opt out with --no-index.
+	idx, _, err := openIndex(p.IndexPath, p.NoIndex, index.BodyCacheCap{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = idx.Close() }()
+
 	opts := search.Options{
 		Roots:               p.Dir,
 		Excludes:            p.Exclude,
@@ -35,17 +62,33 @@ func (p *PlaygroundCmd) Run(ctx context.Context) error {
 		Workers:             p.Workers,
 		IncludeBody:         p.Body,
 		BodyMaxBytes:        p.BodyMaxBytes,
+		Index:               idx,
 	}
-	final, err := playground.Run(ctx, playground.RunOptions{
+
+	ro := playground.RunOptions{
 		Opts:     opts,
 		Registry: content.DefaultRegistry(),
 		Initial:  p.Expr,
 		Limit:    p.Limit,
-	})
+	}
+
+	// Semantic mode is opt-in via --embedding-model. The embedder is
+	// lazy-connect; no HTTP call happens until the TUI submits a query.
+	if p.EmbeddingModel != "" {
+		ro.Embedder = ollamaembed.NewOllama(p.EmbeddingServer, p.EmbeddingModel)
+		ro.EmbeddingModel = p.EmbeddingModel
+		ro.EmbeddingServer = p.EmbeddingServer
+		ro.SimilarityThreshold = p.SimilarityThreshold
+		ro.EmbedMaxBytes = p.EmbedMaxBytes
+		ro.SemanticQuery = p.SemanticQuery
+	}
+
+	final, err := playground.Run(ctx, ro)
 	if err != nil {
 		return err
 	}
-	// Print the final expression so a query authored in the TUI is reusable.
+	// Print the final expression / reproducible command so a query authored in
+	// the TUI is reusable.
 	if final != "" {
 		fmt.Println(final)
 	}

--- a/examples/playground.md
+++ b/examples/playground.md
@@ -8,7 +8,7 @@ file-search-on playground [<expr>] -d <root> [flags]
 
 ## Why
 
-Authoring a non-trivial CEL expression is normally a guess-run-reread loop: edit the string, re-run `search`, scan the output, tweak, repeat. The playground collapses that loop to zero — you see the effect of every character immediately, and the attribute cheat-sheet (`tab`) reminds you what you can filter on. Great for exploration and for live demos.
+Authoring a non-trivial CEL expression is normally a guess-run-reread loop: edit the string, re-run `search`, scan the output, tweak, repeat. The playground collapses that loop to zero — you see the effect of every character immediately, and the scrollable attributes panel (`ctrl+a`) reminds you what you can filter on. Great for exploration and for live demos.
 
 ## How it works
 
@@ -22,14 +22,14 @@ On launch it runs **one** walk (`search` with `Expr: "true"`, attributes include
 
 | Key | Action |
 |---|---|
-| *(type)* | Edit the CEL expression (the input is always focused) |
-| `↑` / `↓` | Move the selection through the match list |
-| `PgUp` / `PgDn` | Page the match list |
-| `tab` | Toggle the attribute cheat-sheet (every available attribute name) |
-| `enter` / `esc` | Quit and print the current expression to stdout |
+| *(type)* | Edit the focused input (CEL filter, or the semantic query box) |
+| `ctrl+a` | Toggle the **scrollable attributes panel** on the right (every attribute name, type, and description). Opening it gives it focus so `↑`/`↓` scroll it immediately |
+| `tab` | Cycle focus between the input(s) and the attributes panel (when open) |
+| `↑` / `↓` · `PgUp` / `PgDn` | Navigate the match list — or scroll the attributes panel when it has focus |
+| `enter` / `esc` | Quit and print the current expression to stdout (in semantic mode `enter` on the query box runs the search; `esc` quits) |
 | `ctrl+c` | Quit |
 
-The selected file's populated attributes (`content_type`, `size`, `mod_time`, plus a few type-specific keys) show in the panel below the list, so you can see exactly what your predicate is matching against.
+The attributes panel lists every CEL attribute and function with its type and a one-line description, and scrolls independently — so you can browse the full vocabulary without leaving the list. The selected file's populated attributes (`content_type`, `size`, `mod_time`, plus a few type-specific keys) show in the detail panel below the list, so you can see exactly what your predicate is matching against.
 
 ## Flags
 
@@ -43,6 +43,40 @@ The selected file's populated attributes (`content_type`, `size`, `mod_time`, pl
 | `--limit` | Cap on files snapshotted (default 5000) |
 | `--body` | Read file bodies so `body.contains(...)` works — expensive (reads every candidate during the snapshot) |
 | `--body-max-bytes` | Per-file body cap (0 = 1 MiB default) |
+| `--index-path` | Persistent bbolt index (caches file embeddings across semantic re-queries) |
+| `--no-index` | Disable the on-disk index |
+| `--embedding-model` | Ollama embedding model (e.g. `all-minilm`). **Setting this enables semantic mode.** |
+| `--embedding-server` | Ollama base URL (env `OLLAMA_HOST`; default `http://localhost:11434`) |
+| `--semantic-query` | Pre-fill the natural-language query box |
+| `--similarity-threshold` | Default similarity floor carried into the printed `search` command (default 0.5) |
+| `--embed-max-bytes` | Cap on body text handed to the embedder (0 = 8 KiB default) |
+
+## Semantic mode
+
+Pass `--embedding-model` and the playground gains a **second input box** for a natural-language query. Type a query, press `enter`, and the files are re-walked with a per-file cosine **`similarity`** score (computed by [Ollama](https://ollama.com)) and listed best-match first. The CEL box below then filters that ranked snapshot live — so `similarity > 0.6` or `is_source && similarity > 0.7` refine the semantic results without re-embedding. File embeddings are cached in the on-disk index, so changing the query only re-embeds the *query*, not every file.
+
+Prerequisite: a running Ollama with the model pulled (the examples use [`all-minilm`](https://ollama.com/library/all-minilm)):
+
+```sh
+ollama pull all-minilm
+```
+
+```sh
+# Semantic search over the codebase; refine with CEL live
+file-search-on playground --embedding-model all-minilm -d ./internal
+
+# Pre-fill the natural-language query
+file-search-on playground --embedding-model all-minilm \
+  --semantic-query "how does cancellation propagate" -d ./internal
+```
+
+On exit, semantic mode prints a **reproducible `search` command** (instead of the bare CEL expression) so the query you dialled in runs non-interactively:
+
+```sh
+file-search-on search --semantic-query 'how does cancellation propagate' \
+  --embedding-model 'all-minilm' --similarity-threshold 0.5 \
+  'is_source && similarity > 0.6'
+```
 
 ## Examples
 

--- a/internal/playground/model.go
+++ b/internal/playground/model.go
@@ -456,7 +456,7 @@ func (m model) reproCommand() string {
 	if m.opts.EmbeddingServer != "" && m.opts.EmbeddingServer != defaultServer {
 		b.WriteString(" --embedding-server " + shellQuote(m.opts.EmbeddingServer))
 	}
-	b.WriteString(fmt.Sprintf(" --similarity-threshold %v", m.opts.SimilarityThreshold))
+	fmt.Fprintf(&b, " --similarity-threshold %v", m.opts.SimilarityThreshold)
 	for _, d := range m.opts.Opts.Roots {
 		if d != "" && d != "." {
 			b.WriteString(" -d " + shellQuote(d))

--- a/internal/playground/model.go
+++ b/internal/playground/model.go
@@ -457,10 +457,30 @@ func (m model) reproCommand() string {
 		b.WriteString(" --embedding-server " + shellQuote(m.opts.EmbeddingServer))
 	}
 	fmt.Fprintf(&b, " --similarity-threshold %v", m.opts.SimilarityThreshold)
+	if m.opts.EmbedMaxBytes > 0 {
+		fmt.Fprintf(&b, " --embed-max-bytes %d", m.opts.EmbedMaxBytes)
+	}
 	for _, d := range m.opts.Opts.Roots {
 		if d != "" && d != "." {
 			b.WriteString(" -d " + shellQuote(d))
 		}
+	}
+	// Carry the walk-scope flags so the printed command reproduces the same
+	// candidate set and body availability as the interactive session.
+	for _, ex := range m.opts.Opts.Excludes {
+		b.WriteString(" --exclude " + shellQuote(ex))
+	}
+	if m.opts.Opts.RespectGitignore {
+		b.WriteString(" --respect-gitignore")
+	}
+	if m.opts.Opts.PruneBuildArtefacts {
+		b.WriteString(" --prune-build-artefacts")
+	}
+	if m.opts.Opts.IncludeBody {
+		b.WriteString(" --body")
+	}
+	if m.opts.Opts.BodyMaxBytes > 0 {
+		fmt.Fprintf(&b, " --body-max-bytes %d", m.opts.Opts.BodyMaxBytes)
 	}
 	if cel != "" {
 		b.WriteString(" " + shellQuote(cel))

--- a/internal/playground/model.go
+++ b/internal/playground/model.go
@@ -2,32 +2,54 @@ package playground
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/richardwooding/file-search-on/internal/content"
 	"github.com/richardwooding/file-search-on/internal/search"
+	"github.com/richardwooding/ollamaembed"
 )
 
 // RunOptions configures the playground. Opts carries the walk scope
 // (Roots / Excludes / RespectGitignore / PruneBuildArtefacts / Workers /
-// IncludeBody / BodyMaxBytes); Run forces Expr="true" + IncludeAttributes so
-// every file's attributes are snapshotted for in-memory filtering. Limit
-// caps the snapshot (0 → a sane default).
+// IncludeBody / BodyMaxBytes / Index); Run forces Expr="true" +
+// IncludeAttributes so every file's attributes are snapshotted for in-memory
+// filtering. Limit caps the snapshot (0 → a sane default).
+//
+// Semantic mode is opt-in: when Embedder is non-nil the TUI shows a
+// natural-language query box above the CEL box. Typing a query and pressing
+// Enter embeds it and re-walks with per-file cosine similarity, then the CEL
+// box filters that snapshot live ("is_source && similarity > 0.6"). The
+// remaining embedding fields are carried for the reproducible `search` command
+// printed on exit.
 type RunOptions struct {
 	Opts     search.Options
 	Registry *content.Registry
 	Initial  string
 	Limit    int
+
+	Embedder            ollamaembed.Embedder
+	EmbeddingModel      string
+	EmbeddingServer     string
+	SimilarityThreshold float64
+	EmbedMaxBytes       int
+	SemanticQuery       string
 }
 
 const defaultLimit = 5000
 
-// Run launches the TUI and blocks until the user quits, returning the final
-// CEL expression they had typed (the caller prints it so a query built here
-// is reusable).
+// defaultServer mirrors the CLI default so reproCommand can omit a redundant
+// --embedding-server flag.
+const defaultServer = "http://localhost:11434"
+
+// Run launches the TUI and blocks until the user quits. It returns a string
+// the caller prints so the query built here is reusable: in semantic mode a
+// full `file-search-on search --semantic-query …` command, otherwise the bare
+// CEL expression (the long-standing playground behaviour).
 func Run(ctx context.Context, o RunOptions) (string, error) {
 	if o.Limit <= 0 {
 		o.Limit = defaultLimit
@@ -40,31 +62,61 @@ func Run(ctx context.Context, o RunOptions) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return final.(model).finalExpr, nil
+	return final.(model).finalOutput(), nil
 }
 
+// loadedMsg carries the plain (no-similarity) attribute snapshot.
 type loadedMsg struct {
 	results []search.Result
 	capped  bool
 	err     error
 }
 
+// semanticDoneMsg carries the result of an embed-the-query-then-walk pass. The
+// query is echoed back so a stale in-flight search (the user kept typing) can
+// be told apart from the current one if needed.
+type semanticDoneMsg struct {
+	query   string
+	results []search.Result
+	capped  bool
+	err     error
+}
+
+// focusArea is which pane receives keystrokes: a text input, or the scrollable
+// attributes panel.
+type focusArea int
+
+const (
+	focusSem   focusArea = iota // natural-language query box (semantic mode)
+	focusCEL                    // CEL filter box
+	focusAttrs                  // the scrollable attributes panel
+)
+
 type model struct {
 	ctx   context.Context
 	opts  RunOptions
-	input textinput.Model
+	input textinput.Model // CEL filter
+	sem   textinput.Model // natural-language query (semantic mode only)
+	attrs viewport.Model  // scrollable attributes reference (right panel)
+
+	semantic bool // semantic mode enabled (opts.Embedder != nil)
+	focus    focusArea
 
 	results []search.Result
 	loaded  bool
 	loadErr error
 	capped  bool
 
+	searching     bool  // an embed+walk is in flight
+	searchErr     error // last semantic search error
+	hasSimilarity bool  // the current snapshot carries similarity scores
+
 	matched  []int
 	selected int
 	top      int // scroll offset into matched
 
 	errMsg     string // compile error for the current expression
-	showSchema bool
+	showSchema bool   // attributes panel is open
 	finalExpr  string
 	width      int
 	height     int
@@ -76,11 +128,36 @@ func newModel(ctx context.Context, o RunOptions) model {
 	ti.Prompt = "› "
 	ti.SetValue(o.Initial)
 	ti.CursorEnd()
-	ti.Focus()
-	return model{ctx: ctx, opts: o, input: ti, finalExpr: o.Initial, width: 80, height: 24}
+
+	m := model{ctx: ctx, opts: o, input: ti, finalExpr: o.Initial, width: 80, height: 24}
+	m.semantic = o.Embedder != nil
+	m.attrs = viewport.New(0, 0)
+
+	if m.semantic {
+		sem := textinput.New()
+		sem.Placeholder = `how does authentication work`
+		sem.Prompt = "› "
+		sem.SetValue(o.SemanticQuery)
+		sem.CursorEnd()
+		sem.Focus() // start in the query box so the user can search first
+		m.sem = sem
+		m.focus = focusSem
+		// An initial query means we go straight to a semantic walk; show the
+		// busy state until semanticDoneMsg lands.
+		if strings.TrimSpace(o.SemanticQuery) != "" {
+			m.searching = true
+		}
+	} else {
+		m.input.Focus()
+	}
+	return m
 }
 
 func (m model) Init() tea.Cmd {
+	if m.semantic && strings.TrimSpace(m.opts.SemanticQuery) != "" {
+		// Skip the plain snapshot — the semantic walk populates results.
+		return tea.Batch(textinput.Blink, m.semanticSearchCmd(m.opts.SemanticQuery))
+	}
 	return tea.Batch(textinput.Blink, m.loadCmd())
 }
 
@@ -96,10 +173,39 @@ func (m model) loadCmd() tea.Cmd {
 	}
 }
 
+// semanticSearchCmd embeds query once, then walks with per-file similarity
+// computed and sorted descending. File embeddings cache in opts.Opts.Index, so
+// re-queries over a warm tree only re-embed the query and recompute
+// dot-products.
+func (m model) semanticSearchCmd(query string) tea.Cmd {
+	o := m.opts
+	ctx := m.ctx
+	embedder := o.Embedder
+	return func() tea.Msg {
+		vec, err := embedder.Embed(ctx, query)
+		if err != nil {
+			return semanticDoneMsg{query: query, err: fmt.Errorf("embed query: %w", err)}
+		}
+		ollamaembed.Normalize(vec)
+		w := o.Opts
+		w.Expr = "true"
+		w.IncludeAttributes = true
+		w.Limit = o.Limit
+		w.Embedder = embedder
+		w.SemanticQueryEmbedding = vec
+		w.EmbedInputMaxBytes = o.EmbedMaxBytes
+		w.Sort = "similarity"
+		w.Order = "desc"
+		res, walkErr := search.Walk(ctx, w, o.Registry)
+		return semanticDoneMsg{query: query, results: res, capped: len(res) >= o.Limit, err: walkErr}
+	}
+}
+
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
+		m.syncAttrsViewport()
 		return m, nil
 
 	case loadedMsg:
@@ -110,40 +216,173 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refilter()
 		return m, nil
 
+	case semanticDoneMsg:
+		m.searching = false
+		m.loaded = true
+		if msg.err != nil {
+			m.searchErr = msg.err
+			return m, nil
+		}
+		m.searchErr = nil
+		m.results = msg.results
+		m.capped = msg.capped
+		m.hasSimilarity = true
+		m.refilter()
+		return m, nil
+
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "esc", "enter":
-			m.finalExpr = m.input.Value()
-			return m, tea.Quit
-		case "tab":
-			m.showSchema = !m.showSchema
-			return m, nil
-		case "up":
-			m.move(-1)
-			return m, nil
-		case "down":
-			m.move(1)
-			return m, nil
-		case "pgup":
-			m.move(-m.listHeight())
-			return m, nil
-		case "pgdown":
-			m.move(m.listHeight())
-			return m, nil
+		return m.updateKey(msg)
+	}
+
+	// Non-key messages (cursor blink, etc.). Drive both inputs so the focused
+	// box's cursor keeps blinking in semantic mode.
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	if m.semantic {
+		var c2 tea.Cmd
+		m.sem, c2 = m.sem.Update(msg)
+		cmd = tea.Batch(cmd, c2)
+	}
+	return m, cmd
+}
+
+// updateKey handles a keystroke for both plain and semantic modes. Global keys
+// (quit / panel toggle / focus cycle / submit) are handled first; otherwise the
+// key is routed to whichever pane has focus — the attributes viewport scrolls,
+// the match list navigates, or the focused text input edits.
+func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "esc":
+		m.finalExpr = m.input.Value()
+		return m, tea.Quit
+	case "ctrl+a":
+		return m, m.toggleAttrs()
+	case "tab":
+		return m, m.cycleFocus()
+	case "enter":
+		if m.semantic {
+			if m.focus != focusSem {
+				return m, nil // CEL filter is live; nothing to submit
+			}
+			q := strings.TrimSpace(m.sem.Value())
+			if q == "" || m.searching {
+				return m, nil
+			}
+			m.searching = true
+			m.searchErr = nil
+			return m, m.semanticSearchCmd(q)
 		}
-		// Everything else edits the expression.
-		prev := m.input.Value()
+		// Plain mode preserves the original contract: enter copies the
+		// expression and quits.
+		m.finalExpr = m.input.Value()
+		return m, tea.Quit
+	}
+
+	// Attributes panel focused → its viewport handles all scroll keys.
+	if m.focus == focusAttrs {
 		var cmd tea.Cmd
-		m.input, cmd = m.input.Update(msg)
-		if m.input.Value() != prev {
-			m.refilter()
-		}
+		m.attrs, cmd = m.attrs.Update(msg)
 		return m, cmd
 	}
 
+	// Match-list navigation.
+	switch msg.String() {
+	case "up":
+		m.move(-1)
+		return m, nil
+	case "down":
+		m.move(1)
+		return m, nil
+	case "pgup":
+		m.move(-m.listHeight())
+		return m, nil
+	case "pgdown":
+		m.move(m.listHeight())
+		return m, nil
+	}
+
+	// Otherwise edit the focused text input.
+	if m.semantic && m.focus == focusSem {
+		var cmd tea.Cmd
+		m.sem, cmd = m.sem.Update(msg)
+		return m, cmd
+	}
+	prev := m.input.Value()
 	var cmd tea.Cmd
 	m.input, cmd = m.input.Update(msg)
+	if m.input.Value() != prev {
+		m.refilter()
+	}
 	return m, cmd
+}
+
+// toggleAttrs opens/closes the right-hand attributes panel. Opening focuses it
+// (so ↑/↓ scroll immediately); closing returns focus to the default input.
+func (m *model) toggleAttrs() tea.Cmd {
+	m.showSchema = !m.showSchema
+	if m.showSchema {
+		m.syncAttrsViewport()
+		m.focus = focusAttrs
+		m.sem.Blur()
+		m.input.Blur()
+		return nil
+	}
+	if m.semantic {
+		m.focus = focusSem
+	} else {
+		m.focus = focusCEL
+	}
+	return m.applyFocus()
+}
+
+// cycleFocus advances focus through the available panes: the query box (when
+// semantic), the CEL box, and the attributes panel (when open).
+func (m *model) cycleFocus() tea.Cmd {
+	order := make([]focusArea, 0, 3)
+	if m.semantic {
+		order = append(order, focusSem)
+	}
+	order = append(order, focusCEL)
+	if m.showSchema {
+		order = append(order, focusAttrs)
+	}
+	cur := 0
+	for i, f := range order {
+		if f == m.focus {
+			cur = i
+		}
+	}
+	m.focus = order[(cur+1)%len(order)]
+	return m.applyFocus()
+}
+
+// applyFocus blurs the inactive inputs and focuses the active one (the
+// attributes panel takes keystrokes directly, not via a text input).
+func (m *model) applyFocus() tea.Cmd {
+	switch m.focus {
+	case focusSem:
+		m.input.Blur()
+		return m.sem.Focus()
+	case focusCEL:
+		m.sem.Blur()
+		return m.input.Focus()
+	default: // focusAttrs
+		m.sem.Blur()
+		m.input.Blur()
+		return nil
+	}
+}
+
+// syncAttrsViewport sizes the attributes viewport to the current panel
+// geometry and (re)builds its content truncated to that width.
+func (m *model) syncAttrsViewport() {
+	w := max(m.attrsPanelWidth(), 8)
+	h := max(
+		// one row for the panel heading
+		m.listHeight()-1, 1)
+	m.attrs.Width = w
+	m.attrs.Height = h
+	m.attrs.SetContent(attrsContent(w))
 }
 
 // refilter recompiles the current expression and recomputes the match set.
@@ -190,6 +429,51 @@ func (m *model) clampScroll() {
 	if m.top < 0 {
 		m.top = 0
 	}
+}
+
+// finalOutput is what Run returns (and the caller prints) on quit. In semantic
+// mode it's a reproducible `file-search-on search` command; otherwise the bare
+// CEL expression, preserving the original playground contract.
+func (m model) finalOutput() string {
+	if !m.semantic {
+		return m.finalExpr
+	}
+	return m.reproCommand()
+}
+
+func (m model) reproCommand() string {
+	q := strings.TrimSpace(m.sem.Value())
+	cel := strings.TrimSpace(m.input.Value())
+
+	var b strings.Builder
+	b.WriteString("file-search-on search")
+	if q != "" {
+		b.WriteString(" --semantic-query " + shellQuote(q))
+	}
+	if m.opts.EmbeddingModel != "" {
+		b.WriteString(" --embedding-model " + shellQuote(m.opts.EmbeddingModel))
+	}
+	if m.opts.EmbeddingServer != "" && m.opts.EmbeddingServer != defaultServer {
+		b.WriteString(" --embedding-server " + shellQuote(m.opts.EmbeddingServer))
+	}
+	b.WriteString(fmt.Sprintf(" --similarity-threshold %v", m.opts.SimilarityThreshold))
+	for _, d := range m.opts.Opts.Roots {
+		if d != "" && d != "." {
+			b.WriteString(" -d " + shellQuote(d))
+		}
+	}
+	if cel != "" {
+		b.WriteString(" " + shellQuote(cel))
+	}
+	return b.String()
+}
+
+// shellQuote single-quotes s for a POSIX shell, escaping embedded quotes.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // compileErr trims cel-go's multi-line compile error to its first line for a

--- a/internal/playground/model_test.go
+++ b/internal/playground/model_test.go
@@ -137,7 +137,7 @@ func TestRenderList_RowsNeverExceedWidth(t *testing.T) {
 		res(long+"/again.go", "source/go", 42, false),
 	}})
 
-	for _, line := range strings.Split(m.renderList(), "\n") {
+	for line := range strings.SplitSeq(m.renderList(), "\n") {
 		if w := lipgloss.Width(line); w > m.listWidth() {
 			t.Errorf("row width %d exceeds listWidth %d: %q", w, m.listWidth(), line)
 		}

--- a/internal/playground/model_test.go
+++ b/internal/playground/model_test.go
@@ -2,10 +2,12 @@ package playground
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/richardwooding/file-search-on/internal/search"
 )
@@ -122,6 +124,33 @@ func TestModel_EnterRecordsFinalExpr(t *testing.T) {
 		t.Errorf("enter should record the typed expression, got %q", m.finalExpr)
 	}
 }
+
+func TestRenderList_RowsNeverExceedWidth(t *testing.T) {
+	// Long paths + a dim-styled size column previously got byte-truncated as a
+	// whole styled string, corrupting ANSI escapes. Each rendered row's visible
+	// width must stay within the list budget so it never wraps.
+	m := newModel(context.Background(), RunOptions{})
+	m = drive(m, tea.WindowSizeMsg{Width: 50, Height: 20})
+	long := "internal/search/very/deeply/nested/directory/structure/walker_orchestrator.go"
+	m = drive(m, loadedMsg{results: []search.Result{
+		res(long, "source/go", 123456, false),
+		res(long+"/again.go", "source/go", 42, false),
+	}})
+
+	for _, line := range strings.Split(m.renderList(), "\n") {
+		if w := lipgloss.Width(line); w > m.listWidth() {
+			t.Errorf("row width %d exceeds listWidth %d: %q", w, m.listWidth(), line)
+		}
+		// Stripping complete SGR sequences must leave no stray ESC behind; a
+		// dangling ESC means an escape was sliced mid-sequence.
+		if stripped := sgrRE.ReplaceAllString(line, ""); strings.ContainsRune(stripped, '\x1b') {
+			t.Errorf("row has a corrupted ANSI escape: %q", line)
+		}
+	}
+}
+
+// sgrRE matches a complete ANSI SGR (colour/style) escape sequence.
+var sgrRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
 
 func TestView_AttrsPanelRendersContent(t *testing.T) {
 	m := newModel(context.Background(), RunOptions{})

--- a/internal/playground/model_test.go
+++ b/internal/playground/model_test.go
@@ -2,6 +2,7 @@ package playground
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -29,6 +30,10 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyEnter}
 	case "tab":
 		return tea.KeyMsg{Type: tea.KeyTab}
+	case "ctrl+a":
+		return tea.KeyMsg{Type: tea.KeyCtrlA}
+	case "pgdown":
+		return tea.KeyMsg{Type: tea.KeyPgDown}
 	}
 	return tea.KeyMsg{}
 }
@@ -118,18 +123,71 @@ func TestModel_EnterRecordsFinalExpr(t *testing.T) {
 	}
 }
 
-func TestModel_TabTogglesSchema(t *testing.T) {
+func TestView_AttrsPanelRendersContent(t *testing.T) {
 	m := newModel(context.Background(), RunOptions{})
+	m = drive(m, tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = drive(m, loaded())
+	m = drive(m, key("ctrl+a")) // open the panel
+
+	out := m.View()
+	if !strings.Contains(out, "attributes") {
+		t.Error("attributes panel heading should render")
+	}
+	if !strings.Contains(out, "content_type") {
+		t.Error("a known attribute name should appear in the scrollable panel")
+	}
+}
+
+func TestModel_AttrsPanelScrollsWhenFocused(t *testing.T) {
+	m := newModel(context.Background(), RunOptions{})
+	m = drive(m, tea.WindowSizeMsg{Width: 100, Height: 24})
+	m = drive(m, loaded())
+	m = drive(m, key("ctrl+a")) // open + focus the panel
+	before := m.attrs.YOffset
+	m = drive(m, key("pgdown"))
+	if m.attrs.YOffset <= before {
+		t.Errorf("focused attributes panel should scroll on pgdown, offset %d → %d", before, m.attrs.YOffset)
+	}
+	// With focus on the panel, navigation keys must NOT move the list selection.
+	if m.selected != 0 {
+		t.Errorf("list selection should stay put while the panel is focused, got %d", m.selected)
+	}
+}
+
+func TestModel_CtrlATogglesAttrsPanel(t *testing.T) {
+	m := newModel(context.Background(), RunOptions{})
+	m = drive(m, tea.WindowSizeMsg{Width: 100, Height: 40})
 	m = drive(m, loaded())
 	if m.showSchema {
-		t.Fatal("schema panel should start hidden")
+		t.Fatal("attributes panel should start hidden")
 	}
-	m = drive(m, key("tab"))
+	m = drive(m, key("ctrl+a"))
 	if !m.showSchema {
-		t.Error("tab should reveal the schema panel")
+		t.Error("ctrl+a should reveal the attributes panel")
 	}
-	m = drive(m, key("tab"))
+	if m.focus != focusAttrs {
+		t.Error("opening the panel should focus it so ↑/↓ scroll immediately")
+	}
+	m = drive(m, key("ctrl+a"))
 	if m.showSchema {
-		t.Error("tab again should hide the schema panel")
+		t.Error("ctrl+a again should hide the attributes panel")
+	}
+	if m.focus != focusCEL {
+		t.Error("closing the panel should return focus to the CEL box")
+	}
+}
+
+func TestModel_TabFocusesAttrsPanelWhenOpen(t *testing.T) {
+	m := newModel(context.Background(), RunOptions{})
+	m = drive(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = drive(m, loaded())
+	m = drive(m, key("ctrl+a")) // open + focus panel
+	m = drive(m, key("tab"))    // cycle: panel → CEL
+	if m.focus != focusCEL {
+		t.Errorf("tab from the panel should return to the CEL box, got %v", m.focus)
+	}
+	m = drive(m, key("tab")) // CEL → panel
+	if m.focus != focusAttrs {
+		t.Errorf("tab should cycle back to the attributes panel, got %v", m.focus)
 	}
 }

--- a/internal/playground/semantic_test.go
+++ b/internal/playground/semantic_test.go
@@ -178,6 +178,26 @@ func TestReproCommand(t *testing.T) {
 			},
 			want: `file-search-on search --semantic-query 'rate limiting' --embedding-model 'all-minilm' --embedding-server 'http://gpu:11434' --similarity-threshold 0.7 -d './src'`,
 		},
+		{
+			name: "carries walk-scope flags",
+			opts: RunOptions{
+				Embedder:            fakeEmbedder{},
+				EmbeddingModel:      "all-minilm",
+				EmbeddingServer:     defaultServer,
+				SimilarityThreshold: 0.5,
+				EmbedMaxBytes:       16384,
+				SemanticQuery:       "logging",
+				Opts: search.Options{
+					Roots:               []string{"./internal"},
+					Excludes:            []string{"*.bak", "testdata"},
+					RespectGitignore:    true,
+					PruneBuildArtefacts: true,
+					IncludeBody:         true,
+					BodyMaxBytes:        2048,
+				},
+			},
+			want: `file-search-on search --semantic-query 'logging' --embedding-model 'all-minilm' --similarity-threshold 0.5 --embed-max-bytes 16384 -d './internal' --exclude '*.bak' --exclude 'testdata' --respect-gitignore --prune-build-artefacts --body --body-max-bytes 2048`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/playground/semantic_test.go
+++ b/internal/playground/semantic_test.go
@@ -1,0 +1,213 @@
+package playground
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/richardwooding/file-search-on/internal/celexpr"
+	"github.com/richardwooding/file-search-on/internal/search"
+)
+
+// fakeEmbedder is a deterministic, network-free Embedder for tests.
+type fakeEmbedder struct{ model string }
+
+func (f fakeEmbedder) Embed(_ context.Context, _ string) ([]float32, error) {
+	return []float32{1, 0, 0}, nil
+}
+func (f fakeEmbedder) Model() string { return f.model }
+
+// semRes builds a result carrying a similarity score.
+func semRes(path string, sim float64, md bool) search.Result {
+	return search.Result{Path: path, Attrs: &celexpr.FileAttributes{
+		Path: path, Name: path, ContentType: "markdown", Size: 100, IsMarkdown: md, Similarity: sim,
+	}}
+}
+
+func semanticModel() model {
+	return newModel(context.Background(), RunOptions{
+		Embedder:            fakeEmbedder{model: "all-minilm"},
+		EmbeddingModel:      "all-minilm",
+		EmbeddingServer:     defaultServer,
+		SimilarityThreshold: 0.5,
+	})
+}
+
+func TestSemantic_ModeEnabledByEmbedder(t *testing.T) {
+	plain := newModel(context.Background(), RunOptions{})
+	if plain.semantic {
+		t.Fatal("no embedder → semantic mode must be off")
+	}
+	m := semanticModel()
+	if !m.semantic {
+		t.Fatal("an embedder should enable semantic mode")
+	}
+	if m.focus != focusSem {
+		t.Errorf("semantic mode should start focused on the query box, got %v", m.focus)
+	}
+}
+
+func TestSemantic_DonePopulatesResultsAndSimilarity(t *testing.T) {
+	m := semanticModel()
+	m = drive(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	// Pretend an embed+walk finished, results already sorted by similarity desc.
+	m = drive(m, semanticDoneMsg{
+		query: "auth",
+		results: []search.Result{
+			semRes("a.md", 0.92, true),
+			semRes("b.md", 0.70, true),
+			semRes("c.md", 0.40, true),
+		},
+	})
+
+	if m.searching {
+		t.Error("searching should clear once semanticDoneMsg lands")
+	}
+	if !m.hasSimilarity {
+		t.Error("hasSimilarity should be set after a semantic walk")
+	}
+	if len(m.matched) != 3 {
+		t.Fatalf("empty CEL filter should match all 3, got %d", len(m.matched))
+	}
+}
+
+func TestSemantic_CELFilterOnSimilarity(t *testing.T) {
+	m := semanticModel()
+	m = drive(m, tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = drive(m, semanticDoneMsg{results: []search.Result{
+		semRes("a.md", 0.92, true),
+		semRes("b.md", 0.70, true),
+		semRes("c.md", 0.40, true),
+	}})
+
+	// Move focus to the CEL box and type a similarity predicate.
+	m = drive(m, key("tab"))
+	if m.focus != focusCEL {
+		t.Fatalf("tab should move focus to the CEL box, got %v", m.focus)
+	}
+	for _, r := range "similarity > 0.6" {
+		m = drive(m, key(string(r)))
+	}
+	if len(m.matched) != 2 {
+		t.Fatalf("similarity > 0.6 should match a.md + b.md (2), got %d", len(m.matched))
+	}
+}
+
+func TestSemantic_DoneError(t *testing.T) {
+	m := semanticModel()
+	m = drive(m, semanticDoneMsg{err: context.DeadlineExceeded})
+	if m.searchErr == nil {
+		t.Error("a failed semantic walk should set searchErr")
+	}
+	if m.searching {
+		t.Error("searching should clear even on error")
+	}
+}
+
+func TestSemantic_EnterOnQueryStartsSearch(t *testing.T) {
+	m := semanticModel()
+	m = drive(m, loaded()) // plain snapshot first
+	for _, r := range "logging" {
+		m = drive(m, key(string(r)))
+	}
+	if m.sem.Value() != "logging" {
+		t.Fatalf("query box should hold the typed text, got %q", m.sem.Value())
+	}
+	m = drive(m, key("enter"))
+	if !m.searching {
+		t.Error("enter on the query box should kick off a search (searching=true)")
+	}
+}
+
+func TestSemantic_EnterDoesNotQuit(t *testing.T) {
+	// Regression guard: in semantic mode enter must search/no-op, never quit.
+	m := semanticModel()
+	m = drive(m, loaded())
+	m = drive(m, key("tab")) // focus CEL box
+	next, cmd := m.Update(key("enter"))
+	_ = next
+	if cmd != nil {
+		// tea.Quit is a cmd; assert enter on the CEL box produced no cmd.
+		t.Error("enter on the CEL box in semantic mode should be a no-op (no quit)")
+	}
+}
+
+func TestSemantic_TabSwitchesFocusNotSchema(t *testing.T) {
+	m := semanticModel()
+	m = drive(m, key("tab"))
+	if m.focus != focusCEL {
+		t.Errorf("tab should switch focus to CEL, got %v", m.focus)
+	}
+	if m.showSchema {
+		t.Error("tab must not toggle the schema panel in semantic mode")
+	}
+	m = drive(m, key("tab"))
+	if m.focus != focusSem {
+		t.Errorf("tab again should switch focus back to the query box, got %v", m.focus)
+	}
+}
+
+func TestReproCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		opts RunOptions
+		want string
+	}{
+		{
+			name: "basic",
+			opts: RunOptions{
+				Embedder:            fakeEmbedder{},
+				EmbeddingModel:      "all-minilm",
+				EmbeddingServer:     defaultServer,
+				SimilarityThreshold: 0.5,
+				SemanticQuery:       "how auth works",
+				Initial:             "is_source && similarity > 0.6",
+			},
+			want: `file-search-on search --semantic-query 'how auth works' --embedding-model 'all-minilm' --similarity-threshold 0.5 'is_source && similarity > 0.6'`,
+		},
+		{
+			name: "custom server and root",
+			opts: RunOptions{
+				Embedder:            fakeEmbedder{},
+				EmbeddingModel:      "all-minilm",
+				EmbeddingServer:     "http://gpu:11434",
+				SimilarityThreshold: 0.7,
+				SemanticQuery:       "rate limiting",
+				Opts:                search.Options{Roots: []string{"./src"}},
+			},
+			want: `file-search-on search --semantic-query 'rate limiting' --embedding-model 'all-minilm' --embedding-server 'http://gpu:11434' --similarity-threshold 0.7 -d './src'`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newModel(context.Background(), tt.opts)
+			if got := m.reproCommand(); got != tt.want {
+				t.Errorf("reproCommand()\n got: %s\nwant: %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFinalOutput_NonSemanticReturnsExpr(t *testing.T) {
+	m := newModel(context.Background(), RunOptions{Initial: "is_pdf"})
+	m = drive(m, key("enter")) // records finalExpr & quits
+	if got := m.finalOutput(); got != "is_pdf" {
+		t.Errorf("non-semantic finalOutput should be the bare CEL expr, got %q", got)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := map[string]string{
+		"":             "''",
+		"plain":        "'plain'",
+		"a b":          "'a b'",
+		"it's":         `'it'\''s'`,
+		"a && b > 0.6": `'a && b > 0.6'`,
+	}
+	for in, want := range cases {
+		if got := shellQuote(in); got != want {
+			t.Errorf("shellQuote(%q) = %s, want %s", in, got, want)
+		}
+	}
+}

--- a/internal/playground/view.go
+++ b/internal/playground/view.go
@@ -148,22 +148,49 @@ func (m model) renderList() string {
 	case len(m.matched) == 0 && m.loaded:
 		lines = append(lines, dimStyle.Render("(no matches)"))
 	case len(m.matched) > 0:
-		pathW := w / 2
 		for i := m.top; i < len(m.matched) && i < m.top+h; i++ {
 			r := m.results[m.matched[i]]
-			meta := r.Attrs.ContentType
-			if r.Attrs.Size > 0 {
-				meta += dimStyle.Render(fmt.Sprintf("  %s", humanSize(r.Attrs.Size)))
-			}
-			var prefix string
+			avail := w - 1 // leave a 1-cell safety margin
+
+			// Similarity score: fixed-width, never truncated.
+			scorePlain := ""
 			if m.hasSimilarity {
-				prefix = okStyle.Render(fmt.Sprintf("%.3f", r.Attrs.Similarity)) + " "
+				scorePlain = fmt.Sprintf("%.3f ", r.Attrs.Similarity)
 			}
-			line := prefix + fmt.Sprintf("%-*s %s", max(20, pathW), truncate(r.Path, pathW), meta)
+
+			// Meta column: content type + human size.
+			ctype := r.Attrs.ContentType
+			sizePlain := ""
+			if r.Attrs.Size > 0 {
+				sizePlain = "  " + humanSize(r.Attrs.Size)
+			}
+
+			// Budget the path column from what's left; drop the size, then
+			// clamp, if the row is too narrow to fit everything.
+			pathW := avail - lipgloss.Width(scorePlain) - 1 - lipgloss.Width(ctype) - lipgloss.Width(sizePlain)
+			if pathW < 8 {
+				sizePlain = ""
+				pathW = avail - lipgloss.Width(scorePlain) - 1 - lipgloss.Width(ctype)
+			}
+			pathW = max(pathW, 4)
+			pathPlain := truncate(r.Path, pathW)
+
 			if i == m.selected {
-				line = selStyle.Render(truncate(line, w-1))
-			} else {
-				line = truncate(line, w-1)
+				// Reverse-highlight a single plain string so no inner reset
+				// code cuts the highlight short.
+				plain := fmt.Sprintf("%s%-*s %s%s", scorePlain, pathW, pathPlain, ctype, sizePlain)
+				lines = append(lines, selStyle.Render(truncate(plain, avail)))
+				continue
+			}
+			// Style each span independently — no truncation of styled text, so
+			// ANSI escapes can never be sliced mid-sequence.
+			var line string
+			if scorePlain != "" {
+				line += okStyle.Render(scorePlain)
+			}
+			line += fmt.Sprintf("%-*s ", pathW, pathPlain) + ctype
+			if sizePlain != "" {
+				line += dimStyle.Render(sizePlain)
 			}
 			lines = append(lines, line)
 		}

--- a/internal/playground/view.go
+++ b/internal/playground/view.go
@@ -20,14 +20,32 @@ var (
 	selStyle    = lipgloss.NewStyle().Reverse(true)
 	boxStyle    = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
 	panelStyle  = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, false, false).MarginTop(1)
+	// attrsPanelStyle is the scrollable right-hand attributes panel: a single
+	// vertical rule on its left, a column of padding, and a left margin that
+	// separates it from the match list. The 3 cols it adds (margin+border+pad)
+	// are accounted for in listWidth.
+	attrsPanelStyle = lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder(), false, false, false, true).
+			BorderForeground(lipgloss.Color("8")).
+			PaddingLeft(1).
+			MarginLeft(1)
 )
 
-// chromeRows is the number of non-list rows (title, input box, status,
+// baseChromeRows is the number of non-list rows (title, input box, status,
 // footer, detail panel) so listHeight can give the rest to the match list.
-const chromeRows = 13
+// Semantic mode adds a second input box + its label.
+const baseChromeRows = 13
+const semanticExtraRows = 4
+
+func (m model) chromeRows() int {
+	if m.semantic {
+		return baseChromeRows + semanticExtraRows
+	}
+	return baseChromeRows
+}
 
 func (m model) listHeight() int {
-	h := m.height - chromeRows
+	h := m.height - m.chromeRows()
 	if h < 1 {
 		return 1
 	}
@@ -37,11 +55,23 @@ func (m model) listHeight() int {
 func (m model) View() string {
 	var b strings.Builder
 
-	b.WriteString(titleStyle.Render("CEL playground") + dimStyle.Render("  —  live filter, type a CEL expression") + "\n")
-	b.WriteString(boxStyle.Width(min(m.width-2, 100)).Render(m.input.View()) + "\n")
+	if m.semantic {
+		b.WriteString(titleStyle.Render("semantic playground") + dimStyle.Render("  —  natural-language search + live CEL filter") + "\n")
+		b.WriteString(focusLabel("semantic query", m.focus == focusSem) + "\n")
+		b.WriteString(boxStyle.Width(min(m.width-2, 100)).Render(m.sem.View()) + "\n")
+		b.WriteString(focusLabel("CEL filter", m.focus == focusCEL) + "\n")
+		b.WriteString(boxStyle.Width(min(m.width-2, 100)).Render(m.input.View()) + "\n")
+	} else {
+		b.WriteString(titleStyle.Render("CEL playground") + dimStyle.Render("  —  live filter, type a CEL expression") + "\n")
+		b.WriteString(boxStyle.Width(min(m.width-2, 100)).Render(m.input.View()) + "\n")
+	}
 
 	// Status / error line.
 	switch {
+	case m.searching:
+		b.WriteString(accentStyle.Render("embedding & searching…") + dimStyle.Render("  ("+m.opts.EmbeddingModel+")") + "\n")
+	case m.searchErr != nil:
+		b.WriteString(errStyle.Render("✗ "+semErrLine(m.searchErr)) + "\n")
 	case !m.loaded:
 		b.WriteString(dimStyle.Render("scanning…") + "\n")
 	case m.loadErr != nil:
@@ -50,54 +80,126 @@ func (m model) View() string {
 		b.WriteString(errStyle.Render("✗ "+m.errMsg) + "\n")
 	default:
 		status := okStyle.Render(fmt.Sprintf("%d", len(m.matched))) + dimStyle.Render(fmt.Sprintf("/%d match", len(m.results)))
+		if m.semantic && m.opts.EmbeddingModel != "" {
+			status += dimStyle.Render("  · model " + m.opts.EmbeddingModel)
+		}
 		if m.capped {
 			status += dimStyle.Render(fmt.Sprintf("  (first %d shown — narrow with -d / --limit)", len(m.results)))
 		}
 		b.WriteString(status + "\n")
 	}
 
-	// Match list (windowed).
-	b.WriteString(m.renderList())
-
-	// Detail / schema panel.
+	// Middle row: the match list, with the scrollable attributes panel docked
+	// on the right when it's open.
+	left := m.renderList()
 	if m.showSchema {
-		b.WriteString(panelStyle.Render(m.renderSchema()))
+		left = lipgloss.NewStyle().Width(m.listWidth()).Render(left)
+		b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, left, m.renderAttrsPanel()))
 	} else {
-		b.WriteString(panelStyle.Render(m.renderDetail()))
+		b.WriteString(left)
 	}
+	b.WriteString("\n")
 
-	b.WriteString("\n" + dimStyle.Render("↑/↓ PgUp/PgDn navigate · tab attributes · enter/esc copy expr & quit"))
+	// Selected-file detail panel (always at the bottom now).
+	b.WriteString(panelStyle.Render(m.renderDetail()))
+
+	b.WriteString("\n" + dimStyle.Render(m.footer()))
 	return b.String()
 }
 
+// footer is the keybinding hint line; the navigate keys' meaning depends on
+// whether the attributes panel currently has focus.
+func (m model) footer() string {
+	nav := "↑/↓ PgUp/PgDn navigate"
+	if m.focus == focusAttrs {
+		nav = "↑/↓ PgUp/PgDn scroll attrs"
+	}
+	if m.semantic {
+		return "tab focus · enter (on query) search · " + nav + " · ctrl+a attrs · esc copy cmd & quit"
+	}
+	return nav + " · tab focus · ctrl+a attrs · enter/esc copy expr & quit"
+}
+
+// focusLabel renders a box label, marked with an accent arrow when focused.
+func focusLabel(name string, focused bool) string {
+	if focused {
+		return accentStyle.Render("▸ " + name)
+	}
+	return dimStyle.Render("  " + name)
+}
+
+// semErrLine flattens a semantic-search error to one line and appends the
+// usual "is Ollama up?" hint (mirrors search_cmd.go's footer warning).
+func semErrLine(err error) string {
+	s := err.Error()
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	return s + "  (is Ollama running and the model pulled?)"
+}
+
+// renderList returns exactly listHeight lines (no trailing newline) so it can
+// be joined horizontally with the attributes panel without misalignment.
 func (m model) renderList() string {
 	h := m.listHeight()
-	if len(m.matched) == 0 {
-		if m.loaded {
-			return dimStyle.Render("(no matches)") + strings.Repeat("\n", h)
-		}
-		return strings.Repeat("\n", h)
-	}
+	w := m.listWidth()
 	var lines []string
-	for i := m.top; i < len(m.matched) && i < m.top+h; i++ {
-		r := m.results[m.matched[i]]
-		meta := r.Attrs.ContentType
-		if r.Attrs.Size > 0 {
-			meta += dimStyle.Render(fmt.Sprintf("  %s", humanSize(r.Attrs.Size)))
+	switch {
+	case len(m.matched) == 0 && m.loaded:
+		lines = append(lines, dimStyle.Render("(no matches)"))
+	case len(m.matched) > 0:
+		pathW := w / 2
+		for i := m.top; i < len(m.matched) && i < m.top+h; i++ {
+			r := m.results[m.matched[i]]
+			meta := r.Attrs.ContentType
+			if r.Attrs.Size > 0 {
+				meta += dimStyle.Render(fmt.Sprintf("  %s", humanSize(r.Attrs.Size)))
+			}
+			var prefix string
+			if m.hasSimilarity {
+				prefix = okStyle.Render(fmt.Sprintf("%.3f", r.Attrs.Similarity)) + " "
+			}
+			line := prefix + fmt.Sprintf("%-*s %s", max(20, pathW), truncate(r.Path, pathW), meta)
+			if i == m.selected {
+				line = selStyle.Render(truncate(line, w-1))
+			} else {
+				line = truncate(line, w-1)
+			}
+			lines = append(lines, line)
 		}
-		line := fmt.Sprintf("%-*s %s", max(20, m.width/2), truncate(r.Path, m.width/2), meta)
-		if i == m.selected {
-			line = selStyle.Render(truncate(line, m.width-1))
-		} else {
-			line = truncate(line, m.width-1)
-		}
-		lines = append(lines, line)
 	}
-	// Pad to a stable height so the panel below doesn't jump.
+	// Pad / clamp to a stable height so neighbouring panels don't jump.
 	for len(lines) < h {
 		lines = append(lines, "")
 	}
-	return strings.Join(lines, "\n") + "\n"
+	if len(lines) > h {
+		lines = lines[:h]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// listWidth is the horizontal budget for the match list, shrunk to leave room
+// for the attributes panel (and its 3 cols of margin/border/padding) when open.
+func (m model) listWidth() int {
+	if m.showSchema {
+		w := max(m.width-m.attrsPanelWidth()-3, 10)
+		return w
+	}
+	return m.width
+}
+
+// attrsPanelWidth is the inner content width of the right-hand attributes
+// panel: roughly a third of the screen, clamped to a readable band and never
+// so wide it starves the list.
+func (m model) attrsPanelWidth() int {
+	w := min(max(m.width/3, 24), 46)
+	if cap := m.width - 24; w > cap {
+		w = cap
+	}
+	if w < 0 {
+		w = 0
+	}
+	return w
 }
 
 func (m model) renderDetail() string {
@@ -132,17 +234,50 @@ func (m model) renderDetail() string {
 	return b.String()
 }
 
-func (m model) renderSchema() string {
+// renderAttrsPanel draws the scrollable attributes viewport with a heading.
+func (m model) renderAttrsPanel() string {
+	scroll := "↑/↓ scroll"
+	if m.focus != focusAttrs {
+		scroll = "tab to scroll"
+	}
+	head := titleStyle.Render("attributes") + dimStyle.Render("  "+scroll)
+	inner := head + "\n" + m.attrs.View()
+	return attrsPanelStyle.Height(m.listHeight()).Render(inner)
+}
+
+// attrsContent builds the full attribute/function reference, one entry per line
+// (with a wrapped description line), each pre-truncated to w so the viewport
+// scrolls vertically without horizontal clipping. Styling is applied AFTER
+// truncation so ANSI escapes are never cut mid-sequence.
+func attrsContent(w int) string {
 	s := celexpr.Schema()
-	var names []string
-	for _, a := range s.Common {
-		names = append(names, a.Name)
+	var b strings.Builder
+	section := func(title string, docs []celexpr.AttributeDoc) {
+		if len(docs) == 0 {
+			return
+		}
+		b.WriteString(titleStyle.Render(title) + "\n")
+		for _, a := range docs {
+			b.WriteString(accentStyle.Render(truncate(a.Name+" ("+a.Type+")", w)) + "\n")
+			if a.Description != "" {
+				b.WriteString(dimStyle.Render(truncate("  "+a.Description, w)) + "\n")
+			}
+		}
+		b.WriteString("\n")
 	}
-	for _, a := range s.TypeSpecific {
-		names = append(names, a.Name)
+	section("COMMON", s.Common)
+	section("TYPE-SPECIFIC", s.TypeSpecific)
+	section("FRONTMATTER", s.Frontmatter)
+	if len(s.Functions) > 0 {
+		b.WriteString(titleStyle.Render("FUNCTIONS") + "\n")
+		for _, f := range s.Functions {
+			b.WriteString(accentStyle.Render(truncate(f.Signature, w)) + "\n")
+			if f.Description != "" {
+				b.WriteString(dimStyle.Render(truncate("  "+f.Description, w)) + "\n")
+			}
+		}
 	}
-	line := strings.Join(names, " · ")
-	return titleStyle.Render("attributes") + "\n" + dimStyle.Render(truncate(line, (m.width-2)*4))
+	return b.String()
 }
 
 func humanSize(n int64) string {


### PR DESCRIPTION
## Summary

Adds an opt-in **semantic-search mode** to the `playground` TUI and reworks the attribute reference into a **scrollable right-hand panel**.

### Semantic mode (`--embedding-model`)
- A natural-language query box appears above the CEL box. Typing a query and pressing **enter** embeds it (via Ollama) and re-walks the tree with a per-file cosine **`similarity`** score, listed best-match first.
- The CEL box then filters that ranked snapshot **live** — `similarity > 0.6`, `is_source && similarity > 0.7`, etc. — with no re-embedding.
- File embeddings are cached in the on-disk index (`--index-path` / default per-cwd), so changing the query only re-embeds the *query*, not every file.
- On exit it prints a **reproducible** `file-search-on search --semantic-query …` command instead of the bare CEL expr.
- Reuses the same `search.Walk` + `Embedder` + `SemanticQueryEmbedding` backend as `search --semantic-query`.

### Scrollable attributes panel
- **ctrl+a** toggles a right-hand panel (`bubbles/viewport`) listing every attribute and CEL function with its **type and a one-line description** — replacing the old cramped one-line strip.
- Opening it gives it focus, so **↑/↓ · PgUp/PgDn** (and `j/k`) scroll it **independently** of the match list.
- **tab** cycles focus between the input(s) and the panel; the footer reflects what the nav keys do.

Plain (non-semantic) mode keeps its original behavior, including the `enter`/`esc` copy-expr-and-quit contract.

## Try it
```sh
ollama pull all-minilm
file-search-on playground --embedding-model all-minilm -d ./internal/search
```

## Tests
- Embed→walk flow, similarity CEL filter, error handling, focus cycling, independent panel scroll, reproducible-command builder, `shellQuote`, and a `View()` render smoke test.
- Full suite green; `gofmt`/`vet` clean; `go fix` idempotent.
- End-to-end smoke-tested against a real Ollama `all-minilm`.

Docs: README playground rows + `examples/playground.md` updated (semantic mode, new flags, new keybindings), using `all-minilm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)