### PR TITLE
fix(watch): skip .git and cap descriptor budget so watch-index can't freeze the server

### DIFF
--- a/internal/search/watch.go
+++ b/internal/search/watch.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -21,6 +22,44 @@ import (
 // match (and emit) multiple times. 300ms is below human-perceptible
 // latency yet long enough to swallow a multi-write save.
 const watchDebounce = 300 * time.Millisecond
+
+// MaxWatchFDs bounds the number of file descriptors the recursive
+// watcher will consume registering a tree. It is a var, not a const, so
+// tests can lower it; operationally it should not need tuning.
+//
+// The cap exists because fsnotify's macOS / *BSD kqueue backend opens
+// one descriptor per watched directory AND one per file inside it (it
+// has to, to report which entry changed). A modest tree — a few
+// thousand files — can therefore exhaust the per-process descriptor
+// limit (kern.maxfilesperproc, commonly 10240) and freeze a long-lived
+// server with EMFILE on every subsequent open. Once the estimated
+// descriptor cost of the watched set reaches this budget, registration
+// stops; the un-watched remainder falls back to lazy (size, mtime)
+// revalidation on the next query — correctness is unaffected, only
+// cache-warmth latency under churn. Issue #464.
+var MaxWatchFDs = 4096
+
+// fileWatchCostsFD reports whether the platform's fsnotify backend holds
+// a descriptor per watched FILE (kqueue: macOS + the BSDs), as opposed
+// to inotify (Linux) where only directories cost a watch. Drives whether
+// files count against MaxWatchFDs.
+func fileWatchCostsFD() bool {
+	switch runtime.GOOS {
+	case "darwin", "freebsd", "netbsd", "openbsd", "dragonfly":
+		return true
+	default:
+		return false
+	}
+}
+
+// watchBudget tracks the descriptor budget shared across a watcher's
+// initial registration and any directories registered later (when a
+// CREATE event arrives). truncated latches once the budget is hit so the
+// caller can warn exactly once.
+type watchBudget struct {
+	remaining int
+	truncated bool
+}
 
 // Watch sets up recursive filesystem watching across opts.Roots and
 // calls onMatch once per newly-created / modified file that matches
@@ -114,11 +153,25 @@ func watchLoop(ctx context.Context, roots, globs []string, respectGitignore bool
 	}
 	defer func() { _ = watcher.Close() }()
 
+	// One descriptor budget shared by the initial registration and any
+	// directories registered later (on CREATE). Warn at most once when it
+	// truncates so a huge tree doesn't silently watch only a prefix.
+	budget := &watchBudget{remaining: MaxWatchFDs}
 	for _, root := range roots {
-		if err := addDirsRecursive(watcher, root, globs, respectGitignore); err != nil {
+		if err := addDirsRecursive(watcher, root, globs, respectGitignore, budget); err != nil {
 			return err
 		}
 	}
+	warnedTruncated := false
+	warnTruncated := func() {
+		if budget.truncated && !warnedTruncated {
+			warnedTruncated = true
+			fmt.Fprintf(os.Stderr, "watch: tree exceeds the %d-descriptor watch budget; "+
+				"watching a subset and relying on lazy revalidation for the rest "+
+				"(results stay correct; narrow the root or exclude large dirs to silence this)\n", MaxWatchFDs)
+		}
+	}
+	warnTruncated()
 
 	// Per-path debounce state. Each entry holds the latest op and its
 	// timer. A WaitGroup tracks scheduled-but-not-yet-finished timer
@@ -189,7 +242,8 @@ func watchLoop(ctx context.Context, roots, globs []string, respectGitignore bool
 			// isn't recursive). Register it and don't forward the event.
 			if event.Has(fsnotify.Create) {
 				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
-					_ = addDirsRecursive(watcher, event.Name, globs, respectGitignore)
+					_ = addDirsRecursive(watcher, event.Name, globs, respectGitignore, budget)
+					warnTruncated()
 					continue
 				}
 			}
@@ -209,10 +263,18 @@ func watchLoop(ctx context.Context, roots, globs []string, respectGitignore bool
 }
 
 // addDirsRecursive registers root and every subdirectory under it with
-// the watcher, skipping basenames matched by the excluder. Missing /
-// unreadable directories are skipped, not fatal — the tree can change
-// under us.
-func addDirsRecursive(watcher *fsnotify.Watcher, root string, globs []string, respectGitignore bool) error {
+// the watcher, skipping basenames matched by the excluder and the VCS
+// metadata directory (.git — large, churny, and never something a search
+// cares to watch; watching it alone can cost thousands of descriptors).
+// Missing / unreadable directories are skipped, not fatal — the tree can
+// change under us.
+//
+// Registration is bounded by budget: each watched directory and (on
+// kqueue platforms) each file inside it draws down budget.remaining. When
+// it reaches zero the walk stops and budget.truncated is set, so a
+// long-lived watcher can't exhaust the process descriptor limit on a
+// large tree (see MaxWatchFDs).
+func addDirsRecursive(watcher *fsnotify.Watcher, root string, globs []string, respectGitignore bool, budget *watchBudget) error {
 	info, err := os.Stat(root)
 	if err != nil {
 		return fmt.Errorf("watch root %s: %w", root, err)
@@ -222,20 +284,41 @@ func addDirsRecursive(watcher *fsnotify.Watcher, root string, globs []string, re
 		// surface (fsnotify watches directories, not files, reliably).
 		return watcher.Add(filepath.Dir(root))
 	}
+	fileCosts := fileWatchCostsFD()
 	excl := newExcluder(os.DirFS(root), globs, respectGitignore)
 	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil // unreadable entry; skip
 		}
 		if !d.IsDir() {
+			// A file inside an already-Added directory still costs a
+			// descriptor on kqueue platforms. Account for it so the budget
+			// reflects real FD pressure, not just directory count.
+			if fileCosts {
+				budget.remaining--
+				if budget.remaining <= 0 {
+					budget.truncated = true
+					return filepath.SkipAll
+				}
+			}
 			return nil
 		}
 		if path != root {
+			// Never watch the VCS metadata dir, and honour caller excludes
+			// (build artefacts, node_modules, gitignored trees).
+			if filepath.Base(path) == ".git" {
+				return filepath.SkipDir
+			}
 			if rel, rerr := filepath.Rel(root, path); rerr == nil && excl.Match(filepath.ToSlash(rel), true) {
 				return filepath.SkipDir
 			}
 		}
+		if budget.remaining <= 0 {
+			budget.truncated = true
+			return filepath.SkipAll
+		}
 		_ = watcher.Add(path) // best-effort; a vanished dir is fine
+		budget.remaining--
 		return nil
 	})
 }

--- a/internal/search/watch_index.go
+++ b/internal/search/watch_index.go
@@ -77,9 +77,9 @@ func WatchIndex(ctx context.Context, opts Options, registry *content.Registry, i
 		registry = content.DefaultRegistry()
 	}
 
-	// addDirsRecursive honours globs + .gitignore but NOT
-	// PruneBuildArtefacts — unlike WalkStream, which unions the build-
-	// excludes in. Resolve them once up front and merge so both the
+	// addDirsRecursive honours globs + .gitignore (and always skips .git)
+	// but NOT PruneBuildArtefacts — unlike WalkStream, which unions the
+	// build-excludes in. Resolve them once up front and merge so both the
 	// directory registration and the per-event excluder skip build
 	// artefacts. Mirrors walker.go's PruneBuildArtefacts handling.
 	excludes := opts.Excludes

--- a/internal/search/watch_index_test.go
+++ b/internal/search/watch_index_test.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -199,6 +200,69 @@ func TestWatchIndexRespectsExcludes(t *testing.T) {
 		t.Errorf("expected no refresh for excluded path, got Refreshed=%d", got)
 	}
 	_ = key
+}
+
+// TestWatchSkipsGitDir verifies the recursive watcher never registers the
+// .git metadata directory: a cached file under .git must not be refreshed
+// when it changes, because .git is never watched. (.git is huge and churny
+// on real repos — watching it can cost thousands of descriptors and freeze
+// a long-lived server. Issue #464.)
+func TestWatchSkipsGitDir(t *testing.T) {
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(gitDir, "HEAD")
+	if err := os.WriteFile(path, []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idx := index.NewMemory()
+	// Even if somehow cached, a path under .git must not be refreshed.
+	key := seedIndex(t, idx, path)
+
+	stats, cancel := startWatchIndex(t, Options{Roots: []string{dir}, Index: idx}, idx)
+	defer cancel()
+
+	time.Sleep(1100 * time.Millisecond)
+	if err := os.WriteFile(path, []byte("ref: refs/heads/feature\nmore\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(900 * time.Millisecond)
+	if got := stats.Refreshed.Load(); got != 0 {
+		t.Errorf("expected no refresh for path under .git, got Refreshed=%d", got)
+	}
+	_ = key
+}
+
+// TestAddDirsRecursiveRespectsBudget verifies that registration stops once
+// the descriptor budget is exhausted, so a large tree can't drive a
+// long-lived watcher into EMFILE (issue #464). With a budget of 10 and a
+// root holding 50 subdirectories, exactly 10 directories (root + 9) get
+// watched and the budget is flagged truncated.
+func TestAddDirsRecursiveRespectsBudget(t *testing.T) {
+	dir := t.TempDir()
+	for i := range 50 {
+		if err := os.Mkdir(filepath.Join(dir, fmt.Sprintf("d%02d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+
+	budget := &watchBudget{remaining: 10}
+	if err := addDirsRecursive(w, dir, nil, false, budget); err != nil {
+		t.Fatalf("addDirsRecursive: %v", err)
+	}
+	if !budget.truncated {
+		t.Errorf("expected budget.truncated=true after exceeding watch budget")
+	}
+	if got := len(w.WatchList()); got != 10 {
+		t.Errorf("expected exactly 10 watched dirs under a budget of 10, got %d", got)
+	}
 }
 
 // TestWatchLoopDebounceCoalesces verifies the shared event loop collapses


### PR DESCRIPTION
Fixes #464.

## Problem

The MCP server's `--warm` flag auto-enables the `watch-index` background watcher, which recursively registers the entire tree with fsnotify. On macOS/BSD the kqueue backend opens **one descriptor per watched directory AND per file**. An idle server on a ~4,036-file / 1,386-dir repo held **~5,400 open FDs** — most of the per-process ceiling (`kern.maxfilesperproc`, commonly 10,240). A larger checkout, a second MCP server (sharing the ~30,720 system-wide ceiling), a concurrent heavy walk during warming, or an FS-event storm (git checkout / sbt build re-parsing every cached file) then tips the process into `EMFILE` — it can't open files and appears frozen.

## Changes

- **Skip `.git`** in `addDirsRecursive` — large, churny, never search-relevant, and not caught by the existing gitignore / build-artefact excludes.
- **Descriptor budget** (`MaxWatchFDs`, default 4096): registration accounts for the per-file kqueue cost on macOS/BSD (`fileWatchCostsFD()`) vs dir-only inotify cost on Linux. When the budget is exhausted the walk stops, latches `truncated`, and the watcher falls back to lazy `(size, mtime)` revalidation for the remainder — emitting a one-time stderr warning. Correctness is unaffected (the watcher is a warmth optimisation, not a correctness mechanism); only cache-warmth latency under churn changes.

## Verification

On the repro repo (`mcp --warm`, idle after warm), with the patched binary:

```
open FDs:        4160   (was 5400, now bounded)
FDs into .git:   0      (was 59)
stderr:          watch: tree exceeds the 4096-descriptor watch budget; ...
warm: 4005 files in 533ms     ← server fully functional
```

## Tests

- `TestWatchSkipsGitDir` — a cached file under `.git` is never refreshed (proves `.git` isn't watched).
- `TestAddDirsRecursiveRespectsBudget` — exactly 10 dirs watched under a budget of 10, `truncated` set.

Full `internal/search` suite passes (incl. `-race`); `go vet` and `go fix -diff` clean.

## Workaround (no upgrade needed)

Add `--no-watch-index` to the MCP server args — drops the idle server to ~13 FDs with no loss of correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)