### PR TITLE
fix(action): bump codeql-action/upload-sarif to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -211,7 +211,7 @@ runs:
 
     - id: upload
       if: ${{ always() && inputs.upload-sarif == 'true' }}
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: ${{ inputs.sarif-file }}
         category: file-search-on-review


### PR DESCRIPTION
The review-gate run surfaced two version deprecation warnings, both from `github/codeql-action/upload-sarif@v3` in `action.yml`:

- `CodeQL Action v3 will be deprecated in December 2026. Please update … to v4.`
- `Node 20 is being deprecated. This workflow is running with Node 24 by default.` (the v3 action bundles a Node 20 runtime)

Bumping to **v4** clears both — it's the current GA major and runs on Node 24. The inputs (`sarif_file`, `category`) are unchanged.

This PR re-runs the `review` job on itself, so the warnings should be gone from its own run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)