### PR TITLE
feat(coupling): detect C# solutions nested under a subdirectory (#467)

### DIFF
--- a/internal/search/coupling.go
+++ b/internal/search/coupling.go
@@ -130,10 +130,33 @@ func hasAnyFile(dir string, names ...string) bool {
 // single canonical root manifest (unlike go.mod / Cargo.toml / pom.xml), so
 // the .sln / .csproj globs are the strongest signal.
 func isCSharpRoot(dir string) bool {
+	if csharpMarkersIn(dir) {
+		return true
+	}
+	// C# solutions commonly live one level down (e.g. a Src/ directory holds
+	// the .sln/.csproj while the repo root has none). Check the immediate
+	// subdirectories — bounded by a single os.ReadDir, no deep walk. Node
+	// resolution is namespace-based (root-independent), so detecting here and
+	// walking from `dir` still produces the right graph.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() && !skipCargoDir(e.Name()) && csharpMarkersIn(filepath.Join(dir, e.Name())) {
+			return true
+		}
+	}
+	return false
+}
+
+// csharpMarkersIn reports whether dir directly contains a C# / .NET project
+// marker: a solution (.sln / .slnx, the modern VS 17.10+ XML format) or
+// project (.csproj) file, or an SDK-style root file.
+func csharpMarkersIn(dir string) bool {
 	if hasAnyFile(dir, "Directory.Build.props", "Directory.Packages.props", "global.json") {
 		return true
 	}
-	// .slnx is the modern XML solution format (VS 17.10+).
 	return hasGlobMatch(dir, "*.sln") || hasGlobMatch(dir, "*.slnx") || hasGlobMatch(dir, "*.csproj")
 }
 

--- a/internal/search/coupling.go
+++ b/internal/search/coupling.go
@@ -128,22 +128,33 @@ func hasAnyFile(dir string, names ...string) bool {
 // isCSharpRoot reports whether dir looks like a C# / .NET project root: a
 // solution or project file, or a modern SDK-style root marker. C# has no
 // single canonical root manifest (unlike go.mod / Cargo.toml / pom.xml), so
-// the .sln / .csproj globs are the strongest signal.
+// the .sln / .csproj files are the strongest signal. Solutions commonly live
+// one level down (e.g. a Src/ directory holds the .sln/.csproj while the repo
+// root has none), so the root's immediate subdirectories are checked too —
+// node resolution is namespace-based (root-independent), so walking from dir
+// still yields the right graph either way.
+//
+// dir is read once here (for both its own markers and its subdir list), then
+// each candidate subdir is read once — no per-marker globbing.
 func isCSharpRoot(dir string) bool {
-	if csharpMarkersIn(dir) {
-		return true
-	}
-	// C# solutions commonly live one level down (e.g. a Src/ directory holds
-	// the .sln/.csproj while the repo root has none). Check the immediate
-	// subdirectories — bounded by a single os.ReadDir, no deep walk. Node
-	// resolution is namespace-based (root-independent), so detecting here and
-	// walking from `dir` still produces the right graph.
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return false
 	}
+	var subdirs []string
 	for _, e := range entries {
-		if e.IsDir() && !skipCargoDir(e.Name()) && csharpMarkersIn(filepath.Join(dir, e.Name())) {
+		if e.IsDir() {
+			if !skipCargoDir(e.Name()) {
+				subdirs = append(subdirs, e.Name())
+			}
+			continue
+		}
+		if isCSharpMarkerFile(e.Name()) {
+			return true
+		}
+	}
+	for _, sd := range subdirs {
+		if csharpMarkersIn(filepath.Join(dir, sd)) {
 			return true
 		}
 	}
@@ -151,31 +162,32 @@ func isCSharpRoot(dir string) bool {
 }
 
 // csharpMarkersIn reports whether dir directly contains a C# / .NET project
-// marker: a solution (.sln / .slnx, the modern VS 17.10+ XML format) or
-// project (.csproj) file, or an SDK-style root file.
+// marker, in a single directory read.
 func csharpMarkersIn(dir string) bool {
-	if hasAnyFile(dir, "Directory.Build.props", "Directory.Packages.props", "global.json") {
-		return true
-	}
-	return hasGlobMatch(dir, "*.sln") || hasGlobMatch(dir, "*.slnx") || hasGlobMatch(dir, "*.csproj")
-}
-
-// hasGlobMatch reports whether any regular file directly in dir has a
-// basename matching pattern. It matches against entry names (not the joined
-// path) so glob metacharacters in dir itself — e.g. a "weird[1]" path
-// component — can't corrupt the match.
-func hasGlobMatch(dir, pattern string) bool {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return false
 	}
 	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		if ok, _ := filepath.Match(pattern, e.Name()); ok {
+		if !e.IsDir() && isCSharpMarkerFile(e.Name()) {
 			return true
 		}
+	}
+	return false
+}
+
+// isCSharpMarkerFile reports whether a filename is a C# / .NET project marker:
+// an SDK-style root file or a solution (.sln / .slnx, the VS 17.10+ XML
+// format) / project (.csproj) file. Matching on the name (not a joined path)
+// is immune to glob metacharacters in the directory path itself.
+func isCSharpMarkerFile(name string) bool {
+	switch name {
+	case "Directory.Build.props", "Directory.Packages.props", "global.json":
+		return true
+	}
+	switch filepath.Ext(name) {
+	case ".sln", ".slnx", ".csproj":
+		return true
 	}
 	return false
 }

--- a/internal/search/coupling_test.go
+++ b/internal/search/coupling_test.go
@@ -535,6 +535,45 @@ func TestCoupling_JSDirectoryImport(t *testing.T) {
 	}
 }
 
+// TestCoupling_CSharpNestedSolution verifies C# detection when the solution /
+// project markers live one level down (e.g. under Src/) and the repo root has
+// none — the real-world Newtonsoft.Json layout that #467 found unhandled.
+func TestCoupling_CSharpNestedSolution(t *testing.T) {
+	root := t.TempDir() // repo root: no C# marker here
+	srcDir := filepath.Join(root, "Src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mk := func(ns, src string) {
+		d := filepath.Join(srcDir, ns)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		mustWriteFile(t, filepath.Join(d, "C.cs"), src)
+	}
+	// Markers live under Src/, not the repo root.
+	mustWriteFile(t, filepath.Join(srcDir, "global.json"), "{}\n")
+	mustWriteFile(t, filepath.Join(srcDir, "App.slnx"), "<Solution />\n")
+	mk("App", "using MyApp.Util;\nnamespace MyApp.App;\npublic class App {}\n")
+	mk("Util", "namespace MyApp.Util;\npublic class Helper {}\n")
+
+	// Pointed at the REPO ROOT (not Src/) — detection must still find C#.
+	res, err := search.Coupling(context.Background(), search.Options{Root: root, Workers: 1}, 0, contentpkg.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("Coupling: %v", err)
+	}
+	if len(res.Packages) == 0 {
+		t.Fatal("C# adapter not selected for a Src/-nested solution; report is empty")
+	}
+	got := map[string]search.PackageCoupling{}
+	for _, p := range res.Packages {
+		got[p.Package] = p
+	}
+	if u, ok := got["MyApp.Util"]; !ok || u.Afferent != 1 {
+		t.Errorf("MyApp.Util Ca = %d (present=%v), want 1 (imported by MyApp.App)", u.Afferent, ok)
+	}
+}
+
 func TestCoupling_NoGoMod(t *testing.T) {
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, "x.go"), "package p\n\nfunc F() {}\n")


### PR DESCRIPTION
## Summary

Second fix from the `~/Code/OpenSource/` testing (logged on #467). `coupling -d Newtonsoft.Json` fell through to the Go adapter ("no go.mod") because the repo **root** has no manifest — the `.slnx` / `.csproj` / `Directory.Build.props` / `global.json` all live under `Src/`.

`isCSharpRoot` now also checks the root's **immediate subdirectories** (a single bounded `os.ReadDir`, no deep walk) for the C# markers, so a `Src/`-nested solution is detected when you point `-d` at the repo root. C# nodes are declared namespaces (root-independent), so walking from the repo root still yields the correct graph.

**Before:** `coupling -d Newtonsoft.Json` → "no go.mod found".
**After:** a full namespace graph from the repo root:
```
CA  CE  INSTABILITY  PACKAGE
21  2   0.09  Newtonsoft.Json.Utilities
15  2   0.12  Newtonsoft.Json.Linq
 9  4   0.31  Newtonsoft.Json.Serialization
```

## Details
- Factored marker detection into `csharpMarkersIn(dir)`; `isCSharpRoot` checks the root, then each immediate subdir (skipping `target`/`.git`/`node_modules`/`vendor`/hidden via the existing `skipCargoDir`).
- One level deep only — bounded and predictable; matches the common `Src/` convention without a recursive search.

## Tests
- `TestCoupling_CSharpNestedSolution` — markers + `.cs` files under `Src/`, `coupling` run from the **repo root**, asserts the C# adapter activates and the namespace edge is recorded.
- Existing C# tests (`TestCoupling_CSharpNamespaces`, `TestCoupling_CSharpRootGlobMetachars`) unchanged.
- Verified via the binary: Newtonsoft.Json now graphs from its repo root.

## Out of scope (still tracked in #467)
- Rust module-level; C/C++ file-level; tsconfig path aliases; the single-parse consolidation follow-up.

## Test plan
- `go build ./... && go vet ./...` ✅
- `go test -count=1 ./internal/search/ ./internal/content/ ./internal/mcpserver/ ./cmd/file-search-on/` ✅
- `go fix ./... && git diff --exit-code` ✅

Refs #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)