### PR TITLE
fix(unused_exports): treat external _test package refs as cross-boundary (#511)

### DIFF
--- a/internal/content/source_symbols_go.go
+++ b/internal/content/source_symbols_go.go
@@ -229,6 +229,9 @@ func goValueRefs(f *ast.File) []string {
 //	"s\x00<func>\x00<Type>" — exported <Type> appears in <func>'s signature
 //	                          (a parameter or result type).
 //	"i\x00<Method>"         — <Method> is declared on an interface (#505).
+//	"p\x00external_test"    — this file is an external test package
+//	                          (`package <pkg>_test`); its references are
+//	                          cross-boundary (#511).
 //
 // The aggregator (search.UnusedExports) joins them:
 //   - #504: an exported type in the signature of a function registered as a
@@ -250,6 +253,14 @@ func goHandlerBoundary(f *ast.File) []string {
 		return nil
 	}
 	var out []string
+	// External test package marker (#511): a `package <pkg>_test` file
+	// IMPORTS the package under test, so a reference it makes to an exported
+	// symbol is cross-boundary — exactly why that symbol is exported. The
+	// aggregator attributes such references under a distinct package key so
+	// the symbol isn't reported as a unexport candidate.
+	if f.Name != nil && strings.HasSuffix(f.Name.Name, "_test") {
+		out = append(out, "p\x00external_test")
+	}
 	for _, name := range goValueRefs(f) {
 		out = append(out, "v\x00"+name)
 	}

--- a/internal/content/source_symbols_go_test.go
+++ b/internal/content/source_symbols_go_test.go
@@ -172,6 +172,32 @@ func handle(ctx context.Context, in Req) (Resp, error) { return Resp{}, nil }
 	if have["s\x00register\x00Req"] {
 		t.Errorf("register has no Req in its signature; unexpected entry: %v", got)
 	}
+	// srv is not an external test package — no "p" marker.
+	if have["p\x00external_test"] {
+		t.Errorf("non-test package srv should not carry the external_test marker: %v", got)
+	}
+}
+
+// TestGoHandlerBoundary_ExternalTestMarker pins issue #511: a file whose
+// package clause ends in _test (an external test package) emits the
+// external_test marker so unused_exports attributes its references as
+// cross-boundary.
+func TestGoHandlerBoundary_ExternalTestMarker(t *testing.T) {
+	ext := "package srv_test\n\nimport \"testing\"\n\nfunc TestX(t *testing.T) {}\n"
+	f, err := parser.ParseFile(token.NewFileSet(), "", ext, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := goHandlerBoundary(f)
+	found := false
+	for _, e := range got {
+		if e == "p\x00external_test" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("external test package srv_test should emit the external_test marker; got %v", got)
+	}
 }
 
 // TestExtractGoSymbols_ValueRefs pins issue #421: a function/method used as

--- a/internal/search/unused_exports.go
+++ b/internal/search/unused_exports.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -192,6 +193,16 @@ func UnusedExports(ctx context.Context, opts Options, registry *content.Registry
 		if !ok {
 			continue
 		}
+		// External test packages (`package <pkg>_test`) import the package
+		// under test, so their references are cross-boundary — attribute defs
+		// AND refs from such a file under a distinct key so a symbol they use
+		// isn't seen as package-local (#511). Marker emitted by the Go
+		// extractor in handler_boundary.
+		boundary, _ := r.Attrs.Extra["handler_boundary"].([]string)
+		effPkg := pkg
+		if slices.Contains(boundary, "p\x00external_test") {
+			effPkg = pkg + "\x00test"
+		}
 		if gen, _ := r.Attrs.Extra["is_generated_code"].(bool); gen {
 			generated[r.Path] = true
 		}
@@ -215,14 +226,14 @@ func UnusedExports(ctx context.Context, opts Options, registry *content.Registry
 		if funcs, ok := r.Attrs.Extra["functions"].([]string); ok {
 			for _, fn := range funcs {
 				if isExported(fn) {
-					note(fn, "function", pkg, r.Path, lang)
+					note(fn, "function", effPkg, r.Path, lang)
 				}
 			}
 		}
 		if types, ok := r.Attrs.Extra["type_names"].([]string); ok {
 			for _, t := range types {
 				if isExported(t) {
-					note(t, "type", pkg, r.Path, lang)
+					note(t, "type", effPkg, r.Path, lang)
 				}
 			}
 		}
@@ -231,23 +242,21 @@ func UnusedExports(ctx context.Context, opts Options, registry *content.Registry
 				if refPkgs[ref] == nil {
 					refPkgs[ref] = map[string]bool{}
 				}
-				refPkgs[ref][pkg] = true
+				refPkgs[ref][effPkg] = true
 			}
 		}
-		if boundary, ok := r.Attrs.Extra["handler_boundary"].([]string); ok {
-			for _, e := range boundary {
-				switch {
-				case strings.HasPrefix(e, "v\x00"):
-					valueRefFuncs[e[2:]] = true
-				case strings.HasPrefix(e, "s\x00"):
-					if rest := e[2:]; len(rest) > 0 {
-						if i := strings.IndexByte(rest, 0); i > 0 && i < len(rest)-1 {
-							sigTypesByFunc[rest[:i]] = append(sigTypesByFunc[rest[:i]], rest[i+1:])
-						}
+		for _, e := range boundary {
+			switch {
+			case strings.HasPrefix(e, "v\x00"):
+				valueRefFuncs[e[2:]] = true
+			case strings.HasPrefix(e, "s\x00"):
+				if rest := e[2:]; len(rest) > 0 {
+					if i := strings.IndexByte(rest, 0); i > 0 && i < len(rest)-1 {
+						sigTypesByFunc[rest[:i]] = append(sigTypesByFunc[rest[:i]], rest[i+1:])
 					}
-				case strings.HasPrefix(e, "i\x00"):
-					interfaceMethods[e[2:]] = true
 				}
+			case strings.HasPrefix(e, "i\x00"):
+				interfaceMethods[e[2:]] = true
 			}
 		}
 	}

--- a/internal/search/unused_exports_test.go
+++ b/internal/search/unused_exports_test.go
@@ -128,6 +128,42 @@ func TestUnusedExports_InterfaceMethod(t *testing.T) {
 	}
 }
 
+// TestUnusedExports_ExternalTestPackage pins issue #511: a symbol referenced
+// from an EXTERNAL test package (`package <pkg>_test`) is exported precisely so
+// that test can import + call it — a cross-boundary use, so it must NOT be
+// reported. A symbol referenced only from an INTERNAL test (`package <pkg>`)
+// stays flagged (an internal test doesn't justify keeping it exported).
+func TestUnusedExports_ExternalTestPackage(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/m\n\ngo 1.21\n")
+	mustWriteFile(t, filepath.Join(root, "pkg", "lib.go"),
+		"package pkg\n\nfunc ExternalOnly() {}\nfunc InternalOnly() {}\n")
+	// External test package — imports the package and calls ExternalOnly.
+	mustWriteFile(t, filepath.Join(root, "pkg", "ext_test.go"),
+		"package pkg_test\n\nimport (\n\t\"testing\"\n\t\"example.com/m/pkg\"\n)\n\nfunc TestExt(t *testing.T) { pkg.ExternalOnly() }\n")
+	// Internal test package — calls InternalOnly from inside the package.
+	mustWriteFile(t, filepath.Join(root, "pkg", "int_test.go"),
+		"package pkg\n\nimport \"testing\"\n\nfunc TestInt(t *testing.T) { InternalOnly() }\n")
+
+	res, err := search.UnusedExports(context.Background(), search.Options{Root: root, Expr: "is_source"}, contentpkg.DefaultRegistry())
+	if err != nil {
+		t.Fatalf("UnusedExports: %v", err)
+	}
+	got := map[string]bool{}
+	for _, c := range res.Candidates {
+		got[c.Symbol] = true
+	}
+	if got["ExternalOnly"] {
+		t.Errorf("ExternalOnly is used from an external test package — must be exempt (#511): %+v", res.Candidates)
+	}
+	if !got["InternalOnly"] {
+		t.Errorf("InternalOnly is used only from an internal test — must stay flagged: %+v", res.Candidates)
+	}
+}
+
 // TestUnusedExports_TypeScript pins Phase B keyword-visibility + file-as-
 // module: an `export`ed function used only within its own file is a
 // candidate; one imported and used from another file is not; a non-exported


### PR DESCRIPTION
Closes #511. Fourth dogfooding false-positive class (after #504 / #505).

## Problem

Symbols exported **solely so an external `foo_test` package can call them** — `celexpr.Levenshtein` / `Soundex` / `Ngrams` / `NgramSimilarity` / `PointInPolygon`, etc. (CLAUDE.md mandates exporting CEL impls for unit-testability) — were flagged as unexport candidates. The `<pkg>_test` file lives in the same directory, so its reference resolved to the defining package key and read as intra-package.

## Fix

A reference from an external test package is genuinely cross-boundary — the test *imports* the package, which is exactly why the symbol is exported. The Go extractor emits a `"p\x00external_test"` marker in `handler_boundary` for files whose package clause ends in `_test`; `UnusedExports` attributes that file's defs + refs under a distinct package key (`pkg + "\x00test"`).

**Scoped to external test packages only** — a symbol used from an *internal* test (`package <pkg>`) stays flagged (an internal test doesn't justify export; it could be unexported + lowercased).

## Result on this repo (`is_source`, test-inclusive)

unused_exports candidates **58 → 48**. The fuzzy-function exports (`Levenshtein`, `Soundex`, `PointInPolygon`, `Ngrams`, `NgramSimilarity`) drop out; internally-tested symbols (`HasSecrets`, …) correctly stay flagged.

## Tests
- `TestGoHandlerBoundary_ExternalTestMarker` — `package srv_test` emits the marker; `package srv` does not.
- `TestUnusedExports_ExternalTestPackage` — `ExternalOnly` (used from `pkg_test`) is exempt; `InternalOnly` (used from an internal `pkg` test) stays flagged.

Full suite green; `golangci-lint` clean; `go fix` idempotent (pre-applied the `slices.Contains` modernizer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)