### PR TITLE
feat(monitor): surface pprof profiling in the dashboard UI

### DIFF
--- a/internal/monitor/static/app.js
+++ b/internal/monitor/static/app.js
@@ -151,6 +151,24 @@ function renderCapabilities(d) {
     ? `<span class="pill pill-ok">reachable</span>`
     : `<span class="pill pill-unknown">unreachable</span>`;
 
+  // Profiling — when --pprof mounted the runtime endpoints on this
+  // dashboard, link straight to them and surface the go-tool-pprof
+  // command. Resolve via new URL against the current page so the links
+  // stay correct under a subpath / reverse proxy and regardless of a
+  // trailing slash. Otherwise nudge toward the flag.
+  const pp = (p) => new URL("debug/pprof/" + p, window.location.href).href;
+  const pprofCell = d.pprof
+    ? `<span class="pill pill-ok">enabled</span>
+       <div class="pprof-links">
+         <a href="${pp("")}" target="_blank" rel="noopener">index</a>
+         <a href="${pp("heap?debug=1")}" target="_blank" rel="noopener">heap</a>
+         <a href="${pp("goroutine?debug=1")}" target="_blank" rel="noopener">goroutines</a>
+         <a href="${pp("profile?seconds=30")}" target="_blank" rel="noopener">CPU&nbsp;(30s)</a>
+       </div>
+       <code class="pprof-cmd">go tool pprof ${pp("profile")}</code>`
+    : `<span class="pill pill-unknown">disabled</span>
+       <span class="muted">restart with <code>--pprof</code> to mount /debug/pprof/*</span>`;
+
   $("capabilities").innerHTML = `<div class="caps-grid">
     <div><h3 class="sub">Content types (${ct.total})</h3>${fams || '<div class="empty">—</div>'}</div>
     <div><h3 class="sub">Project types (${(d.project_types || []).length})</h3>${projects || '<div class="empty">—</div>'}</div>
@@ -158,6 +176,7 @@ function renderCapabilities(d) {
     <div><h3 class="sub">Embedder</h3>
       <div>${embLine} <span class="muted">${emb.model || "no model"} @ ${emb.server || "—"}</span></div>
     </div>
+    <div><h3 class="sub">Profiling</h3>${pprofCell}</div>
   </div>`;
 }
 

--- a/internal/monitor/static/style.css
+++ b/internal/monitor/static/style.css
@@ -77,6 +77,15 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 .ix-memory { color: var(--muted); }
 .ix-memory.ix-warn { color: var(--warn); }
 
+/* --- profiling (pprof) --- */
+.pprof-links { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.pprof-links a { background: var(--card); border: 1px solid var(--line); border-radius: 4px;
+  padding: 2px 8px; font-size: 12px; color: var(--accent); text-decoration: none; }
+.pprof-links a:hover { background: #2d3743; }
+.pprof-cmd { display: block; margin-top: 8px; padding: 6px 8px; background: var(--card);
+  border-radius: 4px; font-family: ui-monospace, monospace; font-size: 11px;
+  color: var(--muted); word-break: break-all; }
+
 /* --- cache browser --- */
 .cb-toolbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 10px; }
 .cb-tabs { display: inline-flex; border: 1px solid var(--line); border-radius: 4px; overflow: hidden; }


### PR DESCRIPTION
## Summary

Makes pprof profiling **visible in the monitoring dashboard UI** (follow-up to #501, now merged). Adds a **Profiling** cell to the Capabilities panel:

- **`--pprof` enabled** → an "enabled" pill, quick links to the mounted endpoints (index / heap / goroutines / 30s CPU profile, opening in a new tab), and the ready-to-paste `go tool pprof <url>` command.
- **disabled** → a "disabled" pill nudging you to restart with `--pprof`.

Links resolve via `new URL("debug/pprof/…", window.location.href)` so they stay correct under a subpath / reverse proxy and regardless of a trailing slash (per review feedback on #502). Pure static-asset change — `app.js` (render) + `style.css` (styling). Driven by the `pprof` boolean on `/api/capabilities` added in #501.

> Supersedes #502, which GitHub auto-closed when its stacked base branch (`feat/pprof-profiling`) was deleted on the #501 merge. Same diff, re-based cleanly on `main`.

## Verification
Rebuilt the embedded binary; confirmed `/api/capabilities` reports `pprof:true`/`false`, the UI renders the links, the linked endpoints return 200 (incl. `POST /debug/pprof/symbol`), and `go test ./internal/monitor/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)