### PR TITLE
feat(monitor): surface pprof profiling in the dashboard UI

### DIFF
--- a/internal/monitor/static/app.js
+++ b/internal/monitor/static/app.js
@@ -152,18 +152,20 @@ function renderCapabilities(d) {
     : `<span class="pill pill-unknown">unreachable</span>`;
 
   // Profiling — when --pprof mounted the runtime endpoints on this
-  // dashboard, link straight to them (relative to the dashboard root) and
-  // surface the go-tool-pprof command. Otherwise nudge toward the flag.
-  const base = window.location.origin;
+  // dashboard, link straight to them and surface the go-tool-pprof
+  // command. Resolve via new URL against the current page so the links
+  // stay correct under a subpath / reverse proxy and regardless of a
+  // trailing slash. Otherwise nudge toward the flag.
+  const pp = (p) => new URL("debug/pprof/" + p, window.location.href).href;
   const pprofCell = d.pprof
     ? `<span class="pill pill-ok">enabled</span>
        <div class="pprof-links">
-         <a href="debug/pprof/" target="_blank" rel="noopener">index</a>
-         <a href="debug/pprof/heap?debug=1" target="_blank" rel="noopener">heap</a>
-         <a href="debug/pprof/goroutine?debug=1" target="_blank" rel="noopener">goroutines</a>
-         <a href="debug/pprof/profile?seconds=30" target="_blank" rel="noopener">CPU&nbsp;(30s)</a>
+         <a href="${pp("")}" target="_blank" rel="noopener">index</a>
+         <a href="${pp("heap?debug=1")}" target="_blank" rel="noopener">heap</a>
+         <a href="${pp("goroutine?debug=1")}" target="_blank" rel="noopener">goroutines</a>
+         <a href="${pp("profile?seconds=30")}" target="_blank" rel="noopener">CPU&nbsp;(30s)</a>
        </div>
-       <code class="pprof-cmd">go tool pprof ${base}/debug/pprof/profile</code>`
+       <code class="pprof-cmd">go tool pprof ${pp("profile")}</code>`
     : `<span class="pill pill-unknown">disabled</span>
        <span class="muted">restart with <code>--pprof</code> to mount /debug/pprof/*</span>`;
 

--- a/internal/monitor/static/app.js
+++ b/internal/monitor/static/app.js
@@ -151,6 +151,22 @@ function renderCapabilities(d) {
     ? `<span class="pill pill-ok">reachable</span>`
     : `<span class="pill pill-unknown">unreachable</span>`;
 
+  // Profiling — when --pprof mounted the runtime endpoints on this
+  // dashboard, link straight to them (relative to the dashboard root) and
+  // surface the go-tool-pprof command. Otherwise nudge toward the flag.
+  const base = window.location.origin;
+  const pprofCell = d.pprof
+    ? `<span class="pill pill-ok">enabled</span>
+       <div class="pprof-links">
+         <a href="debug/pprof/" target="_blank" rel="noopener">index</a>
+         <a href="debug/pprof/heap?debug=1" target="_blank" rel="noopener">heap</a>
+         <a href="debug/pprof/goroutine?debug=1" target="_blank" rel="noopener">goroutines</a>
+         <a href="debug/pprof/profile?seconds=30" target="_blank" rel="noopener">CPU&nbsp;(30s)</a>
+       </div>
+       <code class="pprof-cmd">go tool pprof ${base}/debug/pprof/profile</code>`
+    : `<span class="pill pill-unknown">disabled</span>
+       <span class="muted">restart with <code>--pprof</code> to mount /debug/pprof/*</span>`;
+
   $("capabilities").innerHTML = `<div class="caps-grid">
     <div><h3 class="sub">Content types (${ct.total})</h3>${fams || '<div class="empty">—</div>'}</div>
     <div><h3 class="sub">Project types (${(d.project_types || []).length})</h3>${projects || '<div class="empty">—</div>'}</div>
@@ -158,6 +174,7 @@ function renderCapabilities(d) {
     <div><h3 class="sub">Embedder</h3>
       <div>${embLine} <span class="muted">${emb.model || "no model"} @ ${emb.server || "—"}</span></div>
     </div>
+    <div><h3 class="sub">Profiling</h3>${pprofCell}</div>
   </div>`;
 }
 

--- a/internal/monitor/static/style.css
+++ b/internal/monitor/static/style.css
@@ -77,6 +77,15 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 .ix-memory { color: var(--muted); }
 .ix-memory.ix-warn { color: var(--warn); }
 
+/* --- profiling (pprof) --- */
+.pprof-links { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.pprof-links a { background: var(--card); border: 1px solid var(--line); border-radius: 4px;
+  padding: 2px 8px; font-size: 12px; color: var(--accent); text-decoration: none; }
+.pprof-links a:hover { background: #2d3743; }
+.pprof-cmd { display: block; margin-top: 8px; padding: 6px 8px; background: var(--card);
+  border-radius: 4px; font-family: ui-monospace, monospace; font-size: 11px;
+  color: var(--muted); word-break: break-all; }
+
 /* --- cache browser --- */
 .cb-toolbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 10px; }
 .cb-tabs { display: inline-flex; border: 1px solid var(--line); border-radius: 4px; overflow: hidden; }


### PR DESCRIPTION
## Summary

Follow-up to #501 — makes pprof profiling **visible in the monitoring dashboard UI**, not just the JSON API.

Adds a **Profiling** cell to the Capabilities panel:
- **`--pprof` enabled** → an "enabled" pill, quick links to the mounted endpoints (index / heap / goroutines / 30s CPU profile, relative to the dashboard root, opening in a new tab), and the ready-to-paste `go tool pprof <url>` command.
- **disabled** → a "disabled" pill with a nudge to restart with `--pprof`.

Driven entirely by the `pprof` boolean already on `/api/capabilities` (added in #501). Pure static-asset change — `app.js` (render) + `style.css` (link styling).

> **Stacked on #501.** This needs the `pprof` capabilities field from that PR, so the base branch is `feat/pprof-profiling`. GitHub will retarget this to `main` automatically once #501 merges.

## Verification
- Rebuilt the embedded binary; confirmed the updated `app.js` / `style.css` are served, `/api/capabilities` reports `pprof:true` with `--pprof` (UI renders the links → endpoints return 200) and `pprof:false` without it (UI renders the disabled hint).
- `go vet` + `go test ./internal/monitor/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)