### PR TITLE
fix(unused_exports): exempt first-party interface methods (#505)

### DIFF
--- a/internal/content/source_symbols_go.go
+++ b/internal/content/source_symbols_go.go
@@ -294,8 +294,13 @@ func goHandlerBoundary(f *ast.File) []string {
 			}
 			for _, m := range it.Methods.List {
 				// Method elements carry Names; embedded interfaces don't.
+				// Only exported methods matter — unused_exports judges only
+				// exported symbols — so unexported interface methods (sealed-
+				// interface markers like isNode()) are skipped.
 				for _, nm := range m.Names {
-					out = append(out, "i\x00"+nm.Name)
+					if goExportedName(nm.Name) {
+						out = append(out, "i\x00"+nm.Name)
+					}
 				}
 			}
 		}

--- a/internal/content/source_symbols_go.go
+++ b/internal/content/source_symbols_go.go
@@ -219,22 +219,26 @@ func goValueRefs(f *ast.File) []string {
 	return out
 }
 
-// goHandlerBoundary extracts the data that spares registration-bound types
-// from the unused_exports "package-local" false positive (issue #504). It
-// returns two relations tag-encoded into one []string (mirroring the
-// call_edges "\x00" convention) so they ride in a single attribute:
+// goHandlerBoundary extracts the export-pinning signals that spare symbols
+// from the unused_exports "package-local" false positive. It returns three
+// relations tag-encoded into one []string (mirroring the call_edges "\x00"
+// convention) so they ride in a single attribute:
 //
 //	"v\x00<func>"           — <func> is passed as a VALUE to a call (a handler
 //	                          registered via the AddTool / HandleFunc pattern, #421).
 //	"s\x00<func>\x00<Type>" — exported <Type> appears in <func>'s signature
 //	                          (a parameter or result type).
+//	"i\x00<Method>"         — <Method> is declared on an interface (#505).
 //
-// The aggregator (search.UnusedExports) joins them: an exported type in the
-// signature of a function that is registered as a value is bound to that
-// external generic API — e.g. mcp.AddTool[In, Out] infers In/Out from the
-// handler signature — and must stay exported, so it is exempt from the
-// unexport-candidate list even though every textual reference to it sits
-// inside the defining package.
+// The aggregator (search.UnusedExports) joins them:
+//   - #504: an exported type in the signature of a function registered as a
+//     value is bound to that external generic API — e.g. mcp.AddTool[In, Out]
+//     infers In/Out from the handler signature — and must stay exported.
+//   - #505: a method whose name is declared on a first-party interface can't
+//     be unexported without breaking interface satisfaction.
+//
+// Both are exempt from the unexport-candidate list even though every textual
+// reference sits inside the defining package.
 //
 // Only EXPORTED signature types are emitted (unused_exports only judges
 // exported symbols), which bounds the output. Takes the AST already parsed by
@@ -268,6 +272,31 @@ func goHandlerBoundary(f *ast.File) []string {
 		for _, t := range dedupeStrings(sigTypes) {
 			if goExportedName(t) {
 				out = append(out, "s\x00"+fn.Name.Name+"\x00"+t)
+			}
+		}
+	}
+	// Interface method names (#505): a method that satisfies a first-party
+	// interface can't be unexported without breaking the interface, so the
+	// aggregator exempts methods whose name is declared on any interface.
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			it, ok := ts.Type.(*ast.InterfaceType)
+			if !ok || it.Methods == nil {
+				continue
+			}
+			for _, m := range it.Methods.List {
+				// Method elements carry Names; embedded interfaces don't.
+				for _, nm := range m.Names {
+					out = append(out, "i\x00"+nm.Name)
+				}
 			}
 		}
 	}

--- a/internal/content/source_symbols_go_test.go
+++ b/internal/content/source_symbols_go_test.go
@@ -142,6 +142,10 @@ import "context"
 type Req struct{ A int }
 type Resp struct{ B int }
 
+type Doer interface {
+	Do(x int) error
+}
+
 func register(s any) { AddTool(s, handle) }
 
 func handle(ctx context.Context, in Req) (Resp, error) { return Resp{}, nil }
@@ -155,7 +159,12 @@ func handle(ctx context.Context, in Req) (Resp, error) { return Resp{}, nil }
 	for _, e := range got {
 		have[e] = true
 	}
-	for _, want := range []string{"v\x00handle", "s\x00handle\x00Req", "s\x00handle\x00Resp"} {
+	for _, want := range []string{
+		"v\x00handle",          // handle passed as a value (#504)
+		"s\x00handle\x00Req",   // exported param type
+		"s\x00handle\x00Resp",  // exported result type
+		"i\x00Do",              // interface method (#505)
+	} {
 		if !have[want] {
 			t.Errorf("goHandlerBoundary missing %q; got %v", want, got)
 		}

--- a/internal/search/unused_exports.go
+++ b/internal/search/unused_exports.go
@@ -122,6 +122,10 @@ type UnusedExportsResult struct {
 // mcp.AddTool / HandleFunc pattern) is bound to an external generic API that
 // reflects over it, so it must stay exported and is excluded — even though
 // every textual reference to it sits inside the defining package.
+//
+// Interface-satisfaction exemption (#505): a method whose name is declared on
+// a first-party interface can't be unexported without breaking the interface,
+// so such methods are excluded too (name-based; same caveats).
 func UnusedExports(ctx context.Context, opts Options, registry *content.Registry) (*UnusedExportsResult, error) {
 	root := opts.Root
 	if root == "" && len(opts.Roots) > 0 {
@@ -163,6 +167,7 @@ func UnusedExports(ctx context.Context, opts Options, registry *content.Registry
 	// exported even though every textual reference sits in its own package.
 	valueRefFuncs := map[string]bool{}      // handler names passed as call-arg values
 	sigTypesByFunc := map[string][]string{} // func name -> exported signature type names
+	interfaceMethods := map[string]bool{}   // method names declared on any interface (#505)
 
 	note := func(name, kind, pkg, path, lang string) {
 		d := defs[name]
@@ -240,6 +245,8 @@ func UnusedExports(ctx context.Context, opts Options, registry *content.Registry
 							sigTypesByFunc[rest[:i]] = append(sigTypesByFunc[rest[:i]], rest[i+1:])
 						}
 					}
+				case strings.HasPrefix(e, "i\x00"):
+					interfaceMethods[e[2:]] = true
 				}
 			}
 		}
@@ -264,6 +271,9 @@ func UnusedExports(ctx context.Context, opts Options, registry *content.Registry
 		}
 		if d.kind == "type" && boundaryExempt[name] {
 			continue // bound to an external generic registration API (#504)
+		}
+		if d.kind == "function" && interfaceMethods[name] {
+			continue // satisfies a first-party interface — can't unexport (#505)
 		}
 		users := refPkgs[name]
 		if len(users) == 0 {

--- a/internal/search/unused_exports_test.go
+++ b/internal/search/unused_exports_test.go
@@ -91,6 +91,43 @@ func TestUnusedExports_AddToolBoundary(t *testing.T) {
 	}
 }
 
+// TestUnusedExports_InterfaceMethod pins issue #505: a method whose name is
+// declared on a first-party interface can't be unexported without breaking
+// the interface, so it must NOT be reported — even when referenced only
+// intra-package. A control exported method NOT on any interface, referenced
+// only intra-package, must still be reported (the exemption doesn't over-apply).
+func TestUnusedExports_InterfaceMethod(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/m\n\ngo 1.21\n")
+	mustWriteFile(t, filepath.Join(root, "pkg", "iface.go"),
+		"package pkg\n\ntype Doer interface { Run() }\n")
+	mustWriteFile(t, filepath.Join(root, "pkg", "impl.go"),
+		"package pkg\n\ntype T struct{}\n\n"+
+			"func (T) Run() {}\n"+        // satisfies Doer.Run — must NOT be flagged
+			"func (T) HelperOnly() {}\n") // exported, not on any interface — control
+	// Reference both intra-package so they're candidates (not dead_code).
+	mustWriteFile(t, filepath.Join(root, "pkg", "use.go"),
+		"package pkg\n\nfunc use() { var t T; t.Run(); t.HelperOnly() }\n")
+
+	res, err := search.UnusedExports(context.Background(), search.Options{Root: root, Expr: "is_source"}, contentpkg.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("UnusedExports: %v", err)
+	}
+	got := map[string]bool{}
+	for _, c := range res.Candidates {
+		got[c.Symbol] = true
+	}
+	if got["Run"] {
+		t.Errorf("Run satisfies the Doer interface — must be exempt (#505): %+v", res.Candidates)
+	}
+	if !got["HelperOnly"] {
+		t.Errorf("HelperOnly is exported, intra-only, NOT an interface method — must still be a candidate: %+v", res.Candidates)
+	}
+}
+
 // TestUnusedExports_TypeScript pins Phase B keyword-visibility + file-as-
 // module: an `export`ed function used only within its own file is a
 // candidate; one imported and used from another file is not; a non-exported


### PR DESCRIPTION
Closes #505. Follow-up to #504 — second dogfooding false-positive class.

## Problem

Methods that satisfy a **first-party interface** were reported as unexport candidates when referenced only within their defining package — but they can't be unexported without breaking the interface. On this repo: the `content.ContentType` family (`Attributes`, `MagicBytes`, `Name`, `Extensions`, `Filenames`, `MatchMagic`, `MatchesContent`, `DiscriminatorExtensions`).

## Fix

`goHandlerBoundary` now also emits `"i\x00<Method>"` for every method declared on an interface type — a third tag alongside the #504 `"v"`/`"s"` signals, riding the same single `handler_boundary` attribute. `UnusedExports` exempts functions whose name matches a known first-party interface method.

## Result on this repo: 103 → 98

Precise, not over-applied:
- ✅ exempts the `ContentType`-family interface methods.
- ✅ **still flags** genuinely non-interface intra-package exported methods (`monitor.Serve` / `Listen` / `Ready` / `Publish` / `Subscribe` / `AddListener`) — those are legitimate review candidates, not interface methods.
- `io.ReaderAt`'s `ReadAt` remains (stdlib-interface satisfaction is explicitly out of scope per the issue — first-party only).

## Tests
- `TestGoHandlerBoundary` — asserts the `"i\x00Do"` tag for an interface decl.
- `TestUnusedExports_InterfaceMethod` — `Run` (satisfies `Doer`) is exempt; a control `HelperOnly` (exported, intra-only, not on any interface) is **still** flagged.

Full suite green; `golangci-lint` clean; `go fix` idempotent.

Remaining dogfooding issue: #506 (test_gaps dispatch indirection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)