### PR TITLE
feat(output): SARIF 2.1.0 output for analysis commands (#483)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ file-search-on '...' -o json        # NDJSON, one match per line
 file-search-on '...' --format '{{.Path}} ({{.WordCount}} words)'
 ```
 
+The code-analysis commands **`complexity`**, **`dead-code`**, and **`find-matches`** also accept **`-o sarif`** — a [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) document that [GitHub Code Scanning](https://docs.github.com/en/code-security/code-scanning) (and other CI) ingest, so findings show up as inline PR/code alerts:
+
+```sh
+file-search-on complexity 'is_source && language=="go"' -d . -o sarif > complexity.sarif
+file-search-on dead-code -d . -o sarif > dead-code.sarif
+file-search-on find-matches 'TODO|FIXME|HACK' -d . -o sarif > todos.sarif
+```
+
 ### Content search
 
 CEL's standard string methods (`contains`, `startsWith`, `endsWith`, `matches`) work on every string attribute. Pass `--body` to populate the `body` variable from text-based files (markdown, source, csv, json, xml, html, plus `is_text`) and filter on full file content:

--- a/cmd/file-search-on/codegraph_cmd.go
+++ b/cmd/file-search-on/codegraph_cmd.go
@@ -364,7 +364,9 @@ func (c *DeadCodeCmd) Run(ctx context.Context) error {
 				URI:     d.Path,
 			})
 		}
-		_ = writeSARIF(sarif.Rule{ID: "dead-code", Name: "DeadCode", Description: "Candidate unreferenced definitions (functions / types nothing calls)."}, results)
+		if werr := writeSARIF(sarif.Rule{ID: "dead-code", Name: "DeadCode", Description: "Candidate unreferenced definitions (functions / types nothing calls)."}, results); werr != nil {
+			return werr
+		}
 	default:
 		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 		for _, d := range candidates {
@@ -564,7 +566,9 @@ func (c *ComplexityCmd) Run(ctx context.Context) error {
 					EndLine:   f.EndLine,
 				})
 			}
-			_ = writeSARIF(sarif.Rule{ID: "complexity", Name: "CyclomaticComplexity", Description: "Functions ranked by cyclomatic complexity (maintenance hotspots)."}, results)
+			if werr := writeSARIF(sarif.Rule{ID: "complexity", Name: "CyclomaticComplexity", Description: "Functions ranked by cyclomatic complexity (maintenance hotspots)."}, results); werr != nil {
+				return werr
+			}
 		default:
 			tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 			_, _ = fmt.Fprintln(tw, "COMPLEXITY\tLINES\tFUNCTION\tLOCATION")

--- a/cmd/file-search-on/codegraph_cmd.go
+++ b/cmd/file-search-on/codegraph_cmd.go
@@ -12,6 +12,7 @@ import (
 
 	contentpkg "github.com/richardwooding/file-search-on/internal/content"
 	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/sarif"
 	"github.com/richardwooding/file-search-on/internal/search"
 )
 
@@ -268,7 +269,7 @@ func (c *WhoCallsCmd) Run(ctx context.Context) error {
 type DeadCodeCmd struct {
 	Expr string `arg:"" optional:"" help:"CEL pre-filter for which files enter the graph. Defaults to is_source."`
 	codeGraphWalkFlags
-	Output         string `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table | json."`
+	Output         string `short:"o" name:"output" enum:"table,json,sarif" default:"table" help:"Output format: table | json | sarif (SARIF 2.1.0 for GitHub Code Scanning)."`
 	Resolve        bool   `name:"resolve" help:"Type-resolve Go via go/packages for precise dead-code (distinguishes same-named methods, counts cross-package usage) instead of name-based matching. Requires the 'go' toolchain and a buildable module — falls back to name-based otherwise. Dev-environment only; the first -d root is resolved. Issue #447."`
 	IgnoreExported bool   `name:"ignore-exported" help:"Drop exported/public symbols (funcs, methods, types) from the candidates — exported API used only by external callers is the dominant dead-code false positive. Visibility is known for name-convention (Go / Python) and keyword (Rust / TS / JS / Java / C# / Kotlin / Scala) languages; symbols in languages without a visibility signal are kept."`
 }
@@ -344,11 +345,27 @@ func (c *DeadCodeCmd) Run(ctx context.Context) error {
 		dcPaths[i] = d.Path
 	}
 	hint := g.GeneratedHint(dcPaths)
-	if c.Output == "json" {
+	switch c.Output {
+	case "json":
 		_ = writeJSON(os.Stdout, map[string]any{
 			"candidates": candidates, "count": len(candidates), "total_files": g.TotalFiles, "hint": hint, "resolved": resolved,
 		})
-	} else {
+	case "sarif":
+		results := make([]sarif.Result, 0, len(candidates))
+		for _, d := range candidates {
+			name := d.Symbol
+			if d.Owner != "" {
+				name = d.Owner + "." + d.Symbol
+			}
+			results = append(results, sarif.Result{
+				RuleID:  "dead-code",
+				Level:   "note",
+				Message: fmt.Sprintf("unreferenced %s %q (heuristic — review before deleting)", d.Kind, name),
+				URI:     d.Path,
+			})
+		}
+		_ = writeSARIF(sarif.Rule{ID: "dead-code", Name: "DeadCode", Description: "Candidate unreferenced definitions (functions / types nothing calls)."}, results)
+	default:
 		tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 		for _, d := range candidates {
 			name := d.Symbol
@@ -502,7 +519,7 @@ type ComplexityCmd struct {
 	Expr string `arg:"" optional:"" help:"CEL pre-filter for which files enter the report. Defaults to is_source."`
 	codeGraphWalkFlags
 	Top    int    `name:"top" default:"50" help:"Cap on functions returned (worst-first)."`
-	Output string `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table | json."`
+	Output string `short:"o" name:"output" enum:"table,json,sarif" default:"table" help:"Output format: table | json | sarif (SARIF 2.1.0 for GitHub Code Scanning)."`
 }
 
 func (c *ComplexityCmd) Run(ctx context.Context) error {
@@ -532,9 +549,23 @@ func (c *ComplexityCmd) Run(ctx context.Context) error {
 		return fmt.Errorf("complexity failed: %w", rerr)
 	}
 	if rep != nil {
-		if c.Output == "json" {
+		switch c.Output {
+		case "json":
 			_ = writeJSON(os.Stdout, rep)
-		} else {
+		case "sarif":
+			results := make([]sarif.Result, 0, len(rep.Functions))
+			for _, f := range rep.Functions {
+				results = append(results, sarif.Result{
+					RuleID:    "complexity",
+					Level:     "warning",
+					Message:   fmt.Sprintf("%s has cyclomatic complexity %d (%d lines)", f.Function, f.Complexity, f.Lines),
+					URI:       f.Path,
+					StartLine: f.StartLine,
+					EndLine:   f.EndLine,
+				})
+			}
+			_ = writeSARIF(sarif.Rule{ID: "complexity", Name: "CyclomaticComplexity", Description: "Functions ranked by cyclomatic complexity (maintenance hotspots)."}, results)
+		default:
 			tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 			_, _ = fmt.Fprintln(tw, "COMPLEXITY\tLINES\tFUNCTION\tLOCATION")
 			for _, f := range rep.Functions {

--- a/cmd/file-search-on/find_matches_cmd.go
+++ b/cmd/file-search-on/find_matches_cmd.go
@@ -99,7 +99,9 @@ func (f *FindMatchesCmd) Run(ctx context.Context) error {
 					StartLine: m.Line,
 				})
 			}
-			_ = writeSARIF(sarif.Rule{ID: "find-matches", Name: "PatternMatch", Description: "Lines matching the search pattern: " + f.Pattern}, results)
+			if werr := writeSARIF(sarif.Rule{ID: "find-matches", Name: "PatternMatch", Description: "Lines matching the search pattern: " + f.Pattern}, results); werr != nil {
+				return werr
+			}
 		default:
 			printFindMatches(os.Stdout, res)
 		}

--- a/cmd/file-search-on/find_matches_cmd.go
+++ b/cmd/file-search-on/find_matches_cmd.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	contentpkg "github.com/richardwooding/file-search-on/internal/content"
 	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/sarif"
 	"github.com/richardwooding/file-search-on/internal/search"
 )
 
@@ -31,7 +33,7 @@ type FindMatchesCmd struct {
 	IndexPath           string        `name:"index-path" help:"Persistent attribute index file (bbolt). Overrides the default per-cwd index at <UserCacheDir>/file-search-on/indexes/. Speeds up the walk-stage content-type detection on unchanged files."`
 	NoIndex             bool          `name:"no-index" help:"Disable the on-disk index entirely; use only in-memory caching for the process lifetime."`
 	Timeout             time.Duration `name:"timeout" help:"Maximum duration (Go duration: 30s, 2m). On expiry, partial results are still printed and the process exits 124."`
-	Output              string        `short:"o" name:"output" enum:"default,json" default:"default" help:"Output format: default (grep-style: path:line:text) | json."`
+	Output              string        `short:"o" name:"output" enum:"default,json,sarif" default:"default" help:"Output format: default (grep-style: path:line:text) | json | sarif (SARIF 2.1.0 for GitHub Code Scanning)."`
 }
 
 func (f *FindMatchesCmd) Run(ctx context.Context) error {
@@ -81,11 +83,24 @@ func (f *FindMatchesCmd) Run(ctx context.Context) error {
 	// Print whatever was collected even on cancellation — FindMatches
 	// returns the partial set with Cancelled=true rather than nil.
 	if res != nil {
-		if f.Output == "json" {
+		switch f.Output {
+		case "json":
 			if jerr := printFindMatchesJSON(os.Stdout, res); jerr != nil {
 				return jerr
 			}
-		} else {
+		case "sarif":
+			results := make([]sarif.Result, 0, len(res.Matches))
+			for _, m := range res.Matches {
+				results = append(results, sarif.Result{
+					RuleID:    "find-matches",
+					Level:     "note",
+					Message:   truncateForMessage(strings.TrimSpace(m.Text)),
+					URI:       m.Path,
+					StartLine: m.Line,
+				})
+			}
+			_ = writeSARIF(sarif.Rule{ID: "find-matches", Name: "PatternMatch", Description: "Lines matching the search pattern: " + f.Pattern}, results)
+		default:
 			printFindMatches(os.Stdout, res)
 		}
 	}

--- a/cmd/file-search-on/sarif_out.go
+++ b/cmd/file-search-on/sarif_out.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+
+	"github.com/richardwooding/file-search-on/internal/sarif"
+)
+
+// writeSARIF emits a SARIF 2.1.0 document for one analysis rule + its results
+// to stdout, stamped with the binary version. The analysis commands build
+// their []sarif.Result and call this for the `--output sarif` format (#483).
+func writeSARIF(rule sarif.Rule, results []sarif.Result) error {
+	return sarif.Write(os.Stdout, version, []sarif.Rule{rule}, results)
+}
+
+// truncateForMessage caps a one-line SARIF message so a long matched line
+// doesn't bloat the result. Rune-safe.
+func truncateForMessage(s string) string {
+	const max = 200
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
+}

--- a/cmd/file-search-on/sarif_out_test.go
+++ b/cmd/file-search-on/sarif_out_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestComplexitySARIF runs the complexity command with --output sarif over a
+// fixture containing a deliberately-branchy function and asserts the output is
+// a valid SARIF 2.1.0 document with a located result. Covers the CLI wiring
+// end-to-end (the sarif package itself is unit-tested separately).
+func TestComplexitySARIF(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "go.mod"), "module example.com/m\n\ngo 1.26\n")
+	mustWriteFile(t, filepath.Join(tmp, "branchy.go"), "package m\n\n"+
+		"func Branchy(x int) int {\n"+
+		"\tif x > 0 { x++ } else { x-- }\n"+
+		"\tfor i := 0; i < x; i++ { if i%2 == 0 { x += i } }\n"+
+		"\tswitch x { case 1: return 1; case 2: return 2; default: return x }\n"+
+		"}\n")
+
+	cmd := &ComplexityCmd{Top: 50, Output: "sarif"}
+	cmd.Dir = []string{tmp}
+	cmd.NoIndex = true
+
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	var doc struct {
+		Version string `json:"version"`
+		Runs    []struct {
+			Tool struct {
+				Driver struct {
+					Name  string `json:"name"`
+					Rules []struct {
+						ID string `json:"id"`
+					} `json:"rules"`
+				} `json:"driver"`
+			} `json:"tool"`
+			Results []struct {
+				RuleID    string `json:"ruleId"`
+				Locations []struct {
+					PhysicalLocation struct {
+						ArtifactLocation struct {
+							URI string `json:"uri"`
+						} `json:"artifactLocation"`
+						Region struct {
+							StartLine int `json:"startLine"`
+						} `json:"region"`
+					} `json:"physicalLocation"`
+				} `json:"locations"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if derr := json.NewDecoder(strings.NewReader(out)).Decode(&doc); derr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", derr, out)
+	}
+	if doc.Version != "2.1.0" {
+		t.Errorf("version = %q, want 2.1.0", doc.Version)
+	}
+	if len(doc.Runs) != 1 || doc.Runs[0].Tool.Driver.Name != "file-search-on" {
+		t.Fatalf("unexpected runs/driver: %+v", doc.Runs)
+	}
+	results := doc.Runs[0].Results
+	if len(results) == 0 {
+		t.Fatal("expected at least one complexity result for Branchy")
+	}
+	r0 := results[0]
+	if r0.RuleID != "complexity" {
+		t.Errorf("ruleId = %q, want complexity", r0.RuleID)
+	}
+	loc := r0.Locations[0].PhysicalLocation
+	if !strings.HasSuffix(loc.ArtifactLocation.URI, "branchy.go") {
+		t.Errorf("uri = %q, want .../branchy.go", loc.ArtifactLocation.URI)
+	}
+	if loc.Region.StartLine <= 0 {
+		t.Errorf("startLine = %d, want > 0", loc.Region.StartLine)
+	}
+}

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -1,0 +1,145 @@
+// Package sarif renders analysis findings as a SARIF 2.1.0 document — the
+// Static Analysis Results Interchange Format that GitHub Code Scanning,
+// GitLab, and other CI systems ingest. Each file-search-on analysis command
+// (complexity, dead-code, find-matches, …) maps its findings to []Result and
+// calls Write; the rule table and document scaffolding are built here. Issue
+// #483.
+package sarif
+
+import (
+	"encoding/json"
+	"io"
+)
+
+const (
+	schemaURL = "https://json.schemastore.org/sarif-2.1.0.json"
+	// infoURI is the tool's information URI in the SARIF driver.
+	infoURI = "https://github.com/richardwooding/file-search-on"
+	// toolName is the SARIF driver name surfaced in Code Scanning.
+	toolName = "file-search-on"
+)
+
+// Result is one finding: a rule id, severity level, human message, and
+// location. A StartLine <= 0 omits the line region, producing a file-level
+// result (e.g. dead-code / unused-exports, which have no single line).
+type Result struct {
+	RuleID    string
+	Level     string // "error" | "warning" | "note"; defaults to "warning" when empty
+	Message   string
+	URI       string // file path, relative to the repo root
+	StartLine int
+	EndLine   int
+}
+
+// Rule describes one rule id for the SARIF tool.driver.rules table. Each
+// distinct RuleID emitted in results should have a matching Rule.
+type Rule struct {
+	ID          string
+	Name        string
+	Description string
+}
+
+// Write encodes results as a SARIF 2.1.0 document to w (pretty-printed).
+// rules supplies the rule metadata; version stamps the tool driver. Passing
+// an empty results slice still emits a valid (empty-results) run.
+func Write(w io.Writer, version string, rules []Rule, results []Result) error {
+	d := document{Schema: schemaURL, Version: "2.1.0"}
+	r := run{}
+	r.Tool.Driver = driver{
+		Name:           toolName,
+		Version:        version,
+		InformationURI: infoURI,
+		Rules:          make([]jsonRule, 0, len(rules)),
+	}
+	for _, rule := range rules {
+		jr := jsonRule{ID: rule.ID, Name: rule.Name}
+		if rule.Description != "" {
+			jr.ShortDescription = &text{Text: rule.Description}
+		}
+		r.Tool.Driver.Rules = append(r.Tool.Driver.Rules, jr)
+	}
+	r.Results = make([]jsonResult, 0, len(results))
+	for _, res := range results {
+		level := res.Level
+		if level == "" {
+			level = "warning"
+		}
+		loc := location{}
+		loc.PhysicalLocation.ArtifactLocation.URI = res.URI
+		if res.StartLine > 0 {
+			reg := &region{StartLine: res.StartLine}
+			if res.EndLine >= res.StartLine {
+				reg.EndLine = res.EndLine
+			}
+			loc.PhysicalLocation.Region = reg
+		}
+		r.Results = append(r.Results, jsonResult{
+			RuleID:    res.RuleID,
+			Level:     level,
+			Message:   text{Text: res.Message},
+			Locations: []location{loc},
+		})
+	}
+	d.Runs = []run{r}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(d)
+}
+
+type document struct {
+	Schema  string `json:"$schema"`
+	Version string `json:"version"`
+	Runs    []run  `json:"runs"`
+}
+
+type run struct {
+	Tool    tool         `json:"tool"`
+	Results []jsonResult `json:"results"`
+}
+
+type tool struct {
+	Driver driver `json:"driver"`
+}
+
+type driver struct {
+	Name           string     `json:"name"`
+	Version        string     `json:"version,omitempty"`
+	InformationURI string     `json:"informationUri"`
+	Rules          []jsonRule `json:"rules"`
+}
+
+type jsonRule struct {
+	ID               string `json:"id"`
+	Name             string `json:"name,omitempty"`
+	ShortDescription *text  `json:"shortDescription,omitempty"`
+}
+
+type jsonResult struct {
+	RuleID    string     `json:"ruleId"`
+	Level     string     `json:"level"`
+	Message   text       `json:"message"`
+	Locations []location `json:"locations"`
+}
+
+type location struct {
+	PhysicalLocation physicalLocation `json:"physicalLocation"`
+}
+
+type physicalLocation struct {
+	ArtifactLocation artifactLocation `json:"artifactLocation"`
+	Region           *region          `json:"region,omitempty"`
+}
+
+type artifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type region struct {
+	StartLine int `json:"startLine"`
+	EndLine   int `json:"endLine,omitempty"`
+}
+
+type text struct {
+	Text string `json:"text"`
+}

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -9,6 +9,7 @@ package sarif
 import (
 	"encoding/json"
 	"io"
+	"path/filepath"
 )
 
 const (
@@ -65,7 +66,8 @@ func Write(w io.Writer, version string, rules []Rule, results []Result) error {
 			level = "warning"
 		}
 		loc := location{}
-		loc.PhysicalLocation.ArtifactLocation.URI = res.URI
+		// SARIF artifact URIs use forward slashes (RFC 3986), even on Windows.
+		loc.PhysicalLocation.ArtifactLocation.URI = filepath.ToSlash(res.URI)
 		if res.StartLine > 0 {
 			reg := &region{StartLine: res.StartLine}
 			if res.EndLine >= res.StartLine {

--- a/internal/sarif/sarif_test.go
+++ b/internal/sarif/sarif_test.go
@@ -1,0 +1,67 @@
+package sarif
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestWrite(t *testing.T) {
+	var buf bytes.Buffer
+	err := Write(&buf, "1.2.3",
+		[]Rule{{ID: "complexity", Name: "CyclomaticComplexity", Description: "Function complexity"}},
+		[]Result{
+			{RuleID: "complexity", Level: "warning", Message: "F is complex", URI: "a/b.go", StartLine: 10, EndLine: 20},
+			{RuleID: "complexity", Message: "G (file-level)", URI: "a/c.go"}, // no line → no region, default level
+		})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Valid JSON with the SARIF skeleton.
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if doc["version"] != "2.1.0" {
+		t.Errorf("version = %v, want 2.1.0", doc["version"])
+	}
+	if !strings.Contains(buf.String(), "json.schemastore.org/sarif-2.1.0.json") {
+		t.Error("missing $schema")
+	}
+
+	runs := doc["runs"].([]any)
+	r0 := runs[0].(map[string]any)
+	driver := r0["tool"].(map[string]any)["driver"].(map[string]any)
+	if driver["name"] != "file-search-on" || driver["version"] != "1.2.3" {
+		t.Errorf("driver = %v", driver)
+	}
+	results := r0["results"].([]any)
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+
+	// First result: has a region with the line range.
+	res0 := results[0].(map[string]any)
+	if res0["ruleId"] != "complexity" || res0["level"] != "warning" {
+		t.Errorf("result0 ruleId/level = %v / %v", res0["ruleId"], res0["level"])
+	}
+	loc0 := res0["locations"].([]any)[0].(map[string]any)["physicalLocation"].(map[string]any)
+	if loc0["artifactLocation"].(map[string]any)["uri"] != "a/b.go" {
+		t.Errorf("result0 uri = %v", loc0["artifactLocation"])
+	}
+	if loc0["region"].(map[string]any)["startLine"].(float64) != 10 {
+		t.Errorf("result0 startLine = %v", loc0["region"])
+	}
+
+	// Second result: no line → region omitted, level defaulted to warning.
+	res1 := results[1].(map[string]any)
+	if res1["level"] != "warning" {
+		t.Errorf("result1 level defaulted = %v, want warning", res1["level"])
+	}
+	loc1 := res1["locations"].([]any)[0].(map[string]any)["physicalLocation"].(map[string]any)
+	if _, hasRegion := loc1["region"]; hasRegion {
+		t.Errorf("result1 should have no region (no line): %v", loc1)
+	}
+}


### PR DESCRIPTION
## Summary

From the [fallow](https://github.com/fallow-rs/fallow) gap analysis (#483, P2). Adds a **`-o sarif`** output format emitting a **SARIF 2.1.0** document — the format **GitHub Code Scanning** (and GitLab / generic CI) ingest — so findings surface as inline PR / code-scanning alerts.

## How it works
- **New `internal/sarif` package:** a reusable `Result` / `Rule` model + `Write()` that builds the SARIF scaffolding (driver, rules table, results with `artifactLocation` + optional `region`). Findings without a line (file-level) omit the region; level defaults to `warning`.
- **Wired into the three flagship commands** — chosen to cover all three finding shapes:
  - **`complexity`** — metric with a line range → `region` startLine/endLine
  - **`dead-code`** — file-level symbol → artifact-only (no region)
  - **`find-matches`** — line-level text → `region` startLine
  Each gains `-o sarif` alongside its existing `table`/`json`.

```sh
file-search-on complexity 'is_source && language=="go"' -d . -o sarif > complexity.sarif
file-search-on find-matches 'TODO|FIXME|HACK' -d . -o sarif > todos.sarif
```

## Verified live (this repo)
- `complexity … -o sarif` → valid SARIF 2.1.0, rule `complexity`, results with line regions.
- `find-matches 'TODO|FIXME' -o sarif` → 89 results, rule `find-matches`, region startLine.
- `dead-code -o sarif` → file-level results (no region).

## Tests
- `internal/sarif/sarif_test.go`: document shape, region vs file-level, level defaulting.
- `cmd/.../sarif_out_test.go`: end-to-end — `complexity -o sarif` on a branchy fixture → valid SARIF with a located result.

## Scope
This PR wires the three flagship commands (a complete, useful Code-Scanning feature). **coverage-gaps / unused-exports / duplicate-functions** are a quick follow-up reusing the same `sarif.Write`. Keeping **#483 open** until those land. (`circular` is node-level — no single file location — so it's intentionally excluded.)

## Test plan
- `go build ./... && go vet ./...` ✅
- `go test -count=1 ./internal/sarif/ ./internal/search/ ./internal/mcpserver/ ./cmd/file-search-on/` ✅
- `go fix ./...` clean ✅

Refs #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)