### PR TITLE
fix(unused_exports): exempt AddTool[In,Out]-bound types (#504)

### DIFF
--- a/internal/content/extraction_coverage_test.go
+++ b/internal/content/extraction_coverage_test.go
@@ -28,9 +28,11 @@ import (
 // the stdlib-AST path for Go, tree-sitter for everything else.
 func extractSymbolsFor(language string, src []byte) (funcs, types, imports, refs, callEdges, complexityRows []string) {
 	if language == "go" {
-		return extractGoSymbols(src)
+		funcs, types, imports, refs, callEdges, complexityRows, _ = extractGoSymbols(src)
+		return
 	}
-	return extractTreeSitterSymbols(language, src)
+	funcs, types, imports, refs, callEdges, complexityRows, _ = extractTreeSitterSymbols(language, src)
+	return
 }
 
 type langBaseline struct {

--- a/internal/content/source_cognitive_treesitter_test.go
+++ b/internal/content/source_cognitive_treesitter_test.go
@@ -11,7 +11,7 @@ import (
 // whose row has no 5th field (cognitive unavailable) are omitted.
 func cognitiveByFunc(t *testing.T, language string, src string) map[string]int {
 	t.Helper()
-	_, _, _, _, _, rows := extractTreeSitterSymbols(language, []byte(src))
+	_, _, _, _, _, rows, _ := extractTreeSitterSymbols(language, []byte(src))
 	out := map[string]int{}
 	for _, r := range rows {
 		p := strings.Split(r, "\x00")

--- a/internal/content/source_symbols_go.go
+++ b/internal/content/source_symbols_go.go
@@ -58,12 +58,12 @@ func goExportedName(name string) bool {
 // SonarSource cognitive complexity. Builder-internal, like callEdges. The
 // trailing cognitive field is Go-only today; the tree-sitter extractor emits
 // the 4-field form, so consumers treat a missing 5th field as "unavailable".
-func extractGoSymbols(src []byte) (functions, types, imports, references, callEdges, complexityRows []string) {
+func extractGoSymbols(src []byte) (functions, types, imports, references, callEdges, complexityRows, handlerBoundary []string) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "", src, parser.AllErrors)
 	if f == nil {
 		_ = err
-		return nil, nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil, nil
 	}
 	for _, decl := range f.Decls {
 		switch d := decl.(type) {
@@ -107,7 +107,7 @@ func extractGoSymbols(src []byte) (functions, types, imports, references, callEd
 		return true
 	})
 	references = append(references, goTypeRefs(f)...)
-	return functions, types, imports, dedupeStrings(references), dedupeStrings(callEdges), complexityRows
+	return functions, types, imports, dedupeStrings(references), dedupeStrings(callEdges), complexityRows, goHandlerBoundary(f)
 }
 
 // goPredeclared is the set of Go predeclared type names. They appear in
@@ -237,13 +237,11 @@ func goValueRefs(f *ast.File) []string {
 // inside the defining package.
 //
 // Only EXPORTED signature types are emitted (unused_exports only judges
-// exported symbols), which bounds the output. Re-parses the source (a second
-// go/parser pass beyond extractGoSymbols); the result caches in the attribute
+// exported symbols), which bounds the output. Takes the AST already parsed by
+// extractGoSymbols (no second parse); the result caches in the attribute
 // index alongside the other symbol data, so the cost is paid once per
 // (file, size, mtime).
-func goHandlerBoundary(src []byte) []string {
-	fset := token.NewFileSet()
-	f, _ := parser.ParseFile(fset, "", src, parser.AllErrors)
+func goHandlerBoundary(f *ast.File) []string {
 	if f == nil {
 		return nil
 	}

--- a/internal/content/source_symbols_go.go
+++ b/internal/content/source_symbols_go.go
@@ -6,7 +6,20 @@ import (
 	"go/parser"
 	"go/token"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
+
+// goExportedName reports whether name's first rune is upper-case — Go's
+// export convention. Mirrors search.isExportedName (kept local so the stable
+// content package doesn't import search).
+func goExportedName(name string) bool {
+	if name == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(r)
+}
 
 // extractGoSymbols parses Go source via the stdlib AST and returns
 // (functions, types, imports). The Go path is the gold standard: free,
@@ -204,6 +217,63 @@ func goValueRefs(f *ast.File) []string {
 		return true
 	})
 	return out
+}
+
+// goHandlerBoundary extracts the data that spares registration-bound types
+// from the unused_exports "package-local" false positive (issue #504). It
+// returns two relations tag-encoded into one []string (mirroring the
+// call_edges "\x00" convention) so they ride in a single attribute:
+//
+//	"v\x00<func>"           — <func> is passed as a VALUE to a call (a handler
+//	                          registered via the AddTool / HandleFunc pattern, #421).
+//	"s\x00<func>\x00<Type>" — exported <Type> appears in <func>'s signature
+//	                          (a parameter or result type).
+//
+// The aggregator (search.UnusedExports) joins them: an exported type in the
+// signature of a function that is registered as a value is bound to that
+// external generic API — e.g. mcp.AddTool[In, Out] infers In/Out from the
+// handler signature — and must stay exported, so it is exempt from the
+// unexport-candidate list even though every textual reference to it sits
+// inside the defining package.
+//
+// Only EXPORTED signature types are emitted (unused_exports only judges
+// exported symbols), which bounds the output. Re-parses the source (a second
+// go/parser pass beyond extractGoSymbols); the result caches in the attribute
+// index alongside the other symbol data, so the cost is paid once per
+// (file, size, mtime).
+func goHandlerBoundary(src []byte) []string {
+	fset := token.NewFileSet()
+	f, _ := parser.ParseFile(fset, "", src, parser.AllErrors)
+	if f == nil {
+		return nil
+	}
+	var out []string
+	for _, name := range goValueRefs(f) {
+		out = append(out, "v\x00"+name)
+	}
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Type == nil {
+			continue
+		}
+		var sigTypes []string
+		if fn.Type.Params != nil {
+			for _, p := range fn.Type.Params.List {
+				collectTypeIdents(p.Type, &sigTypes)
+			}
+		}
+		if fn.Type.Results != nil {
+			for _, r := range fn.Type.Results.List {
+				collectTypeIdents(r.Type, &sigTypes)
+			}
+		}
+		for _, t := range dedupeStrings(sigTypes) {
+			if goExportedName(t) {
+				out = append(out, "s\x00"+fn.Name.Name+"\x00"+t)
+			}
+		}
+	}
+	return dedupeStrings(out)
 }
 
 // goFunctionSpans returns the 1-based inclusive line span of every top-level

--- a/internal/content/source_symbols_go_test.go
+++ b/internal/content/source_symbols_go_test.go
@@ -132,6 +132,37 @@ func contains(slice []string, want string) bool {
 // a VALUE (passed as a call argument) must appear in references — so a
 // handler registered via a callback isn't a dead_code false positive — but
 // must NOT become a call edge (passing a function isn't calling it).
+// TestGoHandlerBoundary pins issue #504: the boundary extractor emits the
+// value-ref of a handler passed to a call AND the exported types in that
+// handler's signature, so unused_exports can exempt AddTool[In,Out]-bound
+// types from the package-local false positive.
+func TestGoHandlerBoundary(t *testing.T) {
+	src := []byte(`package srv
+
+import "context"
+
+type Req struct{ A int }
+type Resp struct{ B int }
+
+func register(s any) { AddTool(s, handle) }
+
+func handle(ctx context.Context, in Req) (Resp, error) { return Resp{}, nil }
+`)
+	got := goHandlerBoundary(src)
+	have := map[string]bool{}
+	for _, e := range got {
+		have[e] = true
+	}
+	for _, want := range []string{"v\x00handle", "s\x00handle\x00Req", "s\x00handle\x00Resp"} {
+		if !have[want] {
+			t.Errorf("goHandlerBoundary missing %q; got %v", want, got)
+		}
+	}
+	if have["s\x00register\x00Req"] {
+		t.Errorf("register has no Req in its signature; unexpected entry: %v", got)
+	}
+}
+
 func TestExtractGoSymbols_ValueRefs(t *testing.T) {
 	src := []byte(`package p
 

--- a/internal/content/source_symbols_go_test.go
+++ b/internal/content/source_symbols_go_test.go
@@ -1,6 +1,8 @@
 package content
 
 import (
+	"go/parser"
+	"go/token"
 	"reflect"
 	"slices"
 	"sort"
@@ -25,7 +27,7 @@ func ProcessOrder(id string) error {
 	return nil
 }
 `)
-	funcs, types, imports, _, _, _ := extractGoSymbols(src)
+	funcs, types, imports, _, _, _, _ := extractGoSymbols(src)
 	sort.Strings(funcs)
 	sort.Strings(types)
 	sort.Strings(imports)
@@ -50,7 +52,7 @@ import (
 	_ "embed"
 )
 `)
-	_, _, imports, _, _, _ := extractGoSymbols(src)
+	_, _, imports, _, _, _, _ := extractGoSymbols(src)
 	sort.Strings(imports)
 	want := []string{"embed", "fmt", "net/http"}
 	if !reflect.DeepEqual(imports, want) {
@@ -72,7 +74,7 @@ type Pair[A, B any] struct {
 
 func Map[T, U any](items []T, fn func(T) U) []U { return nil }
 `)
-	funcs, types, _, _, _, _ := extractGoSymbols(src)
+	funcs, types, _, _, _, _, _ := extractGoSymbols(src)
 	if !contains(funcs, "Map") {
 		t.Errorf("expected Map in functions, got %v", funcs)
 	}
@@ -98,7 +100,7 @@ func Working() {
 
 func Broken( {  // syntax error here
 `)
-	funcs, types, imports, _, _, _ := extractGoSymbols(src)
+	funcs, types, imports, _, _, _, _ := extractGoSymbols(src)
 	if !contains(imports, "fmt") {
 		t.Errorf("imports should include fmt despite parse error, got %v", imports)
 	}
@@ -111,14 +113,14 @@ func Broken( {  // syntax error here
 }
 
 func TestExtractGoSymbols_Empty(t *testing.T) {
-	funcs, types, imports, _, _, _ := extractGoSymbols([]byte{})
+	funcs, types, imports, _, _, _, _ := extractGoSymbols([]byte{})
 	if len(funcs) != 0 || len(types) != 0 || len(imports) != 0 {
 		t.Errorf("empty input should yield empty results, got %v/%v/%v", funcs, types, imports)
 	}
 }
 
 func TestExtractGoSymbols_PackageOnly(t *testing.T) {
-	funcs, types, imports, _, _, _ := extractGoSymbols([]byte("package main\n"))
+	funcs, types, imports, _, _, _, _ := extractGoSymbols([]byte("package main\n"))
 	if len(funcs) != 0 || len(types) != 0 || len(imports) != 0 {
 		t.Errorf("package-only file should yield empty results, got %v/%v/%v", funcs, types, imports)
 	}
@@ -128,16 +130,12 @@ func contains(slice []string, want string) bool {
 	return slices.Contains(slice, want)
 }
 
-// TestExtractGoSymbols_ValueRefs pins issue #421: a function/method used as
-// a VALUE (passed as a call argument) must appear in references — so a
-// handler registered via a callback isn't a dead_code false positive — but
-// must NOT become a call edge (passing a function isn't calling it).
 // TestGoHandlerBoundary pins issue #504: the boundary extractor emits the
 // value-ref of a handler passed to a call AND the exported types in that
 // handler's signature, so unused_exports can exempt AddTool[In,Out]-bound
 // types from the package-local false positive.
 func TestGoHandlerBoundary(t *testing.T) {
-	src := []byte(`package srv
+	src := `package srv
 
 import "context"
 
@@ -147,8 +145,12 @@ type Resp struct{ B int }
 func register(s any) { AddTool(s, handle) }
 
 func handle(ctx context.Context, in Req) (Resp, error) { return Resp{}, nil }
-`)
-	got := goHandlerBoundary(src)
+`
+	f, err := parser.ParseFile(token.NewFileSet(), "", src, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := goHandlerBoundary(f)
 	have := map[string]bool{}
 	for _, e := range got {
 		have[e] = true
@@ -163,6 +165,10 @@ func handle(ctx context.Context, in Req) (Resp, error) { return Resp{}, nil }
 	}
 }
 
+// TestExtractGoSymbols_ValueRefs pins issue #421: a function/method used as
+// a VALUE (passed as a call argument) must appear in references — so a
+// handler registered via a callback isn't a dead_code false positive — but
+// must NOT become a call edge (passing a function isn't calling it).
 func TestExtractGoSymbols_ValueRefs(t *testing.T) {
 	src := []byte(`package p
 
@@ -172,7 +178,7 @@ func register() {
 }
 func handleThing() {}
 `)
-	_, _, _, refs, edges, _ := extractGoSymbols(src)
+	_, _, _, refs, edges, _, _ := extractGoSymbols(src)
 	for _, want := range []string{"handleThing", "serveIt"} {
 		if !contains(refs, want) {
 			t.Errorf("references missing value-passed %q: %v", want, refs)
@@ -211,7 +217,7 @@ func use(c Cog) Widget {           // param + result type
 	return Widget{}
 }
 `)
-	_, _, _, refs, edges, _ := extractGoSymbols(src)
+	_, _, _, refs, edges, _, _ := extractGoSymbols(src)
 	for _, want := range []string{"Widget", "Gadget", "Sprocket", "Cog", "Embedded", "Holder"} {
 		if !contains(refs, want) {
 			t.Errorf("references missing type usage %q: %v", want, refs)
@@ -240,7 +246,7 @@ func TestExtractGoSymbols_CallEdges(t *testing.T) {
 func Alpha() { Beta(); helper.Do() }
 func Beta()  {}
 `)
-	_, _, _, refs, edges, _ := extractGoSymbols(src)
+	_, _, _, refs, edges, _, _ := extractGoSymbols(src)
 	if !contains(refs, "Beta") || !contains(refs, "Do") {
 		t.Errorf("references missing Beta/Do: %v", refs)
 	}
@@ -270,7 +276,7 @@ func Branchy(x int) {
 	}
 }
 `)
-	_, _, _, _, _, rows := extractGoSymbols(src)
+	_, _, _, _, _, rows, _ := extractGoSymbols(src)
 	cyclomatic := map[string]string{}
 	cognitive := map[string]string{}
 	for _, r := range rows {

--- a/internal/content/source_symbols_migrate_test.go
+++ b/internal/content/source_symbols_migrate_test.go
@@ -83,7 +83,7 @@ func TestMigratedLanguages(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.language, func(t *testing.T) {
-			funcs, types, imports, refs, _, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
+			funcs, types, imports, refs, _, _, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
 			checkContains(t, "functions", funcs, tc.wantFuncs)
 			checkContains(t, "type_names", types, tc.wantTypes)
 			checkContains(t, "imports", imports, tc.wantImports)

--- a/internal/content/source_symbols_treesitter.go
+++ b/internal/content/source_symbols_treesitter.go
@@ -545,14 +545,18 @@ func declaredPackage(language string, src []byte) string {
 // returns the function / type / import names. Matches the signature of
 // the hand-rolled extractXxxSymbols functions. Returns all-nil when the
 // language isn't tree-sitter-backed.
-func extractTreeSitterSymbols(language string, src []byte) (functions, types, imports, references, callEdges, complexityRows []string) {
+// The trailing handlerBoundary return is always nil here — the #504
+// registration-boundary exemption is Go-only for now (it needs go/ast
+// signature inspection); kept in the signature for parity with
+// extractGoSymbols so sourcetype.go can assign both uniformly.
+func extractTreeSitterSymbols(language string, src []byte) (functions, types, imports, references, callEdges, complexityRows, handlerBoundary []string) {
 	tl := tsLangFor(language)
 	if tl == nil {
-		return nil, nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil, nil
 	}
 	tree, err := tl.pool.Parse(src)
 	if err != nil || tree == nil {
-		return nil, nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil, nil
 	}
 
 	// funcSpans (named function definitions + byte/line span) are shared
@@ -567,7 +571,7 @@ func extractTreeSitterSymbols(language string, src []byte) (functions, types, im
 	complexityRows = tsComplexityRows(language, tl, tree, funcSpans)
 
 	return dedupeStrings(functions), dedupeStrings(types), dedupeStrings(imports),
-		dedupeStrings(references), dedupeStrings(callEdges), complexityRows
+		dedupeStrings(references), dedupeStrings(callEdges), complexityRows, nil
 }
 
 // tsFunctionSpans returns the 1-based inclusive line span of every named

--- a/internal/content/source_symbols_treesitter_test.go
+++ b/internal/content/source_symbols_treesitter_test.go
@@ -139,7 +139,7 @@ int main() { return 0; }
 
 	for _, tc := range cases {
 		t.Run(tc.language, func(t *testing.T) {
-			funcs, types, imports, _, _, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
+			funcs, types, imports, _, _, _, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
 			checkContains(t, "functions", funcs, tc.wantFuncs)
 			checkContains(t, "type_names", types, tc.wantTypes)
 			checkContains(t, "imports", imports, tc.wantImports)
@@ -175,7 +175,7 @@ func TestExtractTreeSitterReferences(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.language, func(t *testing.T) {
-			_, _, _, refs, _, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
+			_, _, _, refs, _, _, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
 			checkContains(t, "references", refs, tc.wantRefs)
 		})
 	}
@@ -231,7 +231,7 @@ func build(c: Cog) -> Sprocket { let b: Bolt = make() }`,
 	}
 	for _, tc := range cases {
 		t.Run(tc.language, func(t *testing.T) {
-			_, _, _, refs, _, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
+			_, _, _, refs, _, _, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
 			checkContains(t, "references (type usages)", refs, tc.wantRefs)
 		})
 	}
@@ -242,7 +242,7 @@ func build(c: Cog) -> Sprocket { let b: Bolt = make() }`,
 // would self-reference and never be flagged as dead). Rust struct defined
 // and never used → must not appear in references.
 func TestExtractTreeSitterTypeRefs_NoSelfCapture(t *testing.T) {
-	_, types, _, refs, _, _ := extractTreeSitterSymbols("rust", []byte(`struct Lonely { x: i32 }`))
+	_, types, _, refs, _, _, _ := extractTreeSitterSymbols("rust", []byte(`struct Lonely { x: i32 }`))
 	if !slices.Contains(types, "Lonely") {
 		t.Fatalf("Lonely should be a defined type; got %v", types)
 	}
@@ -338,7 +338,7 @@ func TestParseTimeoutBudget(t *testing.T) {
 		t.Errorf("tsParseTimeoutMicros = %d (<1s) risks skipping healthy files", tsParseTimeoutMicros)
 	}
 	// A normal file still extracts fine under the cap.
-	funcs, _, _, _, _, _ := extractTreeSitterSymbols("swift", []byte("func greet() -> String { return \"hi\" }\n"))
+	funcs, _, _, _, _, _, _ := extractTreeSitterSymbols("swift", []byte("func greet() -> String { return \"hi\" }\n"))
 	if !slices.Contains(funcs, "greet") {
 		t.Errorf("normal swift file should still extract under the parse cap; got %v", funcs)
 	}
@@ -365,7 +365,7 @@ function d() { e(); }`, []string{"a\x00b", "a\x00c", "d\x00e"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.language, func(t *testing.T) {
-			_, _, _, _, edges, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
+			_, _, _, _, edges, _, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
 			checkContains(t, "call_edges", edges, tc.want)
 		})
 	}
@@ -385,7 +385,7 @@ pub fn g() {}
 	done := make(chan bool, goroutines)
 	for range goroutines {
 		go func() {
-			funcs, types, imports, _, _, _ := extractTreeSitterSymbols("rust", src)
+			funcs, types, imports, _, _, _, _ := extractTreeSitterSymbols("rust", src)
 			done <- len(funcs) == 2 && len(types) == 1 && len(imports) == 1
 		}()
 	}
@@ -397,7 +397,7 @@ pub fn g() {}
 }
 
 func TestExtractTreeSitterSymbols_UnknownLanguage(t *testing.T) {
-	f, ty, im, _, _, _ := extractTreeSitterSymbols("brainfuck", []byte("+++."))
+	f, ty, im, _, _, _, _ := extractTreeSitterSymbols("brainfuck", []byte("+++."))
 	if f != nil || ty != nil || im != nil {
 		t.Errorf("expected all-nil for unsupported language, got %v %v %v", f, ty, im)
 	}
@@ -412,7 +412,7 @@ func TestExtractTreeSitterRequireImports(t *testing.T) {
 			src := `const foo = require("./foo");
 const bar = require("bar");
 import { Baz } from "./baz";`
-			_, _, imports, _, _, _ := extractTreeSitterSymbols(lang, []byte(src))
+			_, _, imports, _, _, _, _ := extractTreeSitterSymbols(lang, []byte(src))
 			checkContains(t, "imports", imports, []string{"./foo", "bar", "./baz"})
 		})
 	}
@@ -446,7 +446,7 @@ func TestExtractTreeSitterComplexity(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.language, func(t *testing.T) {
-			_, _, _, _, _, rows := extractTreeSitterSymbols(tc.language, []byte(tc.src))
+			_, _, _, _, _, rows, _ := extractTreeSitterSymbols(tc.language, []byte(tc.src))
 			cx := ""
 			for _, r := range rows {
 				p := splitNUL(r)

--- a/internal/content/sourcetype.go
+++ b/internal/content/sourcetype.go
@@ -152,23 +152,20 @@ func (s *sourceType) Attributes(ctx context.Context, fsys fs.FS, p string) (Attr
 		attrs["is_generated_code"] = true
 	}
 	if bodyBuf != nil && bodyBuf.Len() > 0 {
-		var funcs, types, imports, refs, callEdges, complexityRows []string
+		var funcs, types, imports, refs, callEdges, complexityRows, handlerBoundary []string
 		switch s.language {
 		case "go":
-			// Go keeps the stdlib-AST extractor (rigorous, free).
-			funcs, types, imports, refs, callEdges, complexityRows = extractGoSymbols(bodyBuf.Bytes())
-			// Registration-boundary data for the unused_exports #504 exemption
-			// (handler value-refs + their signature types). Go-only for now.
-			if boundary := goHandlerBoundary(bodyBuf.Bytes()); len(boundary) > 0 {
-				attrs["handler_boundary"] = boundary
-			}
+			// Go keeps the stdlib-AST extractor (rigorous, free). handlerBoundary
+			// carries the unused_exports #504 registration-boundary data
+			// (Go-only; nil from the tree-sitter path).
+			funcs, types, imports, refs, callEdges, complexityRows, handlerBoundary = extractGoSymbols(bodyBuf.Bytes())
 		default:
 			// Every other wired language (Python / Java / C# / PHP / Perl /
 			// R / MATLAB / Scala + Rust / TS / JS / Ruby / Swift / Kotlin /
 			// C / C++) uses the tree-sitter extractor (#365 migrated the
 			// first eight off regex). Returns nil for unwired languages —
 			// but symbolExtractorWired gates this block.
-			funcs, types, imports, refs, callEdges, complexityRows = extractTreeSitterSymbols(s.language, bodyBuf.Bytes())
+			funcs, types, imports, refs, callEdges, complexityRows, handlerBoundary = extractTreeSitterSymbols(s.language, bodyBuf.Bytes())
 		}
 		if len(funcs) > 0 {
 			attrs["functions"] = funcs
@@ -185,6 +182,11 @@ func (s *sourceType) Attributes(ctx context.Context, fsys fs.FS, p string) (Attr
 		if len(callEdges) > 0 {
 			// Builder-internal (call graph #368); not a CEL variable.
 			attrs["call_edges"] = callEdges
+		}
+		if len(handlerBoundary) > 0 {
+			// Builder-internal (unused_exports #504 registration-boundary
+			// exemption); not a CEL variable.
+			attrs["handler_boundary"] = handlerBoundary
 		}
 		if len(complexityRows) > 0 {
 			// Builder-internal per-function rows (#364) for the complexity

--- a/internal/content/sourcetype.go
+++ b/internal/content/sourcetype.go
@@ -157,6 +157,11 @@ func (s *sourceType) Attributes(ctx context.Context, fsys fs.FS, p string) (Attr
 		case "go":
 			// Go keeps the stdlib-AST extractor (rigorous, free).
 			funcs, types, imports, refs, callEdges, complexityRows = extractGoSymbols(bodyBuf.Bytes())
+			// Registration-boundary data for the unused_exports #504 exemption
+			// (handler value-refs + their signature types). Go-only for now.
+			if boundary := goHandlerBoundary(bodyBuf.Bytes()); len(boundary) > 0 {
+				attrs["handler_boundary"] = boundary
+			}
 		default:
 			// Every other wired language (Python / Java / C# / PHP / Perl /
 			// R / MATLAB / Scala + Rust / TS / JS / Ruby / Swift / Kotlin /

--- a/internal/search/unused_exports.go
+++ b/internal/search/unused_exports.go
@@ -116,6 +116,12 @@ type UnusedExportsResult struct {
 // (kong `…Cmd`, Go test entries) is excluded, but external consumers outside
 // the walked tree, interface satisfaction, and same-name collisions can
 // still mislead — a review list, not an auto-unexport list.
+//
+// Registration-boundary exemption (#504): an exported type used as a
+// parameter / result type of a handler that is registered as a VALUE (the
+// mcp.AddTool / HandleFunc pattern) is bound to an external generic API that
+// reflects over it, so it must stay exported and is excluded — even though
+// every textual reference to it sits inside the defining package.
 func UnusedExports(ctx context.Context, opts Options, registry *content.Registry) (*UnusedExportsResult, error) {
 	root := opts.Root
 	if root == "" && len(opts.Roots) > 0 {
@@ -150,6 +156,13 @@ func UnusedExports(ctx context.Context, opts Options, registry *content.Registry
 	defs := map[string]*defInfo{}
 	refPkgs := map[string]map[string]bool{} // symbol -> set of referencing packages
 	generated := map[string]bool{}
+	// Registration-boundary data (#504): functions passed as values (handlers)
+	// and the exported types in each function's signature. A type in the
+	// signature of a registered handler is bound to an external generic API
+	// (e.g. mcp.AddTool[In, Out] infers In/Out from the handler) and must stay
+	// exported even though every textual reference sits in its own package.
+	valueRefFuncs := map[string]bool{}      // handler names passed as call-arg values
+	sigTypesByFunc := map[string][]string{} // func name -> exported signature type names
 
 	note := func(name, kind, pkg, path, lang string) {
 		d := defs[name]
@@ -216,6 +229,30 @@ func UnusedExports(ctx context.Context, opts Options, registry *content.Registry
 				refPkgs[ref][pkg] = true
 			}
 		}
+		if boundary, ok := r.Attrs.Extra["handler_boundary"].([]string); ok {
+			for _, e := range boundary {
+				switch {
+				case strings.HasPrefix(e, "v\x00"):
+					valueRefFuncs[e[2:]] = true
+				case strings.HasPrefix(e, "s\x00"):
+					if rest := e[2:]; len(rest) > 0 {
+						if i := strings.IndexByte(rest, 0); i > 0 && i < len(rest)-1 {
+							sigTypesByFunc[rest[:i]] = append(sigTypesByFunc[rest[:i]], rest[i+1:])
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// A type in the signature of a function that is registered as a value
+	// (the AddTool / HandleFunc handler pattern) is bound to an external
+	// generic API and can't be unexported — exempt it (#504).
+	boundaryExempt := map[string]bool{}
+	for fn := range valueRefFuncs {
+		for _, t := range sigTypesByFunc[fn] {
+			boundaryExempt[t] = true
+		}
 	}
 
 	for name, d := range defs {
@@ -224,6 +261,9 @@ func UnusedExports(ctx context.Context, opts Options, registry *content.Registry
 		}
 		if isReflectionDispatchedEntry(d.kind, name, d.path, d.lang) {
 			continue // kong …Cmd, go-test entries — dispatched, not statically used
+		}
+		if d.kind == "type" && boundaryExempt[name] {
+			continue // bound to an external generic registration API (#504)
 		}
 		users := refPkgs[name]
 		if len(users) == 0 {

--- a/internal/search/unused_exports_test.go
+++ b/internal/search/unused_exports_test.go
@@ -48,6 +48,49 @@ func TestUnusedExports_Python(t *testing.T) {
 	}
 }
 
+// TestUnusedExports_AddToolBoundary pins issue #504: an exported type used
+// only as the parameter / result type of a handler that is REGISTERED AS A
+// VALUE (the mcp.AddTool / HandleFunc pattern) is bound to an external generic
+// API and must NOT be reported — even though every reference to it sits in its
+// own package. A control type used only intra-package but NOT via a registered
+// handler must still be reported, proving the exemption doesn't over-apply.
+func TestUnusedExports_AddToolBoundary(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "srv"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/m\n\ngo 1.21\n")
+	// Req / Resp are the handler's signature types; Widget is the control.
+	mustWriteFile(t, filepath.Join(root, "srv", "handler.go"),
+		"package srv\n\nimport \"context\"\n\n"+
+			"type Req struct{ A int }\n"+
+			"type Resp struct{ B int }\n"+
+			"type Widget struct{ C int }\n\n"+
+			"func handle(ctx context.Context, in Req) (Resp, error) { return Resp{}, nil }\n\n"+
+			"func useWidget() Widget { return Widget{} }\n")
+	// register.go passes handle as a VALUE to a call — the AddTool pattern.
+	mustWriteFile(t, filepath.Join(root, "srv", "register.go"),
+		"package srv\n\nfunc register() { reg(handle) }\n")
+
+	res, err := search.UnusedExports(context.Background(), search.Options{Root: root, Expr: "is_source"}, contentpkg.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("UnusedExports: %v", err)
+	}
+	got := map[string]bool{}
+	for _, c := range res.Candidates {
+		got[c.Symbol] = true
+	}
+	if got["Req"] {
+		t.Errorf("Req is a registered handler's param type — must be exempt (#504): %+v", res.Candidates)
+	}
+	if got["Resp"] {
+		t.Errorf("Resp is a registered handler's result type — must be exempt (#504): %+v", res.Candidates)
+	}
+	if !got["Widget"] {
+		t.Errorf("Widget is exported, intra-only, NOT a registered-handler type — must still be a candidate: %+v", res.Candidates)
+	}
+}
+
 // TestUnusedExports_TypeScript pins Phase B keyword-visibility + file-as-
 // module: an `export`ed function used only within its own file is a
 // candidate; one imported and used from another file is not; a non-exported


### PR DESCRIPTION
Closes #504.

## Problem

Dogfooding `unused_exports` on file-search-on's own MCP-server code surfaced **~100 false positives** — every `XxxInput` / `XxxOutput` struct. They're referenced only within `internal/mcpserver`, so the package-local heuristic flags them, but they **can't be unexported**: `mcp.AddTool[In, Out]` reflects over them to generate JSON schemas, crossing an API boundary the name-based reference graph can't see (the In/Out are *inferred* from the handler signature, never written as explicit type args).

## Fix

A registration-boundary exemption — the type-level analog of the #421 callback-value handling:

- **`internal/content/source_symbols_go.go`** — `goHandlerBoundary` extracts, per Go file, (a) functions passed as call-argument **values** (handlers) and (b) the **exported types in each function's signature**, tag-encoded into one `[]string` (mirroring the `call_edges` `"\x00"` convention). Stored as the `handler_boundary` attribute (cached like the other symbol data).
- **`internal/search/unused_exports.go`** — joins them across files: a type in the signature of a function registered as a value is bound to an external generic API and is exempt from the candidate list.

Cross-file by design (handlers live in `*_tool.go`, registration in `server.go`), and general (any function passed as a value — `AddTool`, `HandleFunc`, …), not MCP-hardcoded.

## Result on this repo

| | candidates | `*Input`/`*Output` FPs |
|---|---|---|
| before | 191 | ~89 |
| after | **103** | **1** |

The lone remaining `CommonOutput` is *embedded* in the Output structs rather than named in a handler signature, so the direct-signature rule doesn't reach it — a documented residual, not a regression.

## Tests
- `TestGoHandlerBoundary` — the extractor emits the handler value-ref + its exported signature types.
- `TestUnusedExports_AddToolBoundary` — end-to-end: `Req`/`Resp` (registered handler's types) are exempt, while a control `Widget` (exported, intra-only, *not* via a registered handler) is **still** flagged — proving the exemption doesn't over-apply.

Full suite green; `golangci-lint` clean; `go fix` idempotent.

Companion issues from the same dogfooding session: #505 (interface-satisfaction), #506 (test_gaps dispatch indirection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)