### PR TITLE
ci: self-review gate workflow (dogfood action.yml)

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,24 @@
+# Diff-scoped review gate — dogfoods this repo's own Marketplace action
+# (action.yml) against pull requests. Findings (complexity, cognitive
+# complexity, dead code) upload to Code Scanning as SARIF annotations.
+#
+# Uses `./` (the action checked out in this repo) rather than a published ref
+# so the gate always reflects the action.yml on the PR branch.
+name: review
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+  security-events: write   # required for SARIF upload (Code Scanning)
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0     # required — the PR gate needs the merge base
+      - name: file-search-on review gate
+        uses: ./
+        with:
+          base: origin/${{ github.base_ref }}


### PR DESCRIPTION
Adds `.github/workflows/review.yml` so this repo runs its own Marketplace review-gate action (#525) on pull requests, surfacing complexity / cognitive-complexity / dead-code findings as Code Scanning annotations.

### Note on the `uses:` ref

The Marketplace snippet is `uses: richardwooding/file-search-on@v0.115.0`, but `action.yml` was added **after** the v0.115.0 tag, so that ref can't resolve yet. For self-dogfooding this workflow uses `uses: ./` — the action checked out on the PR branch — which always reflects the current `action.yml` and resolves the binary to the latest release. Once a release containing `action.yml` is cut, external consumers use the pinned `@vX.Y.Z` form.

This PR itself exercises the gate: it changes no source files, so the `is_source` diff is empty → `pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)