### PR TITLE
feat(profiling): integrate pprof — file-based flags + live dashboard endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,27 @@ Fingerprints cache via `--index-path` alongside the exact hash; repeat runs skip
 
 `-d <dir>` (repeatable for multi-root walks), `--exclude <glob>` (basename, repeatable), `--respect-gitignore`, `--timeout 30s` (partial results returned on expiry), `--workers N`, `--index-path <file.db>` (override the per-cwd default index — see [examples/indexing.md](./examples/indexing.md)), `--no-index` (opt out of on-disk caching for hermetic runs).
 
+### Profiling
+
+Root-level flags (work with any subcommand) capture a Go runtime profile of the run:
+
+`--cpuprofile <file>` (CPU profile, open with `go tool pprof <file>`), `--memprofile <file>` (heap profile written after the command finishes), `--trace <file>` (execution trace, open with `go tool trace <file>`). For example, profile a large walk:
+
+```sh
+file-search-on search 'is_source' -d ./big-tree --cpuprofile cpu.prof
+go tool pprof -top cpu.prof
+```
+
+For the long-running servers, `mcp` and `watch` accept `--pprof`, which mounts the live `/debug/pprof/*` endpoints on the [monitoring dashboard](#monitoring-dashboard) (loopback-only, off by default) so you can profile a running server without restarting it:
+
+```sh
+file-search-on mcp --pprof --monitor-addr :9090
+go tool pprof http://localhost:9090/debug/pprof/profile   # 30s live CPU profile
+curl -s http://localhost:9090/debug/pprof/heap            # heap snapshot
+```
+
+Release binaries are built with symbols stripped (`-s -w`), so CPU profiles carry less symbol detail there; heap and goroutine profiles are unaffected.
+
 **`.git` is always pruned** from every walk (CLI and MCP) — its objects/refs/logs are never searched or indexed. `search` and `find-matches` expose `--include-git` (CLI) / `include_git` (MCP) to walk into it; pointing `-d` directly at a `.git` directory also works (the walk root is exempt).
 
 ### Pointing at a non-default Ollama
@@ -646,6 +667,10 @@ Open the URL. Five panels:
 Each instance with a dashboard registers itself, so they're mutually discoverable. For `mcp` servers, the **`monitor_info`** tool is the entry point: it returns this server's dashboard URL + the peer list, and `monitor_info{enable:true}` **starts the dashboard on demand** (a dynamic port) even if the server was launched without a monitor flag. That makes monitoring reachable per-agent without editing every launch config.
 
 The JSON API is scriptable too: `curl -s localhost:<port>/api/cache | jq`, plus `/api/overview`, `/api/activity`, `/api/capabilities`, `/api/peers`, and `/healthz` (liveness). See [examples/monitoring.md](./examples/monitoring.md).
+
+### Live profiling
+
+Passing `--pprof` to `mcp` or `watch` mounts the Go runtime profiling endpoints (`/debug/pprof/*`) on this same dashboard, so you can profile a running server without restarting it — `go tool pprof http://localhost:<port>/debug/pprof/profile` for a live CPU profile, `/debug/pprof/heap` for the heap, `/debug/pprof/goroutine` for goroutine stacks. It's **off by default** (the endpoints expose process memory and goroutine stacks) and shares the dashboard's loopback-only trust boundary, so it's a no-op with `--no-monitor`. See the [Profiling](#profiling) section for the file-based `--cpuprofile` / `--memprofile` / `--trace` flags that work with any subcommand.
 
 ## Contributing
 

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
 	"syscall"
 
 	"github.com/alecthomas/kong"
@@ -51,6 +54,15 @@ var (
 var CLI struct {
 	ProjectTypeConfig string `name:"project-type-config" help:"Path to a YAML config registering custom project types (CEL-driven or file-based indicators). Loaded LAST, after any auto-discovered configs. Loaded before any subcommand runs; the new types appear alongside built-ins in detect-project / find-projects / search results."`
 	NoConfigSearch    bool   `name:"no-config-search" help:"Skip automatic discovery of project-type configs at the standard search paths (user-wide UserConfigDir()/file-search-on/project-types.yaml and per-project ./.file-search-on/project-types.yaml). Use for hermetic invocations (tests, CI) where only the explicit --project-type-config should apply."`
+
+	// Profiling — wrap whichever subcommand runs. CPU/trace profiling
+	// spans the command; the heap profile is written after it returns.
+	// Release binaries are built with -s -w (symbols stripped), so CPU
+	// profiles carry less detail there; heap/goroutine profiles are
+	// unaffected.
+	CPUProfile string `name:"cpuprofile" placeholder:"PATH" help:"Write a CPU profile of this run to PATH (open with: go tool pprof PATH). Wraps whichever subcommand runs." type:"path"`
+	MemProfile string `name:"memprofile" placeholder:"PATH" help:"Write a heap profile to PATH after the command finishes (runtime.GC() first for accurate live counts)." type:"path"`
+	TraceProf  string `name:"trace" placeholder:"PATH" help:"Write a runtime/trace execution trace to PATH (open with: go tool trace PATH)." type:"path"`
 
 	Search             SearchCmd             `cmd:"" help:"Search for files matching a CEL expression." default:"withargs"`
 	Preset             PresetCmd             `cmd:"" name:"preset" help:"Run a pre-canned search recipe by name (recent_changes, recent_photos, old_drafts, large_files, large_binaries, suspicious_files, failed_tests, system_metadata). Without args, lists every preset. Each preset bakes a vetted CEL filter + sensible sort / limit defaults; CLI flags override per-call."`
@@ -120,6 +132,68 @@ func openIndex(path string, noIndex bool, bodyCap index.BodyCacheCap) (index.Ind
 	return resolveIndexBackend("", path, noIndex, bodyCap)
 }
 
+// startProfiling honours the root --cpuprofile / --memprofile / --trace
+// flags. CPU and trace profiling begin immediately; the returned stop
+// closure stops them and writes the heap profile. The stop closure MUST
+// be called explicitly before any os.Exit (which skips deferred funcs),
+// or the CPU/trace files will be truncated and the heap profile never
+// written.
+func startProfiling() (stop func(), err error) {
+	var stops []func()
+	cleanup := func() {
+		// LIFO so each writer is stopped before its file is closed.
+		for i := len(stops) - 1; i >= 0; i-- {
+			stops[i]()
+		}
+	}
+
+	if CLI.CPUProfile != "" {
+		f, ferr := os.Create(CLI.CPUProfile)
+		if ferr != nil {
+			cleanup()
+			return nil, fmt.Errorf("create cpu profile: %w", ferr)
+		}
+		if serr := pprof.StartCPUProfile(f); serr != nil {
+			_ = f.Close()
+			cleanup()
+			return nil, fmt.Errorf("start cpu profile: %w", serr)
+		}
+		stops = append(stops, func() { pprof.StopCPUProfile(); _ = f.Close() })
+	}
+
+	if CLI.TraceProf != "" {
+		f, ferr := os.Create(CLI.TraceProf)
+		if ferr != nil {
+			cleanup()
+			return nil, fmt.Errorf("create trace: %w", ferr)
+		}
+		if serr := trace.Start(f); serr != nil {
+			_ = f.Close()
+			cleanup()
+			return nil, fmt.Errorf("start trace: %w", serr)
+		}
+		stops = append(stops, func() { trace.Stop(); _ = f.Close() })
+	}
+
+	if CLI.MemProfile != "" {
+		path := CLI.MemProfile
+		stops = append(stops, func() {
+			f, ferr := os.Create(path)
+			if ferr != nil {
+				fmt.Fprintln(os.Stderr, "memprofile:", ferr)
+				return
+			}
+			defer func() { _ = f.Close() }()
+			runtime.GC() // materialise up-to-date live-allocation stats
+			if werr := pprof.WriteHeapProfile(f); werr != nil {
+				fmt.Fprintln(os.Stderr, "memprofile:", werr)
+			}
+		})
+	}
+
+	return cleanup, nil
+}
+
 func main() {
 	// Bridge OS signals into a cancellable ctx so subcommands shut down
 	// cleanly: HTTP server gets graceful Shutdown, walker workers exit,
@@ -161,14 +235,26 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	if err := kctx.Run(); err != nil {
+	// Start profiling (if requested) so it wraps the subcommand. The stop
+	// closure is called explicitly after Run — NOT deferred — because the
+	// error paths below os.Exit, which would skip a defer.
+	stopProfiling, err := startProfiling()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
+	}
+
+	runErr := kctx.Run()
+	stopProfiling()
+
+	if runErr != nil {
 		var ece *exitCodeError
-		if errors.As(err, &ece) {
+		if errors.As(runErr, &ece) {
 			// The subcommand has already printed its own diagnostic
 			// to stderr; surface only the exit code.
 			os.Exit(ece.code)
 		}
-		fmt.Fprintln(os.Stderr, "Error:", err)
+		fmt.Fprintln(os.Stderr, "Error:", runErr)
 		os.Exit(1)
 	}
 }

--- a/cmd/file-search-on/main.go
+++ b/cmd/file-search-on/main.go
@@ -176,13 +176,16 @@ func startProfiling() (stop func(), err error) {
 	}
 
 	if CLI.MemProfile != "" {
-		path := CLI.MemProfile
+		// Create the file up front so a bad path / permission error
+		// surfaces immediately rather than after the (possibly long)
+		// command has already run. The heap snapshot itself is taken in
+		// the stop closure, when live allocations are most meaningful.
+		f, ferr := os.Create(CLI.MemProfile)
+		if ferr != nil {
+			cleanup()
+			return nil, fmt.Errorf("create mem profile: %w", ferr)
+		}
 		stops = append(stops, func() {
-			f, ferr := os.Create(path)
-			if ferr != nil {
-				fmt.Fprintln(os.Stderr, "memprofile:", ferr)
-				return
-			}
 			defer func() { _ = f.Close() }()
 			runtime.GC() // materialise up-to-date live-allocation stats
 			if werr := pprof.WriteHeapProfile(f); werr != nil {

--- a/cmd/file-search-on/mcp_cmd.go
+++ b/cmd/file-search-on/mcp_cmd.go
@@ -28,6 +28,7 @@ type MCPCmd struct {
 	Monitor           bool          `name:"monitor" help:"No-op — the monitoring dashboard is on by default since v0.65.0. Kept for back-compat with pre-existing scripts. Use --no-monitor to opt out, --monitor-addr to pin a fixed port."`
 	NoMonitor         bool          `name:"no-monitor" help:"Disable the read-only monitoring dashboard for this run. Useful for hermetic CI / sandboxed environments where binding a localhost port is undesirable. monitor_info{enable:true} can still lazy-start the dashboard mid-session."`
 	MonitorAddr       string        `name:"monitor-addr" help:"Bind the monitoring dashboard on this fixed port (e.g. ':9090') instead of an OS-assigned dynamic port. Binds 127.0.0.1 only. Overrides the default dynamic-port behaviour. Shows index cache stats, live tool-call activity, capabilities, and a peer switcher at http://localhost:<port>/."`
+	Pprof             bool          `name:"pprof" help:"Mount Go runtime profiling endpoints (/debug/pprof/*) on the monitoring dashboard for live CPU / heap / goroutine profiling (go tool pprof http://localhost:<port>/debug/pprof/profile). Loopback-only — same 127.0.0.1 trust boundary as the dashboard. Off by default. Requires the dashboard, so it is a no-op with --no-monitor."`
 	Warm              bool          `name:"warm" help:"At startup, walk the warm root in the background to pre-populate the on-disk attribute cache so the first MCP tool call lands on a hot index. Off by default — opt in when the cwd is a project you actually want indexed (starting from $HOME would scan the entire home directory). Heavy attributes (hashes, OCR, body, snippet, phash, xattrs) stay off; only the cheap detector + per-type Attributes() parse runs. Runs concurrently with the MCP server, so clients connect immediately."`
 	WarmDir           string        `name:"warm-dir" help:"Directory to warm. Defaults to the cwd at server start when --warm is set. Implies --warm when non-empty."`
 	WarmWorkers       int           `name:"warm-workers" help:"Worker count for the warmer. Defaults to max(1, NumCPU/4) — a quarter of the cores so the MCP server, the agent driving it, and the rest of the box keep their headroom. Pass 1 for minimum CPU; ignored when --warm is off."`
@@ -92,6 +93,9 @@ func (m *MCPCmd) Run(ctx context.Context) error {
 	if monAddr == "" && !m.NoMonitor {
 		monAddr = ":0" // dynamic, OS-assigned (default since v0.65.0)
 	}
+	if m.Pprof && m.NoMonitor {
+		fmt.Fprintln(os.Stderr, "warning: --pprof needs the monitoring dashboard; ignored because --no-monitor disables it")
+	}
 	// cwd at server start — dashboard warm endpoints walk this when the
 	// operator doesn't supply ?dir=… on the POST. os.Getwd may fail in
 	// pathological environments; an empty string means the buttons go
@@ -121,6 +125,7 @@ func (m *MCPCmd) Run(ctx context.Context) error {
 		IndexBackend:        backend.Mode,
 		IndexFallbackReason: backend.Reason,
 		BodyCacheCap:        bodyCap,
+		EnablePprof:         m.Pprof,
 		Cwd:                 monCwd,
 		WarmAttrsFn:         warmAttrsFn,
 		WarmBodyFn:          warmBodyFn,

--- a/cmd/file-search-on/monitor_default_test.go
+++ b/cmd/file-search-on/monitor_default_test.go
@@ -120,6 +120,57 @@ func TestMonitor_NoMonitorFlag(t *testing.T) {
 	})
 }
 
+// TestPprofFlag confirms --pprof parses into the per-command Pprof
+// field for both mcp and watch (off by default), the opt-in that the
+// Run methods thread into monitor.Config.EnablePprof.
+func TestPprofFlag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mcp default off, --pprof on", func(t *testing.T) {
+		var cli struct {
+			MCP MCPCmd `cmd:""`
+		}
+		parser, err := kong.New(&cli)
+		if err != nil {
+			t.Fatalf("kong.New: %v", err)
+		}
+		if _, err := parser.Parse([]string{"mcp"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if cli.MCP.Pprof {
+			t.Errorf("MCPCmd.Pprof = true with no flags; want false")
+		}
+		if _, err := parser.Parse([]string{"mcp", "--pprof"}); err != nil {
+			t.Fatalf("parse --pprof: %v", err)
+		}
+		if !cli.MCP.Pprof {
+			t.Errorf("MCPCmd.Pprof = false after --pprof; want true")
+		}
+	})
+
+	t.Run("watch default off, --pprof on", func(t *testing.T) {
+		var cli struct {
+			Watch WatchCmd `cmd:""`
+		}
+		parser, err := kong.New(&cli)
+		if err != nil {
+			t.Fatalf("kong.New: %v", err)
+		}
+		if _, err := parser.Parse([]string{"watch"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if cli.Watch.Pprof {
+			t.Errorf("WatchCmd.Pprof = true with no flags; want false")
+		}
+		if _, err := parser.Parse([]string{"watch", "--pprof"}); err != nil {
+			t.Fatalf("parse --pprof: %v", err)
+		}
+		if !cli.Watch.Pprof {
+			t.Errorf("WatchCmd.Pprof = false after --pprof; want true")
+		}
+	})
+}
+
 // TestMonitorAddrWins confirms --monitor-addr always pins the
 // supplied port even when --no-monitor is also passed (explicit
 // pin > implicit opt-out).

--- a/cmd/file-search-on/profile_test.go
+++ b/cmd/file-search-on/profile_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestStartProfiling exercises the root --cpuprofile / --memprofile /
+// --trace plumbing: setting the flags should produce non-empty profile
+// files once the returned stop closure runs. It mutates the global CLI,
+// so it must not run in parallel with other tests that read CLI.
+func TestStartProfiling(t *testing.T) {
+	dir := t.TempDir()
+	cpu := filepath.Join(dir, "cpu.prof")
+	mem := filepath.Join(dir, "mem.prof")
+	trc := filepath.Join(dir, "trace.out")
+
+	saveCPU, saveMem, saveTrace := CLI.CPUProfile, CLI.MemProfile, CLI.TraceProf
+	t.Cleanup(func() {
+		CLI.CPUProfile, CLI.MemProfile, CLI.TraceProf = saveCPU, saveMem, saveTrace
+	})
+	CLI.CPUProfile, CLI.MemProfile, CLI.TraceProf = cpu, mem, trc
+
+	stop, err := startProfiling()
+	if err != nil {
+		t.Fatalf("startProfiling: %v", err)
+	}
+
+	// Burn a little CPU so the CPU profile has at least one sample.
+	sum := 0
+	for i := range 5_000_000 {
+		sum += i % 7
+	}
+	_ = sum
+
+	stop()
+
+	// pprof CPU + heap profiles are gzipped protobufs (gzip magic 1f 8b);
+	// the trace file just needs to be non-empty. Checking size + magic is
+	// enough — we don't re-implement profile parsing here.
+	for _, p := range []string{cpu, mem} {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		if len(b) < 2 || b[0] != 0x1f || b[1] != 0x8b {
+			t.Errorf("%s: want non-empty gzip pprof, got %d bytes (prefix %x)", p, len(b), b[:min(2, len(b))])
+		}
+	}
+	if fi, err := os.Stat(trc); err != nil || fi.Size() == 0 {
+		t.Errorf("trace file %s: err=%v size=%d, want non-empty", trc, err, sizeOf(fi))
+	}
+}
+
+// TestStartProfiling_Disabled is the no-op path: with no flags set,
+// startProfiling returns a usable stop closure and writes nothing.
+func TestStartProfiling_Disabled(t *testing.T) {
+	saveCPU, saveMem, saveTrace := CLI.CPUProfile, CLI.MemProfile, CLI.TraceProf
+	t.Cleanup(func() {
+		CLI.CPUProfile, CLI.MemProfile, CLI.TraceProf = saveCPU, saveMem, saveTrace
+	})
+	CLI.CPUProfile, CLI.MemProfile, CLI.TraceProf = "", "", ""
+
+	stop, err := startProfiling()
+	if err != nil {
+		t.Fatalf("startProfiling: %v", err)
+	}
+	stop() // must be safe to call with nothing started
+}
+
+// TestStartProfiling_BadPath surfaces an error (not a panic) when a
+// profile path is unwritable.
+func TestStartProfiling_BadPath(t *testing.T) {
+	saveCPU := CLI.CPUProfile
+	t.Cleanup(func() { CLI.CPUProfile = saveCPU })
+	CLI.CPUProfile = filepath.Join(t.TempDir(), "no-such-dir", "cpu.prof")
+
+	if _, err := startProfiling(); err == nil {
+		t.Fatal("startProfiling with unwritable cpuprofile path: want error, got nil")
+	}
+}
+
+func sizeOf(fi os.FileInfo) int64 {
+	if fi == nil {
+		return -1
+	}
+	return fi.Size()
+}

--- a/cmd/file-search-on/watch_cmd.go
+++ b/cmd/file-search-on/watch_cmd.go
@@ -38,6 +38,7 @@ type WatchCmd struct {
 	Monitor          bool          `name:"monitor" help:"No-op — the monitoring dashboard is on by default since v0.65.0. Kept for back-compat with pre-existing scripts. Use --no-monitor to opt out, --monitor-addr to pin a fixed port."`
 	NoMonitor        bool          `name:"no-monitor" help:"Disable the read-only monitoring dashboard for this run. Useful for hermetic CI / sandboxed environments where binding a localhost port is undesirable. (Watch mode has no MCP tools, so the dashboard cannot be re-enabled mid-session.)"`
 	MonitorAddr      string        `name:"monitor-addr" help:"Bind the monitoring dashboard on this fixed port (e.g. ':9090') instead of an OS-assigned dynamic port. Binds 127.0.0.1 only. Overrides the default dynamic-port behaviour. Shows index cache stats + capabilities + a peer switcher at http://localhost:<port>/ (no MCP activity panel in watch mode)."`
+	Pprof            bool          `name:"pprof" help:"Mount Go runtime profiling endpoints (/debug/pprof/*) on the monitoring dashboard for live CPU / heap / goroutine profiling (go tool pprof http://localhost:<port>/debug/pprof/profile). Loopback-only — same 127.0.0.1 trust boundary as the dashboard. Off by default. Requires the dashboard, so it is a no-op with --no-monitor."`
 	AllowOutsideHome bool          `name:"allow-outside-home" help:"Bypass the home-directory safety guard. By default watch refuses to start unless every -d directory is inside your home directory, to avoid a long-running watcher over system paths or an entire volume. Pass this to watch a directory elsewhere (other volumes, /opt, /srv) or in a container/CI runner where HOME isn't set."`
 }
 
@@ -106,6 +107,9 @@ func (c *WatchCmd) Run(ctx context.Context) error {
 	if monAddr == "" && !c.NoMonitor {
 		monAddr = ":0" // dynamic, OS-assigned (default since v0.65.0)
 	}
+	if c.Pprof && c.NoMonitor {
+		fmt.Fprintln(os.Stderr, "warning: --pprof needs the monitoring dashboard; ignored because --no-monitor disables it")
+	}
 	if monAddr != "" {
 		mon := monitor.NewServer(monitor.Config{
 			Version:             version,
@@ -113,7 +117,7 @@ func (c *WatchCmd) Run(ctx context.Context) error {
 			Index:               idx,
 			IndexPath:           backend.Path,
 			IndexBackend:        backend.Mode,
-			IndexFallbackReason: backend.Reason,
+			EnablePprof:         c.Pprof,
 		})
 		monDone := make(chan struct{})
 		go func() {

--- a/internal/monitor/server.go
+++ b/internal/monitor/server.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -43,6 +44,13 @@ type Config struct {
 	IndexBackend        string // "persistent" | "in-memory"
 	IndexFallbackReason string // "" | "lock_contention" | "no_index_flag"
 	BodyCacheCap        int64  // 0 → in-memory / no cap
+
+	// EnablePprof mounts the Go runtime profiling endpoints
+	// (/debug/pprof/*) on this dashboard. Off by default — an explicit
+	// operator opt-in (--pprof), because the endpoints expose process
+	// memory contents and goroutine stacks. Still loopback-only, same
+	// trust boundary as the rest of the dashboard.
+	EnablePprof bool
 
 	// Cwd is the server's working directory at start; warm endpoints
 	// default to walking it when the caller doesn't pin a dir.
@@ -138,6 +146,22 @@ func (s *Server) routes() (http.Handler, error) {
 	mux.HandleFunc("POST /api/cache/warm-bodies", s.handleWarmBodies)
 	mux.HandleFunc("POST /api/cache/warm-embeddings", s.handleWarmEmbeddings)
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
+	// Go runtime profiling endpoints, opt-in via --pprof. The named
+	// pprof.* handlers are registered explicitly (NOT the blank
+	// `_ "net/http/pprof"` import, which would also pollute
+	// http.DefaultServeMux and leak the endpoints onto the MCP HTTP
+	// transport). pprof.Index dispatches the named sub-profiles
+	// (/debug/pprof/heap, /goroutine, /allocs, /block, /mutex, …)
+	// itself, so these five cover the full surface. Read-mostly, but
+	// they expose memory contents — hence the explicit opt-in on top of
+	// the loopback trust boundary.
+	if s.cfg.EnablePprof {
+		mux.HandleFunc("GET /debug/pprof/", pprof.Index)
+		mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
+	}
 	sub, err := fs.Sub(staticFiles, "static")
 	if err != nil {
 		return nil, fmt.Errorf("monitor static assets: %w", err)
@@ -440,6 +464,7 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 			"model":     s.cfg.EmbedModel,
 			"reachable": s.embedderReachable(r.Context()),
 		},
+		"pprof": s.cfg.EnablePprof,
 	})
 }
 

--- a/internal/monitor/server.go
+++ b/internal/monitor/server.go
@@ -156,10 +156,15 @@ func (s *Server) routes() (http.Handler, error) {
 	// they expose memory contents — hence the explicit opt-in on top of
 	// the loopback trust boundary.
 	if s.cfg.EnablePprof {
+		// These are GET-only (the static "GET /" catch-all below means a
+		// bare, method-less "/debug/pprof/" pattern would be rejected as
+		// a ServeMux conflict). pprof.Symbol is the exception: go tool
+		// pprof POSTs the address list to resolve, so it gets both verbs.
 		mux.HandleFunc("GET /debug/pprof/", pprof.Index)
 		mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
 		mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
 		mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("POST /debug/pprof/symbol", pprof.Symbol)
 		mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
 	}
 	sub, err := fs.Sub(staticFiles, "static")

--- a/internal/monitor/server_test.go
+++ b/internal/monitor/server_test.go
@@ -119,6 +119,13 @@ func TestServer_Pprof(t *testing.T) {
 			t.Errorf("EnablePprof=true: GET %s status = %d, want 200", path, rec.Code)
 		}
 	}
+	// pprof.Symbol must accept POST — go tool pprof posts the address
+	// list to resolve. A method-routed mux would 405 it otherwise.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/debug/pprof/symbol", nil))
+	if rec.Code != http.StatusOK {
+		t.Errorf("EnablePprof=true: POST /debug/pprof/symbol status = %d, want 200", rec.Code)
+	}
 	// Capabilities reports it.
 	if c := decode(t, on.handleCapabilities, "/api/capabilities"); c["pprof"] != true {
 		t.Errorf("capabilities pprof = %v, want true", c["pprof"])
@@ -131,7 +138,7 @@ func TestServer_Pprof(t *testing.T) {
 	if err != nil {
 		t.Fatalf("routes: %v", err)
 	}
-	rec := httptest.NewRecorder()
+	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("EnablePprof=false: GET /debug/pprof/ status = %d, want 404", rec.Code)

--- a/internal/monitor/server_test.go
+++ b/internal/monitor/server_test.go
@@ -105,6 +105,42 @@ func TestServer_Healthz(t *testing.T) {
 	}
 }
 
+func TestServer_Pprof(t *testing.T) {
+	// Enabled: /debug/pprof/* is mounted and serves through the full mux.
+	on := NewServer(Config{Mode: "mcp-stdio", Index: index.NewMemory(), EnablePprof: true})
+	h, err := on.routes()
+	if err != nil {
+		t.Fatalf("routes: %v", err)
+	}
+	for _, path := range []string{"/debug/pprof/", "/debug/pprof/heap?debug=1"} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Errorf("EnablePprof=true: GET %s status = %d, want 200", path, rec.Code)
+		}
+	}
+	// Capabilities reports it.
+	if c := decode(t, on.handleCapabilities, "/api/capabilities"); c["pprof"] != true {
+		t.Errorf("capabilities pprof = %v, want true", c["pprof"])
+	}
+
+	// Disabled (default): the path falls through to the static file
+	// server, which 404s — the endpoints are not exposed.
+	off := NewServer(Config{Mode: "mcp-stdio", Index: index.NewMemory()})
+	h, err = off.routes()
+	if err != nil {
+		t.Fatalf("routes: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("EnablePprof=false: GET /debug/pprof/ status = %d, want 404", rec.Code)
+	}
+	if c := decode(t, off.handleCapabilities, "/api/capabilities"); c["pprof"] != false {
+		t.Errorf("capabilities pprof = %v, want false", c["pprof"])
+	}
+}
+
 func TestForceLoopback(t *testing.T) {
 	cases := map[string]string{
 		":9090":           "127.0.0.1:9090",


### PR DESCRIPTION
## Summary

Adds Go runtime profiling to file-search-on across two complementary surfaces (per the approved plan):

### Part A — file-based profiles (any subcommand)
Root-level flags wrap whichever subcommand runs:
- `--cpuprofile <file>` — CPU profile (`go tool pprof <file>`)
- `--memprofile <file>` — heap profile written after the command finishes (`runtime.GC()` first)
- `--trace <file>` — execution trace (`go tool trace <file>`)

Implemented via a `startProfiling` helper in `main.go`. Teardown is **explicit, not deferred** — `main()`'s error paths call `os.Exit`, which skips `defer`, so a deferred stop would truncate the CPU/trace files and never write the heap profile.

### Part B — live HTTP pprof on the long-running servers
`mcp` and `watch` accept `--pprof`, which mounts `/debug/pprof/*` on the **existing loopback-only monitoring dashboard** — no new listener, no new port, same 127.0.0.1 trust boundary:

```sh
file-search-on mcp --pprof --monitor-addr :9090
go tool pprof http://localhost:9090/debug/pprof/profile
```

- New `monitor.Config.EnablePprof` gates the routes in `internal/monitor/server.go`.
- Uses the **named** `net/http/pprof` import (`pprof.Index` etc.), **not** the blank `_` import — the blank import registers on `http.DefaultServeMux` and would leak the endpoints onto the MCP HTTP transport.
- **Off by default** (the endpoints expose process memory + goroutine stacks); warns when combined with `--no-monitor`. Surfaced in `/api/capabilities` as `pprof`.

## Tests
- `internal/monitor/server_test.go` — `/debug/pprof/heap` returns 200 when enabled, 404 when gated; capabilities flag both ways.
- `cmd/file-search-on/profile_test.go` — `startProfiling` produces valid gzip pprof + non-empty trace files, is a safe no-op when disabled, and errors (not panics) on an unwritable path.
- `cmd/file-search-on/monitor_default_test.go` — `--pprof` parse for both `mcp` and `watch` (off by default).

## Docs
README gains a **Profiling** subsection (file-based flags) and a **Live profiling** note under the monitoring dashboard.

## Verification
- `go build ./...`, `go vet ./...`, full `go test ./...`, `golangci-lint run` (v2) all green; `go fix ./...` idempotent.
- Manually exercised both surfaces: captured a CPU profile of a real `search` walk (`go tool pprof -top` reads it), live `/debug/pprof/{,heap}` → 200 with `--pprof`, → 404 without, and the `--pprof --no-monitor` warning.

## Out of scope
- No `--pprof-addr` dedicated listener (mounted on the existing dashboard instead).
- pprof not exposed on the agent-facing MCP HTTP wire — operator-facing loopback dashboard only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)