### PR TITLE
feat(review): baseline-aware gate — fail only on new/worsened complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,10 +672,12 @@ The action downloads the matching release binary and runs it on the runner (the 
 OCI image can't run `review`, which shells out to `git`). The job fails on a `fail` verdict;
 set `gate: false` for report-only mode (findings still upload as annotations).
 
-Key inputs: `base`, `max-complexity`, `max-cognitive`, `skip-dead-code`, `strict`, `expr`,
-`exclude`, `prune-build-artefacts`, `timeout`, `version` (which release to use; defaults to
-the action ref or `latest`), `upload-sarif`, `gate`. Outputs: `verdict`, `fail-count`,
-`warn-count`, `sarif-file`. See [`action.yml`](action.yml) for the full list and
+Key inputs: `base`, `max-complexity`, `max-cognitive`, `skip-dead-code`,
+`baseline` (only fail on complexity new/worsened vs the base — don't block on pre-existing
+debt in touched files), `strict`, `expr`, `exclude`, `prune-build-artefacts`, `timeout`,
+`version` (which release to use; defaults to the action ref or `latest`), `upload-sarif`,
+`gate`. Outputs: `verdict`, `fail-count`, `warn-count`, `sarif-file`. See
+[`action.yml`](action.yml) for the full list and
 [`examples/ci-review-gate.md`](examples/ci-review-gate.md) for more recipes.
 
 > Supported runners: `ubuntu-*` and `macos-*`. Windows is not yet supported.

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ inputs:
   skip-dead-code:
     description: "Skip the dead-code check (it adds a second graph pass)."
     default: "false"
+  baseline:
+    description: "Only fail on complexity/cognitive findings new or worsened vs the base ref — don't block a PR on pre-existing debt in files it merely touched."
+    default: "false"
   strict:
     description: "Treat warn-level findings as failures for the verdict / exit code."
     default: "false"
@@ -144,6 +147,7 @@ runs:
         INPUT_MAX_COMPLEXITY: ${{ inputs.max-complexity }}
         INPUT_MAX_COGNITIVE: ${{ inputs.max-cognitive }}
         INPUT_SKIP_DEAD_CODE: ${{ inputs.skip-dead-code }}
+        INPUT_BASELINE: ${{ inputs.baseline }}
         INPUT_STRICT: ${{ inputs.strict }}
         INPUT_EXCLUDE: ${{ inputs.exclude }}
         INPUT_PRUNE: ${{ inputs.prune-build-artefacts }}
@@ -167,6 +171,7 @@ runs:
         [ -n "$INPUT_EXPR" ] && ARGS+=(--expr "$INPUT_EXPR")
         ARGS+=(--max-complexity "$INPUT_MAX_COMPLEXITY" --max-cognitive "$INPUT_MAX_COGNITIVE")
         [ "$INPUT_SKIP_DEAD_CODE" = "true" ] && ARGS+=(--no-dead-code)
+        [ "$INPUT_BASELINE" = "true" ] && ARGS+=(--baseline)
         [ "$INPUT_STRICT" = "true" ] && ARGS+=(--strict)
         [ "$INPUT_PRUNE" = "true" ] && ARGS+=(--prune-build-artefacts)
         [ "$INPUT_RESPECT_GITIGNORE" = "true" ] && ARGS+=(--respect-gitignore)

--- a/cmd/file-search-on/review_cmd.go
+++ b/cmd/file-search-on/review_cmd.go
@@ -25,6 +25,7 @@ type ReviewCmd struct {
 	MaxComplexity int  `name:"max-complexity" default:"15" help:"Cyclomatic-complexity ceiling for a function in a changed file; functions above it are a fail-level finding."`
 	MaxCognitive  int  `name:"max-cognitive" default:"15" help:"Cognitive-complexity ceiling (SonarSource, nesting-weighted) for a function in a changed file; functions above it are a fail-level finding. Only applies where cognitive complexity is computed (Go + most tree-sitter languages)."`
 	NoDeadCode    bool `name:"no-dead-code" help:"Skip the dead-code check (it adds a second graph pass)."`
+	Baseline      bool `name:"baseline" help:"Only fail on complexity/cognitive findings that are NEW or WORSENED versus the base ref — pre-existing debt in a touched file is not flagged. Lets a PR touch a complex file without being blocked on code it didn't change (#538)."`
 	Strict        bool `name:"strict" help:"Treat warn-level findings as failures for exit-code purposes (warn verdict also exits non-zero)."`
 
 	Workers             int           `short:"w" help:"Parallel workers. 0 = runtime.NumCPU()." default:"0"`
@@ -67,6 +68,7 @@ func (c *ReviewCmd) Run(ctx context.Context) error {
 		MaxComplexity: c.MaxComplexity,
 		MaxCognitive:  c.MaxCognitive,
 		CheckDeadCode: !c.NoDeadCode,
+		BaselineOnly:  c.Baseline,
 	})
 	if err != nil {
 		return fmt.Errorf("review failed: %w", err)

--- a/cmd/file-search-on/review_cmd.go
+++ b/cmd/file-search-on/review_cmd.go
@@ -74,11 +74,31 @@ func (c *ReviewCmd) Run(ctx context.Context) error {
 		return fmt.Errorf("review failed: %w", err)
 	}
 
-	switch c.Output {
-	case "json":
-		if jerr := writeJSON(os.Stdout, res); jerr != nil {
-			return jerr
+	if rerr := renderReview(c.Output, res); rerr != nil {
+		return rerr
+	}
+
+	if res.Cancelled {
+		fmt.Fprintln(os.Stderr, "review interrupted; verdict above may be incomplete")
+		if res.CancellationReason == "timeout" {
+			return &exitCodeError{code: 124, msg: "timeout"}
 		}
+		return &exitCodeError{code: 130, msg: "interrupted"}
+	}
+
+	// Gate: fail always exits non-zero; warn exits non-zero only under --strict.
+	if res.Verdict == "fail" || (c.Strict && res.Verdict == "warn") {
+		return &exitCodeError{code: 1, msg: res.Verdict}
+	}
+	return nil
+}
+
+// renderReview writes the review result in the requested output format
+// (json | sarif | table).
+func renderReview(format string, res *search.ReviewResult) error {
+	switch format {
+	case "json":
+		return writeJSON(os.Stdout, res)
 	case "sarif":
 		results := make([]sarif.Result, 0, len(res.Findings))
 		for _, f := range res.Findings {
@@ -95,26 +115,11 @@ func (c *ReviewCmd) Run(ctx context.Context) error {
 				EndLine:   f.EndLine,
 			})
 		}
-		if werr := writeSARIF(sarif.Rule{ID: "review", Name: "Review", Description: "Diff-scoped review findings"}, results); werr != nil {
-			return werr
-		}
+		return writeSARIF(sarif.Rule{ID: "review", Name: "Review", Description: "Diff-scoped review findings"}, results)
 	default:
 		printReviewTable(os.Stdout, res)
+		return nil
 	}
-
-	if res.Cancelled {
-		fmt.Fprintln(os.Stderr, "review interrupted; verdict above may be incomplete")
-		if res.CancellationReason == "timeout" {
-			return &exitCodeError{code: 124, msg: "timeout"}
-		}
-		return &exitCodeError{code: 130, msg: "interrupted"}
-	}
-
-	// Gate: fail always exits non-zero; warn exits non-zero only under --strict.
-	if res.Verdict == "fail" || (c.Strict && res.Verdict == "warn") {
-		return &exitCodeError{code: 1, msg: res.Verdict}
-	}
-	return nil
 }
 
 func printReviewTable(w io.Writer, res *search.ReviewResult) {

--- a/examples/ci-review-gate.md
+++ b/examples/ci-review-gate.md
@@ -59,6 +59,26 @@ Two requirements are easy to miss:
           prune-build-artefacts: "true"
 ```
 
+## Baseline mode — don't block on pre-existing debt
+
+The gate is diff-scoped at *file* granularity: by default it flags every over-threshold
+function in a changed file, so a PR that merely touches a complex file is blocked on code
+it didn't change. Set `baseline: true` to fail only on complexity that is **new or worsened**
+versus the base ref — a function whose cyclomatic/cognitive value is unchanged (or lower)
+than its baseline is left alone, even if it's over the ceiling.
+
+```yaml
+      - uses: richardwooding/file-search-on@v0.116.0
+        with:
+          base: origin/${{ github.base_ref }}
+          baseline: "true"   # only NEW or WORSENED complexity fails the gate
+```
+
+The baseline is the same content the diff is taken against (the merge-base of `base` and
+`HEAD`). New files and worsened functions still fail; pre-existing debt in touched files
+does not. The same flag is `--baseline` on the CLI and `baseline: true` on the MCP `review`
+tool.
+
 ## Report-only mode
 
 To surface annotations without blocking the merge, set `gate: false`. The SARIF still

--- a/internal/mcpserver/review_tool.go
+++ b/internal/mcpserver/review_tool.go
@@ -19,6 +19,7 @@ type ReviewInput struct {
 	MaxComplexity int    `json:"max_complexity,omitempty" jsonschema:"Cyclomatic-complexity ceiling for a function in a changed file; functions above it are a fail-level finding. Defaults to 15."`
 	MaxCognitive  int    `json:"max_cognitive,omitempty" jsonschema:"Cognitive-complexity ceiling (SonarSource, nesting-weighted) for a function in a changed file; functions above it are a fail-level finding. Defaults to 15. Only applies where cognitive complexity is computed (Go + most tree-sitter languages)."`
 	SkipDeadCode  bool   `json:"skip_dead_code,omitempty" jsonschema:"When true, skip the dead-code check (it adds a second graph pass). Dead-code findings are warn-level."`
+	Baseline      bool   `json:"baseline,omitempty" jsonschema:"When true, only fail on complexity/cognitive findings that are NEW or WORSENED versus the base ref — pre-existing debt in a touched file is not flagged, so a PR isn't blocked on code it didn't change."`
 }
 
 // ReviewOutput is the diff-scoped review verdict + findings.
@@ -53,6 +54,7 @@ func (h *handlers) reviewHandler(ctx context.Context, _ *mcp.CallToolRequest, in
 		MaxComplexity: in.MaxComplexity,
 		MaxCognitive:  in.MaxCognitive,
 		CheckDeadCode: !in.SkipDeadCode,
+		BaselineOnly:  in.Baseline,
 	})
 	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		return nil, ReviewOutput{}, fmt.Errorf("review: %w", err)

--- a/internal/search/review.go
+++ b/internal/search/review.go
@@ -9,7 +9,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/richardwooding/file-search-on/internal/content"
 )
@@ -47,6 +49,16 @@ type ReviewConfig struct {
 	// CheckDeadCode includes dead-code candidates in changed files as "warn"
 	// findings. Heuristic, so it never escalates to "fail" on its own.
 	CheckDeadCode bool
+	// BaselineOnly restricts the complexity / cognitive-complexity gate to
+	// findings that are NEW or WORSENED relative to the base ref — a function
+	// whose metric is unchanged (or lower) than its baseline value is not
+	// flagged, even if it's over the ceiling. This stops a PR that merely
+	// touches a file with pre-existing debt from being blocked on code it
+	// didn't change (issue #538). The baseline is the same content the diff is
+	// taken against: HEAD when Base is empty, else the merge-base of Base and
+	// HEAD. Off by default (every over-ceiling function in a changed file is
+	// flagged). Dead-code (warn-level) is unaffected.
+	BaselineOnly bool
 }
 
 // ReviewResult is the verdict + findings for a diff-scoped review. Verdict is
@@ -83,7 +95,7 @@ func Review(ctx context.Context, opts Options, registry *content.Registry, cfg R
 	}
 	root := reviewRoot(opts)
 
-	changedAbs, changedRel, err := changedFiles(ctx, root, cfg.Base)
+	changedAbs, changedRel, toplevel, err := changedFiles(ctx, root, cfg.Base)
 	if err != nil {
 		// Can't resolve the changed set: treat a cancellation/timeout as a
 		// (clean) partial result so the caller's gate maps it to the usual
@@ -107,13 +119,49 @@ func Review(ctx context.Context, opts Options, registry *content.Registry, cfg R
 	// path repeats across its symbols, so caching collapses EvalSymlinks
 	// (physical disk I/O) to one call per distinct path.
 	resolved := map[string]string{}
-	inChanged := func(p string) bool {
+	canon := func(p string) string {
 		c, ok := resolved[p]
 		if !ok {
 			c = absClean(p)
 			resolved[p] = c
 		}
-		return changedAbs[c]
+		return c
+	}
+	inChanged := func(p string) bool { return changedAbs[canon(p)] }
+
+	// Baseline mode (#538): build the per-file, per-symbol complexity at the
+	// base ref so the gate can suppress findings that are pre-existing and not
+	// worsened. Keyed by absClean path (matching changedAbs). A nil/partial map
+	// (e.g. baseRef unresolvable) safely degrades to flagging everything.
+	var baseline map[string]map[string]metricPair
+	if cfg.BaselineOnly {
+		if baseRef, berr := reviewBaseRef(ctx, root, cfg.Base); berr == nil {
+			baseline = baselineComplexity(ctx, root, toplevel, baseRef, changedRel, registry)
+		}
+	}
+	// suppressed reports whether a metric finding is pre-existing and not
+	// worsened vs the baseline (so baseline mode drops it). Always false when
+	// not in baseline mode.
+	suppressed := func(path, symbol string, value int, cognitive bool) bool {
+		if baseline == nil {
+			return false
+		}
+		m := baseline[canon(path)]
+		if m == nil {
+			return false // file absent at base (newly added) → finding is new
+		}
+		prev, ok := m[symbol]
+		if !ok {
+			return false // symbol new at base → finding is new
+		}
+		base := prev.cyclomatic
+		if cognitive {
+			base = prev.cognitive
+		}
+		if base < 0 {
+			return false // baseline metric unavailable → don't suppress
+		}
+		return value <= base // unchanged or improved → suppress
 	}
 
 	// Complexity: every function, then filter to changed files over the gate.
@@ -126,7 +174,7 @@ func Review(ctx context.Context, opts Options, registry *content.Registry, cfg R
 			if !inChanged(fn.Path) {
 				continue
 			}
-			if fn.Complexity > cfg.MaxComplexity {
+			if fn.Complexity > cfg.MaxComplexity && !suppressed(fn.Path, fn.Function, fn.Complexity, false) {
 				out.Findings = append(out.Findings, ReviewFinding{
 					Rule:      "complexity",
 					Level:     "fail",
@@ -140,7 +188,8 @@ func Review(ctx context.Context, opts Options, registry *content.Registry, cfg R
 			// Cognitive complexity (nesting-weighted) — only where the language
 			// computes it (CognitiveComplexity != nil); a distinct fail signal
 			// from cyclomatic, so a function may trip both.
-			if fn.CognitiveComplexity != nil && *fn.CognitiveComplexity > cfg.MaxCognitive {
+			if fn.CognitiveComplexity != nil && *fn.CognitiveComplexity > cfg.MaxCognitive &&
+				!suppressed(fn.Path, fn.Function, *fn.CognitiveComplexity, true) {
 				out.Findings = append(out.Findings, ReviewFinding{
 					Rule:      "cognitive-complexity",
 					Level:     "fail",
@@ -278,10 +327,10 @@ func absClean(p string) string {
 // ReviewConfig.Base for the semantics). It returns a set of absolute cleaned
 // paths (for matching) and the sorted repo-relative paths (for reporting).
 // Deleted paths are dropped — they can't carry a current finding.
-func changedFiles(ctx context.Context, dir, base string) (map[string]bool, []string, error) {
+func changedFiles(ctx context.Context, dir, base string) (map[string]bool, []string, string, error) {
 	top, err := gitOutput(ctx, dir, "rev-parse", "--show-toplevel")
 	if err != nil {
-		return nil, nil, fmt.Errorf("not a git repository (or git unavailable) at %q: %w", dir, err)
+		return nil, nil, "", fmt.Errorf("not a git repository (or git unavailable) at %q: %w", dir, err)
 	}
 	toplevel := strings.TrimSpace(top)
 
@@ -297,7 +346,7 @@ func changedFiles(ctx context.Context, dir, base string) (map[string]bool, []str
 	args = append(args, "--", ".")
 	rawList, err := gitOutput(ctx, dir, args...)
 	if err != nil {
-		return nil, nil, fmt.Errorf("git diff failed: %w", err)
+		return nil, nil, "", fmt.Errorf("git diff failed: %w", err)
 	}
 
 	abs := map[string]bool{}
@@ -313,7 +362,114 @@ func changedFiles(ctx context.Context, dir, base string) (map[string]bool, []str
 		abs[absClean(filepath.Join(toplevel, filepath.FromSlash(line)))] = true
 	}
 	sort.Strings(rel)
-	return abs, rel, nil
+	return abs, rel, toplevel, nil
+}
+
+// metricPair is a function's cyclomatic + cognitive complexity at the baseline.
+// cognitive is -1 when the language doesn't compute it.
+type metricPair struct {
+	cyclomatic int
+	cognitive  int
+}
+
+// reviewBaseRef resolves the git ref whose content is the baseline for the
+// diff: HEAD when base is empty (uncommitted vs HEAD), else the merge-base of
+// base and HEAD (matching the `base...HEAD` three-dot diff the gate uses).
+func reviewBaseRef(ctx context.Context, dir, base string) (string, error) {
+	if base == "" {
+		return "HEAD", nil
+	}
+	mb, err := gitOutput(ctx, dir, "merge-base", base, "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(mb), nil
+}
+
+// baselineComplexity returns, for each changed file, the per-symbol complexity
+// at baseRef, keyed by absClean(toplevel/rel) to match the changed-set keys. It
+// reuses the production extractor on the base content (via a single-file fs.FS),
+// so baseline metrics are computed identically to HEAD. Files absent at baseRef
+// (newly added) get no entry — their findings then count as new.
+func baselineComplexity(ctx context.Context, dir, toplevel, baseRef string, changedRel []string, registry *content.Registry) map[string]map[string]metricPair {
+	out := make(map[string]map[string]metricPair, len(changedRel))
+	for _, rel := range changedRel {
+		data, err := gitShowFile(ctx, dir, baseRef, rel)
+		if err != nil {
+			continue // not present at baseRef → no baseline (treated as new)
+		}
+		name := filepath.Base(rel)
+		fsys := content.NewSingleFileFS(name, data, time.Time{}, 0)
+		ct := registry.Detect(fsys, name)
+		if ct == nil {
+			continue
+		}
+		attrs, aerr := ct.Attributes(ctx, fsys, name)
+		if aerr != nil || attrs == nil {
+			continue
+		}
+		rows, _ := attrs["complexity_rows"].([]string)
+		if len(rows) == 0 {
+			continue
+		}
+		m := make(map[string]metricPair, len(rows))
+		for _, r := range rows {
+			sym, mp, ok := parseComplexityRow(r)
+			if !ok {
+				continue
+			}
+			// Same-named functions in one file collapse to the most lenient
+			// (max) baseline, so a finding is only "worsened" if it exceeds
+			// every prior namesake — avoiding false positives on overloads.
+			if prev, exists := m[sym]; exists {
+				if prev.cyclomatic > mp.cyclomatic {
+					mp.cyclomatic = prev.cyclomatic
+				}
+				if prev.cognitive > mp.cognitive {
+					mp.cognitive = prev.cognitive
+				}
+			}
+			m[sym] = mp
+		}
+		out[absClean(filepath.Join(toplevel, filepath.FromSlash(rel)))] = m
+	}
+	return out
+}
+
+// parseComplexityRow parses a builder-internal complexity row
+// "name\x00cyclomatic\x00startLine\x00endLine[\x00cognitive]" into its symbol
+// and metrics. cognitive is -1 when the row has no cognitive field.
+func parseComplexityRow(r string) (string, metricPair, bool) {
+	p := strings.Split(r, "\x00")
+	if len(p) < 2 {
+		return "", metricPair{}, false
+	}
+	cyc, err := strconv.Atoi(p[1])
+	if err != nil {
+		return "", metricPair{}, false
+	}
+	mp := metricPair{cyclomatic: cyc, cognitive: -1}
+	if len(p) >= 5 {
+		if cog, e := strconv.Atoi(p[4]); e == nil {
+			mp.cognitive = cog
+		}
+	}
+	return p[0], mp, true
+}
+
+// gitShowFile returns the content of relpath (repo-root-relative) at ref via
+// `git show <ref>:<relpath>`. An error (e.g. the path didn't exist at ref)
+// means no baseline for that file.
+func gitShowFile(ctx context.Context, dir, ref, relpath string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", "show", ref+":"+filepath.ToSlash(relpath))
+	cmd.Dir = dir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return stdout.Bytes(), nil
 }
 
 // gitOutput runs `git <args...>` in dir and returns stdout. The context bounds

--- a/internal/search/review.go
+++ b/internal/search/review.go
@@ -128,24 +128,65 @@ func Review(ctx context.Context, opts Options, registry *content.Registry, cfg R
 		return c
 	}
 	inChanged := func(p string) bool { return changedAbs[canon(p)] }
+	suppressed := baselineSuppressor(ctx, root, toplevel, cfg, changedRel, registry, canon)
 
-	// Baseline mode (#538): build the per-file, per-symbol complexity at the
-	// base ref so the gate can suppress findings that are pre-existing and not
-	// worsened. Keyed by absClean path (matching changedAbs). A nil/partial map
-	// (e.g. baseRef unresolvable) safely degrades to flagging everything.
-	var baseline map[string]map[string]metricPair
-	if cfg.BaselineOnly {
-		if baseRef, berr := reviewBaseRef(ctx, root, cfg.Base); berr == nil {
-			baseline = baselineComplexity(ctx, root, toplevel, baseRef, changedRel, registry)
-		}
+	// Complexity: every function, then filter to changed files over the gate.
+	rep, cErr := Complexity(ctx, opts, registry, 1<<30)
+	if cErr != nil && !isReviewCancel(cErr) {
+		return nil, fmt.Errorf("complexity analysis: %w", cErr)
 	}
-	// suppressed reports whether a metric finding is pre-existing and not
-	// worsened vs the baseline (so baseline mode drops it). Always false when
-	// not in baseline mode.
-	suppressed := func(path, symbol string, value int, cognitive bool) bool {
-		if baseline == nil {
-			return false
-		}
+	appendComplexityFindings(out, rep, cfg, inChanged, suppressed)
+
+	if err := runDeadCode(ctx, opts, registry, cfg, out, inChanged); err != nil {
+		return nil, err
+	}
+
+	surfaceCancellation(out, ctx, rep)
+	finalizeReview(out)
+	return out, nil
+}
+
+// runDeadCode appends warn-level dead-code findings for changed files, unless
+// cancellation is already in flight (a partial graph yields false positives).
+// A genuine (non-cancellation) graph error is returned.
+func runDeadCode(ctx context.Context, opts Options, registry *content.Registry, cfg ReviewConfig, out *ReviewResult, inChanged func(string) bool) error {
+	if !cfg.CheckDeadCode || cancelReason(ctx) != "" {
+		return nil
+	}
+	g, gErr := BuildCodeGraph(ctx, opts, registry)
+	if gErr != nil && !isReviewCancel(gErr) {
+		return fmt.Errorf("dead-code analysis: %w", gErr)
+	}
+	appendDeadCodeFindings(out, g, inChanged)
+	return nil
+}
+
+// surfaceCancellation marks the result as partial when the context was
+// cancelled, or when the complexity pass reported its own cancellation.
+func surfaceCancellation(out *ReviewResult, ctx context.Context, rep *ComplexityReport) {
+	if reason := cancelReason(ctx); reason != "" {
+		out.Cancelled = true
+		out.CancellationReason = reason
+	} else if rep != nil && rep.Cancelled {
+		out.Cancelled = true
+		out.CancellationReason = rep.CancellationReason
+	}
+}
+
+// baselineSuppressor returns the predicate appendComplexityFindings uses to
+// drop pre-existing-and-not-worsened complexity findings in baseline mode
+// (#538). When cfg.BaselineOnly is off it returns a predicate that suppresses
+// nothing. The baseline is built once here (keyed by absClean path via canon);
+// an unresolvable base ref degrades safely to flagging everything.
+func baselineSuppressor(ctx context.Context, root, toplevel string, cfg ReviewConfig, changedRel []string, registry *content.Registry, canon func(string) string) func(path, symbol string, value int, cognitive bool) bool {
+	if !cfg.BaselineOnly {
+		return func(string, string, int, bool) bool { return false }
+	}
+	var baseline map[string]map[string]metricPair
+	if baseRef, err := reviewBaseRef(ctx, root, cfg.Base); err == nil {
+		baseline = baselineComplexity(ctx, root, toplevel, baseRef, changedRel, registry)
+	}
+	return func(path, symbol string, value int, cognitive bool) bool {
 		m := baseline[canon(path)]
 		if m == nil {
 			return false // file absent at base (newly added) → finding is new
@@ -163,85 +204,68 @@ func Review(ctx context.Context, opts Options, registry *content.Registry, cfg R
 		}
 		return value <= base // unchanged or improved → suppress
 	}
+}
 
-	// Complexity: every function, then filter to changed files over the gate.
-	rep, cErr := Complexity(ctx, opts, registry, 1<<30)
-	if cErr != nil && !isReviewCancel(cErr) {
-		return nil, fmt.Errorf("complexity analysis: %w", cErr)
+// appendComplexityFindings adds fail-level cyclomatic + cognitive findings for
+// every changed-file function over the configured ceilings, skipping any the
+// baseline suppressor marks as pre-existing-and-not-worsened (#538). Cognitive
+// is only checked where the language computes it (a distinct signal from
+// cyclomatic, so a function may trip both).
+func appendComplexityFindings(out *ReviewResult, rep *ComplexityReport, cfg ReviewConfig, inChanged func(string) bool, suppressed func(path, symbol string, value int, cognitive bool) bool) {
+	if rep == nil {
+		return
 	}
-	if rep != nil {
-		for _, fn := range rep.Functions {
-			if !inChanged(fn.Path) {
-				continue
-			}
-			if fn.Complexity > cfg.MaxComplexity && !suppressed(fn.Path, fn.Function, fn.Complexity, false) {
-				out.Findings = append(out.Findings, ReviewFinding{
-					Rule:      "complexity",
-					Level:     "fail",
-					Message:   fmt.Sprintf("%s has cyclomatic complexity %d (> %d)", fn.Function, fn.Complexity, cfg.MaxComplexity),
-					Path:      fn.Path,
-					Symbol:    fn.Function,
-					StartLine: fn.StartLine,
-					EndLine:   fn.EndLine,
-				})
-			}
-			// Cognitive complexity (nesting-weighted) — only where the language
-			// computes it (CognitiveComplexity != nil); a distinct fail signal
-			// from cyclomatic, so a function may trip both.
-			if fn.CognitiveComplexity != nil && *fn.CognitiveComplexity > cfg.MaxCognitive &&
-				!suppressed(fn.Path, fn.Function, *fn.CognitiveComplexity, true) {
-				out.Findings = append(out.Findings, ReviewFinding{
-					Rule:      "cognitive-complexity",
-					Level:     "fail",
-					Message:   fmt.Sprintf("%s has cognitive complexity %d (> %d)", fn.Function, *fn.CognitiveComplexity, cfg.MaxCognitive),
-					Path:      fn.Path,
-					Symbol:    fn.Function,
-					StartLine: fn.StartLine,
-					EndLine:   fn.EndLine,
-				})
-			}
+	for _, fn := range rep.Functions {
+		if !inChanged(fn.Path) {
+			continue
+		}
+		if fn.Complexity > cfg.MaxComplexity && !suppressed(fn.Path, fn.Function, fn.Complexity, false) {
+			out.Findings = append(out.Findings, ReviewFinding{
+				Rule:      "complexity",
+				Level:     "fail",
+				Message:   fmt.Sprintf("%s has cyclomatic complexity %d (> %d)", fn.Function, fn.Complexity, cfg.MaxComplexity),
+				Path:      fn.Path,
+				Symbol:    fn.Function,
+				StartLine: fn.StartLine,
+				EndLine:   fn.EndLine,
+			})
+		}
+		if fn.CognitiveComplexity != nil && *fn.CognitiveComplexity > cfg.MaxCognitive &&
+			!suppressed(fn.Path, fn.Function, *fn.CognitiveComplexity, true) {
+			out.Findings = append(out.Findings, ReviewFinding{
+				Rule:      "cognitive-complexity",
+				Level:     "fail",
+				Message:   fmt.Sprintf("%s has cognitive complexity %d (> %d)", fn.Function, *fn.CognitiveComplexity, cfg.MaxCognitive),
+				Path:      fn.Path,
+				Symbol:    fn.Function,
+				StartLine: fn.StartLine,
+				EndLine:   fn.EndLine,
+			})
 		}
 	}
+}
 
-	// Dead code: candidates in changed files, as warn-level findings. Skipped
-	// once cancellation is in flight — a partial graph yields false positives.
-	if cfg.CheckDeadCode && cancelReason(ctx) == "" {
-		g, gErr := BuildCodeGraph(ctx, opts, registry)
-		if gErr != nil && !isReviewCancel(gErr) {
-			return nil, fmt.Errorf("dead-code analysis: %w", gErr)
-		}
-		if g != nil {
-			for _, d := range g.DeadCode() {
-				if !inChanged(d.Path) {
-					continue
-				}
-				name := d.Symbol
-				if d.Owner != "" {
-					name = d.Owner + "." + d.Symbol
-				}
-				out.Findings = append(out.Findings, ReviewFinding{
-					Rule:    "dead-code",
-					Level:   "warn",
-					Message: fmt.Sprintf("%s %q is never referenced (candidate dead code)", d.Kind, name),
-					Path:    d.Path,
-					Symbol:  name,
-				})
-			}
-		}
+// appendDeadCodeFindings adds warn-level dead-code candidates in changed files.
+func appendDeadCodeFindings(out *ReviewResult, g *CodeGraph, inChanged func(string) bool) {
+	if g == nil {
+		return
 	}
-
-	// Surface a cancellation that landed during either analysis phase, so the
-	// caller knows the verdict is over a partial set.
-	if reason := cancelReason(ctx); reason != "" {
-		out.Cancelled = true
-		out.CancellationReason = reason
-	} else if rep != nil && rep.Cancelled {
-		out.Cancelled = true
-		out.CancellationReason = rep.CancellationReason
+	for _, d := range g.DeadCode() {
+		if !inChanged(d.Path) {
+			continue
+		}
+		name := d.Symbol
+		if d.Owner != "" {
+			name = d.Owner + "." + d.Symbol
+		}
+		out.Findings = append(out.Findings, ReviewFinding{
+			Rule:    "dead-code",
+			Level:   "warn",
+			Message: fmt.Sprintf("%s %q is never referenced (candidate dead code)", d.Kind, name),
+			Path:    d.Path,
+			Symbol:  name,
+		})
 	}
-
-	finalizeReview(out)
-	return out, nil
 }
 
 // cancelReason maps a cancelled context to the reason vocabulary the CLI gate
@@ -394,46 +418,59 @@ func reviewBaseRef(ctx context.Context, dir, base string) (string, error) {
 func baselineComplexity(ctx context.Context, dir, toplevel, baseRef string, changedRel []string, registry *content.Registry) map[string]map[string]metricPair {
 	out := make(map[string]map[string]metricPair, len(changedRel))
 	for _, rel := range changedRel {
-		data, err := gitShowFile(ctx, dir, baseRef, rel)
-		if err != nil {
-			continue // not present at baseRef → no baseline (treated as new)
+		if m := baselineFileComplexity(ctx, dir, baseRef, rel, registry); m != nil {
+			out[absClean(filepath.Join(toplevel, filepath.FromSlash(rel)))] = m
 		}
-		name := filepath.Base(rel)
-		fsys := content.NewSingleFileFS(name, data, time.Time{}, 0)
-		ct := registry.Detect(fsys, name)
-		if ct == nil {
-			continue
-		}
-		attrs, aerr := ct.Attributes(ctx, fsys, name)
-		if aerr != nil || attrs == nil {
-			continue
-		}
-		rows, _ := attrs["complexity_rows"].([]string)
-		if len(rows) == 0 {
-			continue
-		}
-		m := make(map[string]metricPair, len(rows))
-		for _, r := range rows {
-			sym, mp, ok := parseComplexityRow(r)
-			if !ok {
-				continue
-			}
-			// Same-named functions in one file collapse to the most lenient
-			// (max) baseline, so a finding is only "worsened" if it exceeds
-			// every prior namesake — avoiding false positives on overloads.
-			if prev, exists := m[sym]; exists {
-				if prev.cyclomatic > mp.cyclomatic {
-					mp.cyclomatic = prev.cyclomatic
-				}
-				if prev.cognitive > mp.cognitive {
-					mp.cognitive = prev.cognitive
-				}
-			}
-			m[sym] = mp
-		}
-		out[absClean(filepath.Join(toplevel, filepath.FromSlash(rel)))] = m
 	}
 	return out
+}
+
+// baselineFileComplexity returns the per-symbol complexity of one file at
+// baseRef, or nil when the file is absent at baseRef or carries no source
+// symbols. It runs the production extractor on the base content via a
+// single-file fs.FS so metrics match HEAD's exactly.
+func baselineFileComplexity(ctx context.Context, dir, baseRef, rel string, registry *content.Registry) map[string]metricPair {
+	data, err := gitShowFile(ctx, dir, baseRef, rel)
+	if err != nil {
+		return nil // not present at baseRef → no baseline (treated as new)
+	}
+	name := filepath.Base(rel)
+	fsys := content.NewSingleFileFS(name, data, time.Time{}, 0)
+	ct := registry.Detect(fsys, name)
+	if ct == nil {
+		return nil
+	}
+	attrs, aerr := ct.Attributes(ctx, fsys, name)
+	if aerr != nil || attrs == nil {
+		return nil
+	}
+	rows, _ := attrs["complexity_rows"].([]string)
+	if len(rows) == 0 {
+		return nil
+	}
+	m := make(map[string]metricPair, len(rows))
+	for _, r := range rows {
+		if sym, mp, ok := parseComplexityRow(r); ok {
+			mergeMaxMetric(m, sym, mp)
+		}
+	}
+	return m
+}
+
+// mergeMaxMetric records mp for sym, keeping the per-metric maximum when sym is
+// already present. Same-named functions in one file thus collapse to the most
+// lenient baseline, so a finding is only "worsened" if it exceeds every prior
+// namesake — avoiding false positives on overloads / same-named methods.
+func mergeMaxMetric(m map[string]metricPair, sym string, mp metricPair) {
+	if prev, exists := m[sym]; exists {
+		if prev.cyclomatic > mp.cyclomatic {
+			mp.cyclomatic = prev.cyclomatic
+		}
+		if prev.cognitive > mp.cognitive {
+			mp.cognitive = prev.cognitive
+		}
+	}
+	m[sym] = mp
 }
 
 // parseComplexityRow parses a builder-internal complexity row

--- a/internal/search/review_test.go
+++ b/internal/search/review_test.go
@@ -234,3 +234,78 @@ func TestReview_NonGitDirErrors(t *testing.T) {
 		t.Fatal("expected an error for a non-git directory")
 	}
 }
+
+// branchyN returns a Go file with one function `name` of cyclomatic complexity
+// ~n+1 (n if-branches), for modelling baseline vs worsened complexity.
+func branchyN(pkg, name string, n int) string {
+	var b strings.Builder
+	b.WriteString("package " + pkg + "\n\nfunc " + name + "(x int) int {\n\tr := 0\n")
+	for i := 1; i <= n; i++ {
+		b.WriteString("\tif x > ")
+		b.WriteByte(byte('0' + i%10))
+		b.WriteString(" {\n\t\tr++\n\t}\n")
+	}
+	b.WriteString("\treturn r\n}\n")
+	return b.String()
+}
+
+// TestReview_Baseline checks the #538 baseline-aware gate: pre-existing
+// over-threshold complexity in a touched file is suppressed, while NEW and
+// WORSENED complexity still fails.
+func TestReview_Baseline(t *testing.T) {
+	root := initRepo(t)
+	commitAs(t, root, "go.mod", "module example.com/m\n\ngo 1.26\n", "Dev", "dev@example.com")
+	// Commit 1: a pre-existing complex function (cyclomatic ~21, over the gate).
+	commitAs(t, root, "hot.go", branchyN("m", "Hot", 20), "Dev", "dev@example.com")
+	// Commit 2: touch the same file (append a trivial function) WITHOUT changing Hot.
+	commitAs(t, root, "hot.go", branchyN("m", "Hot", 20)+"\nfunc Added() int { return 1 }\n", "Dev", "dev@example.com")
+
+	reg := contentpkg.DefaultRegistry()
+	opts := search.Options{Root: root, Workers: 1}
+
+	// Default mode: Hot is over the ceiling in a changed file → fail.
+	res, err := search.Review(context.Background(), opts, reg, search.ReviewConfig{Base: "HEAD~1"})
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	if res.Verdict != "fail" {
+		t.Fatalf("default mode verdict = %q, want fail (%+v)", res.Verdict, res.Findings)
+	}
+
+	// Baseline mode: Hot is pre-existing and unchanged → suppressed → pass.
+	res, err = search.Review(context.Background(), opts, reg, search.ReviewConfig{Base: "HEAD~1", BaselineOnly: true})
+	if err != nil {
+		t.Fatalf("Review(baseline): %v", err)
+	}
+	if res.Verdict != "pass" {
+		t.Fatalf("baseline mode verdict = %q, want pass (Hot is pre-existing, unchanged); findings: %+v", res.Verdict, res.Findings)
+	}
+
+	// Commit 3: WORSEN Hot (more branches) → baseline mode must flag it.
+	commitAs(t, root, "hot.go", branchyN("m", "Hot", 30), "Dev", "dev@example.com")
+	res, err = search.Review(context.Background(), opts, reg, search.ReviewConfig{Base: "HEAD~1", BaselineOnly: true})
+	if err != nil {
+		t.Fatalf("Review(worsened): %v", err)
+	}
+	if res.Verdict != "fail" {
+		t.Fatalf("baseline mode verdict = %q, want fail (Hot worsened); findings: %+v", res.Verdict, res.Findings)
+	}
+}
+
+// TestReview_BaselineFlagsNewFile: a newly added file with a complex function
+// has no baseline, so baseline mode still flags it.
+func TestReview_BaselineFlagsNewFile(t *testing.T) {
+	root := initRepo(t)
+	commitAs(t, root, "go.mod", "module example.com/m\n\ngo 1.26\n", "Dev", "dev@example.com")
+	commitAs(t, root, "simple.go", "package m\n\nfunc Simple() int { return 1 }\n", "Dev", "dev@example.com")
+	commitAs(t, root, "newhot.go", branchyN("m", "NewHot", 20), "Dev", "dev@example.com")
+
+	res, err := search.Review(context.Background(), search.Options{Root: root, Workers: 1},
+		contentpkg.DefaultRegistry(), search.ReviewConfig{Base: "HEAD~1", BaselineOnly: true})
+	if err != nil {
+		t.Fatalf("Review: %v", err)
+	}
+	if res.Verdict != "fail" {
+		t.Fatalf("verdict = %q, want fail (new file's complex func has no baseline); %+v", res.Verdict, res.Findings)
+	}
+}


### PR DESCRIPTION
Closes #538. Adds a baseline-aware mode to the review gate so a PR that merely *touches* a file with pre-existing complexity isn't blocked on code it didn't change — the file-granular friction hit repeatedly across #534 / #536 / #539 / #540.

## What
`ReviewConfig.BaselineOnly` (CLI `review --baseline`, MCP `review` `baseline:`, Action `baseline:` input). When set, the complexity / cognitive gate only fails on functions whose metric is **new or worsened** versus the base ref:

- The baseline is the same content the diff is taken against — `HEAD` when base is empty, else `merge-base(base, HEAD)`.
- Per changed file, `git show <baseRef>:path` content is run through the **same production extractor** (via a single-file `fs.FS`), so baseline metrics match HEAD's exactly — no parallel metric logic.
- **New files** (absent at baseRef) and **worsened** functions still fail; an unresolvable base ref degrades safely to flagging everything. Dead-code (warn-level) is unaffected.
- Off by default — existing behaviour, output, and tests unchanged.

## Dogfooding (the nice part)
This PR's own changes initially tripped the gate on new complexity I added (`baselineComplexity` cog 26, `Review` worsened to 36/59). So I decomposed:
- `Review` 36/59 → <15 (extracted `baselineSuppressor`, `runDeadCode`, `surfaceCancellation`, `appendComplexity/DeadCodeFindings`)
- CLI `Run` 16/19 → <15 (`renderReview`)
- `baselineComplexity` → `baselineFileComplexity` + `mergeMaxMetric`

The review gate now passes on this PR **in both modes** — file-granular **and** `--baseline`.

## Tests
`TestReview_Baseline` (pre-existing suppressed → pass; worsened → fail) and `TestReview_BaselineFlagsNewFile` (new file → fail). Full suite, vet, `go fix` (idempotent) green.

## Follow-up
Once a release ships with this, the repo's own `review.yml` can set `baseline: true` (it currently can't — `@main` pulls the latest *release* binary, which predates the flag). I'll do that after the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)