### PR TITLE
feat(action): Marketplace review-gate GitHub Action

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -13,6 +13,8 @@ A release publishes to three independent targets in one shot. Pushing a tag matc
 
 This skill encodes the pre-flight, the tag-and-push, the verification, and the rollback. Tag pushes are public and hard to reverse — confirm version with the user before pushing if there's any ambiguity.
 
+> **GitHub Marketplace action.** The repo-root `action.yml` (a composite "review gate" action) is published to the Marketplace. GoReleaser creates releases via the API and **cannot** tick the Marketplace checkbox, so this is a **one-time manual step** done once: on a published release, click *Edit*, check **"Publish this Action to the GitHub Marketplace"**, confirm "Everything looks good!", pick categories (**Code quality** + **Code review**), and save. After the first publish, every subsequent `v*` release automatically becomes a new Marketplace version — no per-release action needed. The action downloads the release binary matching its ref, so the action version tracks the CLI version automatically; just keep `action.yml`'s example version references roughly current.
+
 ## Quick start
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -639,6 +639,47 @@ For HTTP-based clients, point at `http://<host>:<port>/` after starting the serv
 
 Built on [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk).
 
+## GitHub Action
+
+`file-search-on` ships a composite GitHub Action that runs the [`review`](#usage) gate on
+pull requests and uploads findings to **Code Scanning** as SARIF, so over-complexity and
+dead-code show up as inline annotations on the diff.
+
+```yaml
+# .github/workflows/review.yml
+name: review
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+  security-events: write   # required for SARIF upload (Code Scanning)
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0     # required — the PR gate needs the merge base
+      - uses: richardwooding/file-search-on@v0.115.0
+        with:
+          base: origin/${{ github.base_ref }}
+          max-complexity: "15"
+          max-cognitive: "15"
+```
+
+The action downloads the matching release binary and runs it on the runner (the published
+OCI image can't run `review`, which shells out to `git`). The job fails on a `fail` verdict;
+set `gate: false` for report-only mode (findings still upload as annotations).
+
+Key inputs: `base`, `max-complexity`, `max-cognitive`, `skip-dead-code`, `strict`, `expr`,
+`exclude`, `prune-build-artefacts`, `timeout`, `version` (which release to use; defaults to
+the action ref or `latest`), `upload-sarif`, `gate`. Outputs: `verdict`, `fail-count`,
+`warn-count`, `sarif-file`. See [`action.yml`](action.yml) for the full list and
+[`examples/ci-review-gate.md`](examples/ci-review-gate.md) for more recipes.
+
+> Supported runners: `ubuntu-*` and `macos-*`. Windows is not yet supported.
+
 ## Monitoring dashboard
 
 Both long-running modes (`mcp` and `watch`) expose a read-only monitoring dashboard. Since v0.65.0 it's **on by default** on a dynamic OS-assigned localhost port — many concurrent stdio agents each get their own dashboard without colliding. The server binds **127.0.0.1 only** (the host part of any address is ignored — only the port is used), needs no auth, and adds no dependencies — the UI is a single embedded page that polls a small JSON API.

--- a/action.yml
+++ b/action.yml
@@ -185,11 +185,18 @@ runs:
         fail_count=$(jq '[.runs[0].results[]? | select(.level=="error")] | length' "$SARIF_FILE" 2>/dev/null || echo 0)
         warn_count=$(jq '[.runs[0].results[]? | select(.level=="warning")] | length' "$SARIF_FILE" 2>/dev/null || echo 0)
 
+        # Derive the verdict from the finding counts (matching the CLI's own
+        # logic: any fail -> fail, else any warn -> warn, else pass), so a
+        # warn verdict is reported even when --strict is off and the binary
+        # exits 0. Gating itself is left to the exit code (see the gate step):
+        # the binary already exits non-zero on fail OR strict+warn.
         case "$ec" in
-          0)   verdict=pass ;;
-          1)   if [ "$INPUT_STRICT" = "true" ] && [ "$fail_count" = "0" ]; then verdict=warn; else verdict=fail; fi ;;
           124) verdict=timeout ;;
           130) verdict=interrupted ;;
+          0)   if [ "${warn_count:-0}" -gt 0 ] 2>/dev/null; then verdict=warn; else verdict=pass; fi ;;
+          1)   if [ "${fail_count:-0}" -gt 0 ] 2>/dev/null; then verdict=fail
+               elif [ "${warn_count:-0}" -gt 0 ] 2>/dev/null; then verdict=warn
+               else verdict=fail; fi ;;  # ec=1 but counts unknown (jq failed) -> fail, safe
           *)   verdict=fail ;;
         esac
 
@@ -214,12 +221,16 @@ runs:
       shell: bash
       env:
         VERDICT: ${{ steps.review.outputs.verdict }}
+        EC: ${{ steps.review.outputs.exit_code }}
       run: |
-        case "$VERDICT" in
-          fail|timeout|interrupted)
-            echo "::error::file-search-on review verdict: $VERDICT"
-            exit 1 ;;
-          *)
+        # Defer to the binary's exit code, which already encodes the full
+        # gating decision: 0 = pass, 1 = fail OR (strict & warn), 124/130 =
+        # timeout/interrupted. This honours --strict without re-deriving it.
+        case "$EC" in
+          0)
             echo "file-search-on review verdict: $VERDICT"
             exit 0 ;;
+          *)
+            echo "::error::file-search-on review verdict: $VERDICT (exit $EC)"
+            exit 1 ;;
         esac

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,225 @@
+# GitHub Marketplace action: a diff-scoped code review gate.
+#
+# Wraps `file-search-on review` — resolve the files changed in the git diff,
+# run complexity / cognitive-complexity / dead-code scoped to them, emit a
+# pass/warn/fail verdict, and surface findings as SARIF for Code Scanning.
+#
+# This is a COMPOSITE action (not a Docker action) on purpose: `review` shells
+# out to `git`, and the published OCI image's base (chainguard/static) has no
+# git/shell. So the binary is downloaded from the matching GitHub Release and
+# run on the runner host, where git + the checkout already exist.
+#
+# Requirements in the consuming workflow:
+#   - actions/checkout with `fetch-depth: 0` (the PR gate needs the merge base).
+#   - `permissions: security-events: write` when upload-sarif is true (default).
+# Supported runners: ubuntu-* and macos-* (Windows is not yet supported).
+name: "file-search-on review gate"
+description: "Diff-scoped code review gate (complexity, cognitive complexity, dead code) with SARIF output for Code Scanning."
+author: "Richard Wooding"
+branding:
+  icon: git-pull-request
+  color: blue
+
+inputs:
+  directory:
+    description: "Repository directory to review (git working dir & walk root)."
+    default: "."
+  base:
+    description: "Git ref to diff against. Empty reviews uncommitted changes vs HEAD; on pull_request events it defaults to the PR base (origin/<base_ref>). A ref like origin/main reviews <base>...HEAD."
+    default: ""
+  expr:
+    description: "CEL pre-filter for which files enter the graph. Defaults to is_source when empty."
+    default: ""
+  max-complexity:
+    description: "Cyclomatic-complexity ceiling for a function in a changed file; above it is a fail-level finding."
+    default: "15"
+  max-cognitive:
+    description: "Cognitive-complexity ceiling (SonarSource, nesting-weighted) for a function in a changed file; above it is a fail-level finding."
+    default: "15"
+  skip-dead-code:
+    description: "Skip the dead-code check (it adds a second graph pass)."
+    default: "false"
+  strict:
+    description: "Treat warn-level findings as failures for the verdict / exit code."
+    default: "false"
+  exclude:
+    description: "Newline-separated basename globs to prune from the walk."
+    default: ""
+  prune-build-artefacts:
+    description: "Prune canonical build-artefact dirs (vendor / node_modules / target / …)."
+    default: "false"
+  respect-gitignore:
+    description: "Parse a .gitignore at the walk root and skip matching paths."
+    default: "false"
+  timeout:
+    description: "Maximum duration (Go duration, e.g. 5m). On expiry the partial verdict is reported and the gate fails."
+    default: ""
+  version:
+    description: "file-search-on release to use. Empty = the action ref when it is a vX.Y.Z tag, else the latest release."
+    default: ""
+  upload-sarif:
+    description: "Upload the SARIF report to GitHub Code Scanning."
+    default: "true"
+  sarif-file:
+    description: "Path to write the SARIF report."
+    default: "file-search-on-review.sarif"
+  gate:
+    description: "Fail the action on a fail (or timeout) verdict. Set false to report-only — findings still upload as annotations."
+    default: "true"
+
+outputs:
+  verdict:
+    description: "pass | warn | fail | timeout | interrupted."
+    value: "${{ steps.review.outputs.verdict }}"
+  fail-count:
+    description: "Number of fail-level findings."
+    value: "${{ steps.review.outputs.fail_count }}"
+  warn-count:
+    description: "Number of warn-level findings."
+    value: "${{ steps.review.outputs.warn_count }}"
+  sarif-file:
+    description: "Path to the generated SARIF report."
+    value: "${{ inputs.sarif-file }}"
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        ACTION_REF: ${{ github.action_ref }}
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        # Resolve the release tag.
+        TAG="$INPUT_VERSION"
+        if [ -z "$TAG" ]; then
+          if printf '%s' "$ACTION_REF" | grep -Eq '^v[0-9]'; then
+            TAG="$ACTION_REF"
+          else
+            TAG="latest"
+          fi
+        fi
+
+        # Map runner OS/arch to the goreleaser archive tokens.
+        case "$RUNNER_OS" in
+          Linux)  OS=linux  ;;
+          macOS)  OS=darwin ;;
+          *) echo "::error::file-search-on review gate supports ubuntu-* and macos-* runners only (got RUNNER_OS=$RUNNER_OS)."; exit 1 ;;
+        esac
+        case "$RUNNER_ARCH" in
+          X64)   ARCH=amd64 ;;
+          ARM64) ARCH=arm64 ;;
+          *) echo "::error::Unsupported RUNNER_ARCH=$RUNNER_ARCH."; exit 1 ;;
+        esac
+
+        DEST="$RUNNER_TEMP/file-search-on"
+        mkdir -p "$DEST"
+
+        # Resolve the concrete tag for `latest` so we can name the asset
+        # (archive filenames embed the version, which /latest/ doesn't expose).
+        if [ "$TAG" = "latest" ]; then
+          TAG=$(gh release view --repo richardwooding/file-search-on --json tagName -q .tagName)
+        fi
+        VER="${TAG#v}"
+        ASSET="file-search-on_${VER}_${OS}_${ARCH}.tar.gz"
+
+        echo "Downloading $ASSET (tag $TAG)…"
+        gh release download "$TAG" --repo richardwooding/file-search-on --pattern "$ASSET" --dir "$DEST"
+        tar -xzf "$DEST/$ASSET" -C "$DEST"
+        chmod +x "$DEST/file-search-on"
+        echo "$DEST" >> "$GITHUB_PATH"
+        "$DEST/file-search-on" --version || true
+
+    - id: review
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_REF: ${{ github.base_ref }}
+        INPUT_DIR: ${{ inputs.directory }}
+        INPUT_BASE: ${{ inputs.base }}
+        INPUT_EXPR: ${{ inputs.expr }}
+        INPUT_MAX_COMPLEXITY: ${{ inputs.max-complexity }}
+        INPUT_MAX_COGNITIVE: ${{ inputs.max-cognitive }}
+        INPUT_SKIP_DEAD_CODE: ${{ inputs.skip-dead-code }}
+        INPUT_STRICT: ${{ inputs.strict }}
+        INPUT_EXCLUDE: ${{ inputs.exclude }}
+        INPUT_PRUNE: ${{ inputs.prune-build-artefacts }}
+        INPUT_RESPECT_GITIGNORE: ${{ inputs.respect-gitignore }}
+        INPUT_TIMEOUT: ${{ inputs.timeout }}
+        SARIF_FILE: ${{ inputs.sarif-file }}
+      run: |
+        set -uo pipefail
+
+        # Resolve the base ref: explicit input wins; else on a PR fetch and use
+        # the PR base; else empty (uncommitted vs HEAD).
+        BASE="$INPUT_BASE"
+        if [ -z "$BASE" ] && [ "$EVENT_NAME" = "pull_request" ] && [ -n "$BASE_REF" ]; then
+          # Safety net for shallow checkouts; with fetch-depth: 0 this is a no-op.
+          git fetch --no-tags origin "$BASE_REF" >/dev/null 2>&1 || true
+          BASE="origin/$BASE_REF"
+        fi
+
+        ARGS=(review -d "$INPUT_DIR" -o sarif)
+        [ -n "$BASE" ] && ARGS+=(--base "$BASE")
+        [ -n "$INPUT_EXPR" ] && ARGS+=(--expr "$INPUT_EXPR")
+        ARGS+=(--max-complexity "$INPUT_MAX_COMPLEXITY" --max-cognitive "$INPUT_MAX_COGNITIVE")
+        [ "$INPUT_SKIP_DEAD_CODE" = "true" ] && ARGS+=(--no-dead-code)
+        [ "$INPUT_STRICT" = "true" ] && ARGS+=(--strict)
+        [ "$INPUT_PRUNE" = "true" ] && ARGS+=(--prune-build-artefacts)
+        [ "$INPUT_RESPECT_GITIGNORE" = "true" ] && ARGS+=(--respect-gitignore)
+        [ -n "$INPUT_TIMEOUT" ] && ARGS+=(--timeout "$INPUT_TIMEOUT")
+        while IFS= read -r glob; do
+          [ -n "$glob" ] && ARGS+=(--exclude "$glob")
+        done <<< "$INPUT_EXCLUDE"
+
+        echo "+ file-search-on ${ARGS[*]}"
+        file-search-on "${ARGS[@]}" > "$SARIF_FILE"
+        ec=$?
+        echo "review exit code: $ec"
+
+        # Counts come from the SARIF result levels (error=fail, warning=warn) —
+        # no second analysis pass.
+        fail_count=$(jq '[.runs[0].results[]? | select(.level=="error")] | length' "$SARIF_FILE" 2>/dev/null || echo 0)
+        warn_count=$(jq '[.runs[0].results[]? | select(.level=="warning")] | length' "$SARIF_FILE" 2>/dev/null || echo 0)
+
+        case "$ec" in
+          0)   verdict=pass ;;
+          1)   if [ "$INPUT_STRICT" = "true" ] && [ "$fail_count" = "0" ]; then verdict=warn; else verdict=fail; fi ;;
+          124) verdict=timeout ;;
+          130) verdict=interrupted ;;
+          *)   verdict=fail ;;
+        esac
+
+        {
+          echo "verdict=$verdict"
+          echo "fail_count=$fail_count"
+          echo "warn_count=$warn_count"
+          echo "exit_code=$ec"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "### file-search-on review: \`$verdict\` ($fail_count fail, $warn_count warn)" >> "$GITHUB_STEP_SUMMARY"
+
+    - id: upload
+      if: ${{ always() && inputs.upload-sarif == 'true' }}
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.sarif-file }}
+        category: file-search-on-review
+
+    - id: gate
+      if: ${{ inputs.gate == 'true' }}
+      shell: bash
+      env:
+        VERDICT: ${{ steps.review.outputs.verdict }}
+      run: |
+        case "$VERDICT" in
+          fail|timeout|interrupted)
+            echo "::error::file-search-on review verdict: $VERDICT"
+            exit 1 ;;
+          *)
+            echo "file-search-on review verdict: $VERDICT"
+            exit 0 ;;
+        esac

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,7 @@ CEL expression recipes by content family, plus cross-cutting cookbook patterns.
 | [`hashsets.md`](./hashsets.md) | Hash allowlist / denylist — `is_known_good` / `is_known_bad` predicates; build NSRL or threat-intel-feed `.hashset` files via `file-search-on hash-set build` |
 | [`semantic-search.md`](./semantic-search.md) | Semantic similarity via local Ollama embeddings — `similarity` CEL variable + `search_semantic` MCP tool; conceptual / paraphrase-tolerant document discovery |
 | [`monitoring.md`](./monitoring.md) | Read-only dashboard for a running `mcp` / `watch` process — `--monitor-addr :9090`. Cache hit-rates, live tool-call activity, capabilities; localhost-only, zero-dep, JSON API |
+| [`ci-review-gate.md`](./ci-review-gate.md) | Diff-scoped review gate as a GitHub Action — `richardwooding/file-search-on@vX.Y.Z` runs `review` on PRs and uploads SARIF to Code Scanning. Complexity / cognitive-complexity / dead-code annotations on the diff |
 
 Every recipe is a complete `file-search-on '<expr>'` invocation that you can paste and run. Most include a few variations and useful output-format snippets.
 

--- a/examples/ci-review-gate.md
+++ b/examples/ci-review-gate.md
@@ -1,0 +1,118 @@
+# Recipes — CI review gate (GitHub Action)
+
+`file-search-on review` is a diff-scoped review gate: it resolves the files changed in a git
+diff, runs the per-file analyses (cyclomatic complexity, cognitive complexity, dead code)
+scoped to just those files, and emits a `pass` / `warn` / `fail` verdict whose exit code
+gates CI. The repo ships a composite **GitHub Action** that wraps it and uploads findings to
+**Code Scanning** as SARIF — over-complex functions and dead code show up as inline
+annotations on the pull-request diff.
+
+> The action is a *composite* action, not a Docker action: `review` shells out to `git`, and
+> the published OCI image's base (`chainguard/static`) has no git or shell. The action
+> downloads the matching release binary and runs it on the runner, where git + the checkout
+> already exist.
+
+## Minimal PR gate
+
+```yaml
+# .github/workflows/review.yml
+name: review
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+  security-events: write   # required for SARIF upload (Code Scanning)
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0     # required — the PR gate needs the merge base
+      - uses: richardwooding/file-search-on@v0.115.0
+        with:
+          base: origin/${{ github.base_ref }}
+```
+
+Two requirements are easy to miss:
+
+- **`fetch-depth: 0`** on `actions/checkout` — `review --base origin/<branch>` computes the
+  `<base>...HEAD` 3-dot diff, which needs the merge base in history. A shallow clone has no
+  merge base and the diff comes back empty.
+- **`permissions: security-events: write`** — `github/codeql-action/upload-sarif` writes to
+  Code Scanning. Without it the upload step fails (the gate still works).
+
+## Tuning the thresholds
+
+```yaml
+      - uses: richardwooding/file-search-on@v0.115.0
+        with:
+          base: origin/${{ github.base_ref }}
+          max-complexity: "20"        # cyclomatic ceiling (default 15)
+          max-cognitive: "25"         # cognitive ceiling (default 15)
+          skip-dead-code: "true"      # complexity only — skip the second graph pass
+          expr: "is_source && !path.contains('/vendor/')"
+          exclude: |
+            *_test.go
+            *.gen.go
+          prune-build-artefacts: "true"
+```
+
+## Report-only mode
+
+To surface annotations without blocking the merge, set `gate: false`. The SARIF still
+uploads, so findings appear in the PR and the Security tab, but the job stays green.
+
+```yaml
+      - uses: richardwooding/file-search-on@v0.115.0
+        with:
+          base: origin/${{ github.base_ref }}
+          gate: false
+```
+
+Or flip the opposite way with `strict: "true"` to fail the job on `warn`-level findings
+(e.g. dead code) too, not just `fail`-level ones.
+
+## Using the outputs
+
+```yaml
+      - id: review
+        uses: richardwooding/file-search-on@v0.115.0
+        with:
+          base: origin/${{ github.base_ref }}
+          gate: false
+      - if: steps.review.outputs.fail-count != '0'
+        run: echo "::warning::${{ steps.review.outputs.fail-count }} fail / ${{ steps.review.outputs.warn-count }} warn — verdict ${{ steps.review.outputs.verdict }}"
+```
+
+Outputs: `verdict` (`pass` / `warn` / `fail` / `timeout` / `interrupted`), `fail-count`,
+`warn-count`, `sarif-file`.
+
+## Pinning the binary version
+
+By default the action uses the binary from its own ref (`@v0.115.0` → the `v0.115.0`
+release) or `latest` when referenced by branch/SHA. Override explicitly with `version`:
+
+```yaml
+      - uses: richardwooding/file-search-on@main
+        with:
+          version: v0.115.0     # pin the binary even when tracking @main
+          base: origin/${{ github.base_ref }}
+```
+
+## Pre-commit / local equivalent
+
+The same gate runs locally without the action — empty `--base` reviews uncommitted changes
+against `HEAD`:
+
+```sh
+file-search-on review                       # uncommitted vs HEAD (pre-commit hook)
+file-search-on review --base origin/main    # everything on this branch since main
+file-search-on review --base origin/main -o sarif > review.sarif
+```
+
+Exit codes: `0` pass, `1` fail (or `warn` under `--strict`), `124` timeout, `130`
+interrupted.
+
+> Supported runners: `ubuntu-*` and `macos-*`. Windows is not yet supported.


### PR DESCRIPTION
## What

Adds a composite **GitHub Action** that wraps the `file-search-on review` diff-scoped review gate and publishes findings to **Code Scanning** as SARIF — over-complex functions, cognitive-complexity hotspots, and dead code show up as inline annotations on the PR diff.

```yaml
permissions: { contents: read, security-events: write }
on: { pull_request: { branches: [main] } }
jobs:
  review:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
        with: { fetch-depth: 0 }
      - uses: richardwooding/file-search-on@v0.115.0
        with:
          base: origin/${{ github.base_ref }}
```

## Why a composite action (not the OCI container)

`review` shells out to `git`, but the published image's base (`chainguard/static`) has no git or shell — so the container can't run `review` unmodified. The action instead downloads the matching release binary and runs it on the runner host, where git + the checkout already exist. Fast, cross-OS, no container pull.

## Design notes

- **`action.yml` at repo root** — Marketplace requires root metadata + a unique `name`. The action version tracks the CLI version: `@vX.Y.Z` downloads the `vX.Y.Z` release binary (falls back to `latest` for branch/SHA refs; override with the `version` input).
- **Gating** mirrors the binary's exit codes (0 pass / 1 fail / 124 timeout / 130 interrupted). `gate: false` = report-only (annotations still upload). `strict: true` fails on warn too.
- **Outputs** (`verdict`, `fail-count`, `warn-count`) are derived from the SARIF result levels — no second analysis pass.
- **No Go / release-pipeline changes** — `review -o sarif` and the SARIF emitter already exist; the action just consumes published release archives.

## Docs

- README "GitHub Action" section + `examples/ci-review-gate.md`.
- `cut-release` skill documents the one-time manual Marketplace publish step (GoReleaser can't tick the Marketplace checkbox via API).

## Follow-ups (deferred)

- Windows runner support (zip-asset extraction) — currently ubuntu-* / macos-* only.
- Optional sticky-PR-comment reporting mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)