### PR TITLE
chore(deps): bump odvcencio/gotreesitter v0.20.2 → v0.20.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/cel-go v0.28.1
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/modelcontextprotocol/go-sdk v1.6.1
-	github.com/odvcencio/gotreesitter v0.20.2
+	github.com/odvcencio/gotreesitter v0.20.5
 	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/richardwooding/bm25 v0.1.0
 	github.com/richardwooding/c2pa v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/odvcencio/gotreesitter v0.20.2 h1:oWxGgy0WzLJKeiZB8EFzXDDlHYG/hqiZmWrW+81uwy4=
-github.com/odvcencio/gotreesitter v0.20.2/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=
+github.com/odvcencio/gotreesitter v0.20.5 h1:V/F/Xv3fld61IVLnlRAgdZXrwuPQba6VPDWyXTOfooc=
+github.com/odvcencio/gotreesitter v0.20.5/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=


### PR DESCRIPTION
Upgrades the pure-Go tree-sitter runtime, pulling in the grammar-recovery fixes requested for this project (landed in v0.20.3):

- **Swift**: functions whose `if`/`while` condition contains a comparison operator no longer collapse into an `ERROR` tree (the condition is re-parsed with synthetic parens). Concretely — a function like `func f(x: Int) -> Int { if x > 0 { return x }; return 0 }` previously extracted **no** symbols/complexity; it now extracts cleanly. (Verified before/after.)
- **C#**: namespace bodies that fail to parse cleanly now surface their type declarations instead of collapsing to a single error node — better symbol/coupling extraction for malformed or edge-case C#.
- **Go**: iterative selector-chain normalization (was recursive), avoiding deep-stack issues.

## Impact
No code changes — the improvements flow through the existing tree-sitter extraction (`internal/content`), benefiting symbol extraction, complexity, coupling, and the rest for Swift/C#. Full test suite green; `go vet` clean.

Swift's `for-in`-over-range and `switch` still break body extraction, so **full Swift cognitive complexity remains blocked (#491)** — but more Swift functions now parse than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)