### PR TITLE
fix(test_gaps): exclude value-registered handlers (#506)

### DIFF
--- a/internal/search/codegraph.go
+++ b/internal/search/codegraph.go
@@ -123,6 +123,14 @@ type CodeGraph struct {
 	// generated: set of file paths the detector flagged is_generated_code.
 	// Drives the generated-dominance hint (#430).
 	generated map[string]bool
+	// dispatchTargets: function names registered as a VALUE — the AddTool /
+	// HandleFunc handler pattern (the #504 "v" tag). A test exercises them
+	// through the tool, never by name, so the name-based "untested" signal is
+	// a guaranteed false positive; TestGaps excludes them (#506). Interface
+	// methods are deliberately NOT included — they're usually name-referenced
+	// in tests already, and excluding them from the denominator would flip
+	// files to fully_untested.
+	dispatchTargets map[string]bool
 }
 
 // GeneratedHint returns a nudge toward the !is_generated_code filter when
@@ -172,14 +180,15 @@ func BuildCodeGraph(ctx context.Context, opts Options, registry *content.Registr
 	results, walkErr := Walk(ctx, opts, registry)
 
 	g := &CodeGraph{
-		importedBy:   map[string]map[string]string{},
-		definedIn:    map[string][]symbolEntry{},
-		referencedBy: map[string]map[string]string{},
-		callsByName:  map[string]map[string]bool{},
-		fanOut:       map[string]fileFanOut{},
-		languages:    map[string]int64{},
-		testFiles:    map[string]bool{},
-		generated:    map[string]bool{},
+		importedBy:      map[string]map[string]string{},
+		definedIn:       map[string][]symbolEntry{},
+		referencedBy:    map[string]map[string]string{},
+		callsByName:     map[string]map[string]bool{},
+		fanOut:          map[string]fileFanOut{},
+		languages:       map[string]int64{},
+		testFiles:       map[string]bool{},
+		dispatchTargets: map[string]bool{},
+		generated:       map[string]bool{},
 	}
 	g.TotalFiles = int64(len(results))
 
@@ -270,6 +279,17 @@ func BuildCodeGraph(ctx context.Context, opts Options, registry *content.Registr
 					g.callsByName[caller] = set
 				}
 				set[callee] = true
+			}
+		}
+		if boundary, ok := r.Attrs.Extra["handler_boundary"].([]string); ok {
+			for _, e := range boundary {
+				// Only value-registered handlers (#504 "v" tag). NOT interface
+				// methods ("i"): an interface method is often name-referenced
+				// in a test (so already counted tested), and excluding it from
+				// the denominator perversely flips files to fully_untested.
+				if strings.HasPrefix(e, "v\x00") {
+					g.dispatchTargets[e[2:]] = true
+				}
 			}
 		}
 	}
@@ -699,12 +719,17 @@ type TestGap struct {
 // Restricted to languages with reference extraction (refExtractionLangs);
 // functions defined in test files are themselves excluded.
 //
+// Functions registered as a value (the AddTool / HandleFunc handler pattern)
+// are excluded (#506): a test drives them through the tool, never by name, so
+// "not referenced from a test" is a guaranteed false positive for them.
+//
 // HEURISTIC, name-based and DIRECT-reference only: a function exercised only
-// transitively (test → A → B, with B never named in a test) reads as
-// untested, and same-name collisions / reflection / table-driven dispatch
-// can mislead either way. Present as candidates — pair with a real coverage
-// profile for precision. Mirrors DeadCode's machinery (defined-but-not-
-// referenced), filtered to "not referenced *from a test*".
+// transitively (test → A → B, with B never named in a test) STILL reads as
+// untested — that class isn't statically resolvable here, so pair with a real
+// coverage profile (the coverage_gaps tool) for precision. Same-name
+// collisions / reflection / table-driven dispatch can mislead either way.
+// Mirrors DeadCode's machinery (defined-but-not-referenced), filtered to
+// "not referenced *from a test*".
 func (g *CodeGraph) TestGaps() []TestGap {
 	type fileInfo struct {
 		lang  string
@@ -728,7 +753,17 @@ func (g *CodeGraph) TestGaps() []TestGap {
 	out := make([]TestGap, 0, len(byFile))
 	for path, fi := range byFile {
 		var untested []string
+		assessable := 0
 		for _, name := range fi.funcs {
+			if g.dispatchTargets[name] {
+				// Reached only via indirect dispatch (registered handler /
+				// interface method) — a test exercises it through the tool or
+				// interface, never by name, so the name-based "untested"
+				// signal is meaningless here. Excluded from both the gap list
+				// and the function count so FullyUntested stays accurate (#506).
+				continue
+			}
+			assessable++
 			if !g.referencedFromTest(name) {
 				untested = append(untested, name)
 			}
@@ -740,10 +775,10 @@ func (g *CodeGraph) TestGaps() []TestGap {
 		out = append(out, TestGap{
 			Path:              path,
 			Language:          fi.lang,
-			FunctionCount:     len(fi.funcs),
+			FunctionCount:     assessable,
 			UntestedCount:     len(untested),
 			UntestedFunctions: untested,
-			FullyUntested:     len(untested) == len(fi.funcs),
+			FullyUntested:     len(untested) == assessable,
 		})
 	}
 

--- a/internal/search/test_gaps_test.go
+++ b/internal/search/test_gaps_test.go
@@ -45,3 +45,37 @@ func TestCodeGraph_TestGaps(t *testing.T) {
 		t.Errorf("a *_test.go file must not be reported as a test gap")
 	}
 }
+
+// TestCodeGraph_TestGaps_ExcludesRegisteredHandlers pins issue #506: a
+// function registered as a VALUE (the AddTool / HandleFunc handler pattern) is
+// exercised by tests through the tool, never by name, so the name-based
+// "untested" signal is a guaranteed false positive — it must be excluded. A
+// normal untested function in the same file must still be reported, and must
+// not be dragged into a false fully_untested by the exclusion accounting.
+func TestCodeGraph_TestGaps_ExcludesRegisteredHandlers(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "handler.go"),
+		"package p\n\nfunc searchHandler() {}\nfunc plainHelper() {}\n")
+	// register.go passes searchHandler as a value — the handler pattern.
+	mustWriteFile(t, filepath.Join(dir, "register.go"),
+		"package p\n\nfunc reg() { AddTool(searchHandler) }\n")
+
+	g := mustBuildGraph(t, dir)
+	byPath := map[string]search.TestGap{}
+	for _, gp := range g.TestGaps() {
+		byPath[filepath.Base(gp.Path)] = gp
+	}
+
+	gap, ok := byPath["handler.go"]
+	if !ok {
+		t.Fatalf("handler.go should still be a gap (plainHelper is untested): %+v", byPath)
+	}
+	for _, f := range gap.UntestedFunctions {
+		if f == "searchHandler" {
+			t.Errorf("searchHandler is a value-registered handler — must be excluded (#506): %v", gap.UntestedFunctions)
+		}
+	}
+	if gap.FunctionCount != 1 || gap.UntestedCount != 1 || len(gap.UntestedFunctions) != 1 || gap.UntestedFunctions[0] != "plainHelper" {
+		t.Errorf("handler.go gap = %+v, want only plainHelper (handler excluded from count + list)", gap)
+	}
+}


### PR DESCRIPTION
Closes #506. Final issue of the dogfooding trilogy (#504, #505, #506).

## Problem

`test_gaps` reported MCP tool handlers (`searchHandler`, …) as untested: tests drive them via `client.CallTool("name")`, so the handler **function name never appears in a `*_test` file**. 35 of the repo's 73 fully-untested files were these handlers.

## Fix

Handlers are registered as values — already captured by the #504 `handler_boundary` `"v"` tag. `BuildCodeGraph` collects those into a `dispatchTargets` set; `TestGaps` excludes them from both the gap list and the assessable function count (so `fully_untested` stays accurate).

**Scoped to value-registered handlers only — not interface methods.** An earlier draft also excluded interface methods (`"i"` tag) and the repo's fully-untested count went *up* 73→80: an interface method that's name-referenced in a test counts as "tested", and removing it from the denominator flips files to `fully_untested`. Restricting to `"v"` gives the clean win.

## Result on this repo (go, non-generated)

| | fully-untested | mcpserver | content |
|---|---|---|---|
| before | 73 | 35 | 30 |
| after | **44** | **5** | 30 |

The 30 mcpserver-handler FPs drop out; content's 30 are **transitive-testing** gaps (helpers reached through tested callers, never named in a test) — not dispatch, not fixable here. The doc now points to `coverage_gaps` for that class (the precise, profile-based complement), addressing the issue's option (b).

## Test
`TestCodeGraph_TestGaps_ExcludesRegisteredHandlers` — a registered handler is excluded while a normal untested function in the same file is still reported (and not dragged into a false `fully_untested`).

Full suite green; `golangci-lint` clean; `go fix` idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)