### PR TITLE
ci: bump actions/checkout to v7 (clear Node 20 warning)

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -15,7 +15,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0     # required — the PR gate needs the merge base
       - name: file-search-on review gate

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0     # required — the PR gate needs the merge base
       - uses: richardwooding/file-search-on@v0.115.0

--- a/examples/ci-review-gate.md
+++ b/examples/ci-review-gate.md
@@ -27,7 +27,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0     # required — the PR gate needs the merge base
       - uses: richardwooding/file-search-on@v0.115.0


### PR DESCRIPTION
Follow-up to #528. With `upload-sarif` on v4, the only remaining version-deprecation warning in the review run is:

> `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4`

Bumps `actions/checkout@v4 → @v7` (targets Node 24, and matches the version the repo's other workflows already use) in `.github/workflows/review.yml`, plus the README and example snippets so consumers copying them don't inherit the warning.

After this the review run should have zero deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)