### PR TITLE
ci: enable baseline mode on the review gate

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,3 +22,6 @@ jobs:
         uses: ./
         with:
           base: origin/${{ github.base_ref }}
+          # Only fail on complexity new or worsened vs the base — don't block a
+          # PR on pre-existing debt in files it merely touched (#538).
+          baseline: "true"


### PR DESCRIPTION
Now that v0.117.0 ships `--baseline` (#542), flip the self-review gate to `baseline: true` so it only fails on complexity **new or worsened** vs the PR base — resolving the pre-existing-debt friction that made #536/#539/#540/#541's gates red.

This PR only touches review.yml (no source), so its own gate has no changed source files → trivially green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)