### PR TITLE
feat(output): -o sarif for coverage-gaps, unused-exports, duplicate-functions (#483)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,15 @@ file-search-on '...' -o json        # NDJSON, one match per line
 file-search-on '...' --format '{{.Path}} ({{.WordCount}} words)'
 ```
 
-The code-analysis commands **`complexity`**, **`dead-code`**, and **`find-matches`** also accept **`-o sarif`** — a [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) document that [GitHub Code Scanning](https://docs.github.com/en/code-security/code-scanning) (and other CI) ingest, so findings show up as inline PR/code alerts:
+The code-analysis commands **`complexity`**, **`dead-code`**, **`find-matches`**, **`coverage-gaps`**, **`unused-exports`**, and **`duplicate-functions`** also accept **`-o sarif`** — a [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) document that [GitHub Code Scanning](https://docs.github.com/en/code-security/code-scanning) (and other CI) ingest, so findings show up as inline PR/code alerts:
 
 ```sh
 file-search-on complexity 'is_source && language=="go"' -d . -o sarif > complexity.sarif
 file-search-on dead-code -d . -o sarif > dead-code.sarif
 file-search-on find-matches 'TODO|FIXME|HACK' -d . -o sarif > todos.sarif
+file-search-on coverage-gaps cover.out -d . -o sarif > coverage-gaps.sarif
+file-search-on unused-exports -d . -o sarif > unused-exports.sarif
+file-search-on duplicate-functions -d . -o sarif > duplicate-functions.sarif
 ```
 
 ### Content search

--- a/cmd/file-search-on/coverage_gaps_cmd.go
+++ b/cmd/file-search-on/coverage_gaps_cmd.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	contentpkg "github.com/richardwooding/file-search-on/internal/content"
+	"github.com/richardwooding/file-search-on/internal/sarif"
 	"github.com/richardwooding/file-search-on/internal/search"
 )
 
@@ -14,7 +15,7 @@ type CoverageGapsCmd struct {
 	Profile   string  `arg:"" help:"Path to a Go coverage profile (go test -coverprofile=cover.out ./...)."`
 	Dir       string  `short:"d" name:"dir" default:"." help:"Module root holding go.mod; resolves the profile's import-path filenames to disk."`
 	Threshold float64 `name:"threshold" default:"0" help:"Coverage fraction 0..1; report functions strictly below it. 0 (default) = 1.0 — every function not fully covered. 0.8 = under 80%."`
-	Output    string  `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table | json."`
+	Output    string  `short:"o" name:"output" enum:"table,json,sarif" default:"table" help:"Output format: table | json | sarif (SARIF 2.1.0 for GitHub Code Scanning)."`
 }
 
 func (c *CoverageGapsCmd) Run(ctx context.Context) error {
@@ -22,8 +23,22 @@ func (c *CoverageGapsCmd) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("coverage-gaps failed: %w", err)
 	}
-	if c.Output == "json" {
+	switch c.Output {
+	case "json":
 		return writeJSON(os.Stdout, res)
+	case "sarif":
+		results := make([]sarif.Result, 0, len(res.Gaps))
+		for _, g := range res.Gaps {
+			results = append(results, sarif.Result{
+				RuleID:    "coverage-gap",
+				Level:     "warning",
+				Message:   fmt.Sprintf("%s is %.0f%% covered (%d/%d statements)", g.Function, g.CoveredPct*100, g.CoveredStatements, g.TotalStatements),
+				URI:       g.Path,
+				StartLine: g.StartLine,
+				EndLine:   g.EndLine,
+			})
+		}
+		return writeSARIF(sarif.Rule{ID: "coverage-gap", Name: "CoverageGap", Description: "Functions below the coverage threshold"}, results)
 	}
 	if len(res.Gaps) == 0 {
 		fmt.Printf("No coverage gaps below threshold %.2f (analysed %d file(s), mode %q).\n", res.Threshold, res.FilesAnalysed, res.ProfileMode)

--- a/cmd/file-search-on/duplicate_functions_cmd.go
+++ b/cmd/file-search-on/duplicate_functions_cmd.go
@@ -10,6 +10,7 @@ import (
 
 	contentpkg "github.com/richardwooding/file-search-on/internal/content"
 	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/sarif"
 	"github.com/richardwooding/file-search-on/internal/search"
 )
 
@@ -26,7 +27,7 @@ type DuplicateFunctionsCmd struct {
 	Exclude          []string      `name:"exclude" help:"Glob pattern matched against file/dir basenames; matches are skipped. Repeatable."`
 	RespectGitignore bool          `name:"respect-gitignore" help:"Parse a .gitignore at each walk root and skip matching paths."`
 	FollowSymlinks   bool          `name:"follow-symlinks" help:"Descend through symbolic links to directories. Off by default."`
-	Output           string        `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table (default) | json."`
+	Output           string        `short:"o" name:"output" enum:"table,json,sarif" default:"table" help:"Output format: table (default) | json | sarif (SARIF 2.1.0 for GitHub Code Scanning)."`
 }
 
 func (d *DuplicateFunctionsCmd) Run(ctx context.Context) error {
@@ -57,13 +58,31 @@ func (d *DuplicateFunctionsCmd) Run(ctx context.Context) error {
 	}, contentpkg.DefaultRegistry())
 
 	if dups != nil {
-		if d.Output == "json" {
+		switch d.Output {
+		case "json":
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
 			if err := enc.Encode(dups); err != nil {
 				return err
 			}
-		} else {
+		case "sarif":
+			var results []sarif.Result
+			for i, g := range dups.Groups {
+				for _, m := range g.Members {
+					results = append(results, sarif.Result{
+						RuleID:    "duplicate-function",
+						Level:     "note",
+						Message:   fmt.Sprintf("%s is a near-duplicate (group %d, %d members, ≈%s)", m.Symbol, i+1, g.Count, g.Fingerprint),
+						URI:       m.Path,
+						StartLine: m.StartLine,
+						EndLine:   m.EndLine,
+					})
+				}
+			}
+			if werr := writeSARIF(sarif.Rule{ID: "duplicate-function", Name: "DuplicateFunction", Description: "Functions clustered as near-duplicates by SimHash"}, results); werr != nil {
+				return werr
+			}
+		default:
 			printDuplicateFunctionsTable(dups)
 		}
 	}

--- a/cmd/file-search-on/sarif_out_test.go
+++ b/cmd/file-search-on/sarif_out_test.go
@@ -81,3 +81,156 @@ func TestComplexitySARIF(t *testing.T) {
 		t.Errorf("startLine = %d, want > 0", loc.Region.StartLine)
 	}
 }
+
+// sarifDoc is the minimal SARIF shape the CLI SARIF tests decode against.
+type sarifDoc struct {
+	Version string `json:"version"`
+	Runs    []struct {
+		Tool struct {
+			Driver struct {
+				Name  string `json:"name"`
+				Rules []struct {
+					ID string `json:"id"`
+				} `json:"rules"`
+			} `json:"driver"`
+		} `json:"tool"`
+		Results []struct {
+			RuleID    string `json:"ruleId"`
+			Level     string `json:"level"`
+			Locations []struct {
+				PhysicalLocation struct {
+					ArtifactLocation struct {
+						URI string `json:"uri"`
+					} `json:"artifactLocation"`
+					Region struct {
+						StartLine int `json:"startLine"`
+					} `json:"region"`
+				} `json:"physicalLocation"`
+			} `json:"locations"`
+		} `json:"results"`
+	} `json:"runs"`
+}
+
+func decodeSARIF(t *testing.T, out string) sarifDoc {
+	t.Helper()
+	var doc sarifDoc
+	if err := json.NewDecoder(strings.NewReader(out)).Decode(&doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if doc.Version != "2.1.0" {
+		t.Errorf("version = %q, want 2.1.0", doc.Version)
+	}
+	if len(doc.Runs) != 1 || doc.Runs[0].Tool.Driver.Name != "file-search-on" {
+		t.Fatalf("unexpected runs/driver: %+v", doc.Runs)
+	}
+	return doc
+}
+
+// TestCoverageGapsSARIF runs coverage-gaps -o sarif over a tiny module + profile
+// with a partially-covered function and asserts a located coverage-gap result
+// (with a line region).
+func TestCoverageGapsSARIF(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "go.mod"), "module example.com/m\n\ngo 1.26\n")
+	mustWriteFile(t, filepath.Join(tmp, "foo.go"), "package m\n\n"+
+		"func Foo(x int) int {\n"+
+		"\tif x > 0 {\n\t\treturn x\n\t}\n"+
+		"\treturn -x\n"+
+		"}\n")
+	profile := "mode: set\n" +
+		"example.com/m/foo.go:3.20,4.11 1 1\n" +
+		"example.com/m/foo.go:4.11,6.3 1 0\n"
+	mustWriteFile(t, filepath.Join(tmp, "cover.out"), profile)
+
+	cmd := &CoverageGapsCmd{Profile: filepath.Join(tmp, "cover.out"), Dir: tmp, Output: "sarif"}
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	doc := decodeSARIF(t, out)
+	results := doc.Runs[0].Results
+	if len(results) == 0 {
+		t.Fatal("expected at least one coverage-gap result")
+	}
+	r0 := results[0]
+	if r0.RuleID != "coverage-gap" {
+		t.Errorf("ruleId = %q, want coverage-gap", r0.RuleID)
+	}
+	loc := r0.Locations[0].PhysicalLocation
+	if !strings.HasSuffix(loc.ArtifactLocation.URI, "foo.go") {
+		t.Errorf("uri = %q, want .../foo.go", loc.ArtifactLocation.URI)
+	}
+	if loc.Region.StartLine <= 0 {
+		t.Errorf("startLine = %d, want > 0", loc.Region.StartLine)
+	}
+}
+
+// TestUnusedExportsSARIF runs unused-exports -o sarif over a module whose
+// exported symbol is referenced only intra-package and asserts a file-level
+// unused-export result (no line region).
+func TestUnusedExportsSARIF(t *testing.T) {
+	tmp := t.TempDir()
+	mustWriteFile(t, filepath.Join(tmp, "go.mod"), "module example.com/m\n\ngo 1.26\n")
+	mustWriteFile(t, filepath.Join(tmp, "lib.go"), "package m\n\n"+
+		"func Helper() int { return 42 }\n\n"+
+		"func use() int { return Helper() }\n")
+
+	cmd := &UnusedExportsCmd{Dir: tmp, Output: "sarif"}
+	cmd.NoIndex = true
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	doc := decodeSARIF(t, out)
+	results := doc.Runs[0].Results
+	if len(results) == 0 {
+		t.Fatal("expected at least one unused-export result for Helper")
+	}
+	r0 := results[0]
+	if r0.RuleID != "unused-export" {
+		t.Errorf("ruleId = %q, want unused-export", r0.RuleID)
+	}
+	if r0.Level != "note" {
+		t.Errorf("level = %q, want note", r0.Level)
+	}
+	loc := r0.Locations[0].PhysicalLocation
+	if !strings.HasSuffix(loc.ArtifactLocation.URI, "lib.go") {
+		t.Errorf("uri = %q, want .../lib.go", loc.ArtifactLocation.URI)
+	}
+	if loc.Region.StartLine != 0 {
+		t.Errorf("startLine = %d, want 0 (file-level, no region)", loc.Region.StartLine)
+	}
+}
+
+// TestDuplicateFunctionsSARIF runs duplicate-functions -o sarif over two
+// identical functions in different packages and asserts one located
+// duplicate-function result per cluster member.
+func TestDuplicateFunctionsSARIF(t *testing.T) {
+	tmp := t.TempDir()
+	dup := "func process(items []int) int {\n" +
+		"\ttotal := 0\n\tfor _, v := range items {\n\t\ttotal += v\n\t}\n" +
+		"\tif total > 100 {\n\t\ttotal = 100\n\t}\n\treturn total\n}\n"
+	mustWriteFile(t, filepath.Join(tmp, "a.go"), "package a\n\n"+dup)
+	mustWriteFile(t, filepath.Join(tmp, "b.go"), "package b\n\n"+dup)
+
+	cmd := &DuplicateFunctionsCmd{Output: "sarif"}
+	cmd.Dir = []string{tmp}
+	cmd.NoIndex = true
+	out, err := captureStdout(t, func() error { return cmd.Run(t.Context()) })
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	doc := decodeSARIF(t, out)
+	results := doc.Runs[0].Results
+	if len(results) < 2 {
+		t.Fatalf("expected >=2 duplicate-function results (one per member), got %d", len(results))
+	}
+	r0 := results[0]
+	if r0.RuleID != "duplicate-function" {
+		t.Errorf("ruleId = %q, want duplicate-function", r0.RuleID)
+	}
+	loc := r0.Locations[0].PhysicalLocation
+	if loc.Region.StartLine <= 0 {
+		t.Errorf("startLine = %d, want > 0", loc.Region.StartLine)
+	}
+}

--- a/cmd/file-search-on/unused_exports_cmd.go
+++ b/cmd/file-search-on/unused_exports_cmd.go
@@ -9,6 +9,7 @@ import (
 
 	contentpkg "github.com/richardwooding/file-search-on/internal/content"
 	"github.com/richardwooding/file-search-on/internal/index"
+	"github.com/richardwooding/file-search-on/internal/sarif"
 	"github.com/richardwooding/file-search-on/internal/search"
 )
 
@@ -27,7 +28,7 @@ type UnusedExportsCmd struct {
 	FollowSymlinks      bool          `name:"follow-symlinks" help:"Descend through symbolic links to directories."`
 	PruneBuildArtefacts bool          `name:"prune-build-artefacts" help:"Prune canonical build-artefact dirs (vendor / node_modules / target / …)."`
 
-	Output string `short:"o" name:"output" enum:"table,json" default:"table" help:"Output format: table | json."`
+	Output string `short:"o" name:"output" enum:"table,json,sarif" default:"table" help:"Output format: table | json | sarif (SARIF 2.1.0 for GitHub Code Scanning)."`
 }
 
 func (c *UnusedExportsCmd) Run(ctx context.Context) error {
@@ -56,9 +57,23 @@ func (c *UnusedExportsCmd) Run(ctx context.Context) error {
 	}, contentpkg.DefaultRegistry())
 
 	if res != nil {
-		if c.Output == "json" {
+		switch c.Output {
+		case "json":
 			_ = writeJSON(os.Stdout, res)
-		} else {
+		case "sarif":
+			results := make([]sarif.Result, 0, len(res.Candidates))
+			for _, cand := range res.Candidates {
+				results = append(results, sarif.Result{
+					RuleID:  "unused-export",
+					Level:   "note",
+					Message: fmt.Sprintf("exported %s %q is referenced only within package %s", cand.Kind, cand.Symbol, cand.Package),
+					URI:     cand.Path,
+				})
+			}
+			if werr := writeSARIF(sarif.Rule{ID: "unused-export", Name: "UnusedExport", Description: "Exported symbols referenced only intra-package (unexport candidates)"}, results); werr != nil {
+				return werr
+			}
+		default:
 			printUnusedExportsTable(os.Stdout, res)
 		}
 	}


### PR DESCRIPTION
Completes the SARIF 2.1.0 work started in #488 by wiring `-o sarif` into the three remaining analysis commands, all reusing `internal/sarif.Write`.

| Command | Rule | Level | Location |
|---|---|---|---|
| `coverage-gaps` | `coverage-gap` | warning | line region (start/end) |
| `unused-exports` | `unused-export` | note | file-level (no region) |
| `duplicate-functions` | `duplicate-function` | note | one result per cluster member, line range |

`circular` is intentionally excluded — a cycle is a node set with no single file location.

## Testing
- `go build ./...`, `go vet ./cmd/...`, `go fix ./...` byte-stable
- New CLI-level tests in `sarif_out_test.go` (one per command): assert valid SARIF 2.1.0, driver name, rule id, level, and region-present-vs-omitted
- Live smoke on this repo: `unused-exports -o sarif` → 189 file-level results, forward-slashed URIs

Closes #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)