### PR TITLE
chore(deps): bump gotreesitter to v0.20.6 (via treesitter-symbols + go-codemetrics)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,13 +20,13 @@ require (
 	github.com/richardwooding/c2pa v0.2.0
 	github.com/richardwooding/fingerprint v0.1.0
 	github.com/richardwooding/gitmeta v0.1.0
-	github.com/richardwooding/go-codemetrics v0.4.0
+	github.com/richardwooding/go-codemetrics v0.4.1
 	github.com/richardwooding/go-coupling v0.1.0
 	github.com/richardwooding/go-hashset v0.1.0
 	github.com/richardwooding/go-sarif v0.1.0
 	github.com/richardwooding/ollamaembed v0.1.0
 	github.com/richardwooding/projectdetect v0.4.0
-	github.com/richardwooding/treesitter-symbols v0.3.0
+	github.com/richardwooding/treesitter-symbols v0.3.1
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	go.etcd.io/bbolt v1.5.0
 	golang.org/x/image v0.43.0
@@ -64,7 +64,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/odvcencio/gotreesitter v0.20.5 // indirect
+	github.com/odvcencio/gotreesitter v0.20.6 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/odvcencio/gotreesitter v0.20.5 h1:V/F/Xv3fld61IVLnlRAgdZXrwuPQba6VPDWyXTOfooc=
-github.com/odvcencio/gotreesitter v0.20.5/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=
+github.com/odvcencio/gotreesitter v0.20.6 h1:tGq0vJwlpprxf5/2cfSVSo58dtvAj6/3Y39CjXtohbY=
+github.com/odvcencio/gotreesitter v0.20.6/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=
 github.com/pelletier/go-toml/v2 v2.4.2 h1:M2fKKbmyvI+hGId/D0W64qDBMVhJnNR10O5gIbMc//Q=
 github.com/pelletier/go-toml/v2 v2.4.2/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/philhofer/fwd v1.2.0 h1:e6DnBTl7vGY+Gz322/ASL4Gyp1FspeMvx1RNDoToZuM=
@@ -113,8 +113,8 @@ github.com/richardwooding/fingerprint v0.1.0 h1:Dch6OdHUboH4PKOaMiwe4Xqbfk/rxQfd
 github.com/richardwooding/fingerprint v0.1.0/go.mod h1:VYCbaXMrpgHewwYnv8GfQoEEcnQwsKFtDlH5bTI00w0=
 github.com/richardwooding/gitmeta v0.1.0 h1:TOf6P+dzcFh5fFbDwJrJFVUGPzbwqyg76wRosuYrlBA=
 github.com/richardwooding/gitmeta v0.1.0/go.mod h1:arft+ynVGxEeeRnQMnosIvlfsaxEAaHoBYh1U7Nq1n0=
-github.com/richardwooding/go-codemetrics v0.4.0 h1:8bICtkXW9Q5v3V+awehWVIYGeSJbqX/td6iMQIOHX4w=
-github.com/richardwooding/go-codemetrics v0.4.0/go.mod h1:KZdI1YYNUKqdVr0kmiEmY5nHiFBu+r6h4rIxbNY9p8o=
+github.com/richardwooding/go-codemetrics v0.4.1 h1:2z88lFNvxVizGfk63Lh+xZDBPdSuaSn0HYEDomfZ0Wc=
+github.com/richardwooding/go-codemetrics v0.4.1/go.mod h1:1DOnaQkAKjuHI1fZulOpZbPDXHb6W0tEX6L/8U8X3ZY=
 github.com/richardwooding/go-coupling v0.1.0 h1:lW5gI3C0xyR9d83wpvjlr7YvK4X+KiTWsMWVwYqxEYA=
 github.com/richardwooding/go-coupling v0.1.0/go.mod h1:Ygz2/NnbEEFLe50QPpe8TsmNQy7Az+FwzyMi8sOwzPo=
 github.com/richardwooding/go-hashset v0.1.0 h1:K0lWQ4Vh8xM9Y5bnTC/fXK3TU6KLeZMB923daCZC9dw=
@@ -125,8 +125,8 @@ github.com/richardwooding/ollamaembed v0.1.0 h1:N5bx4v7IxnOa+Rw4/ROlkQS2LjQCPnAi
 github.com/richardwooding/ollamaembed v0.1.0/go.mod h1:rj/euwbkM8dcad6EMzp5bshVy+GVdu5JEojbFTFNQhY=
 github.com/richardwooding/projectdetect v0.4.0 h1:v6ZTF/r0BD/s7Cw2WW+B6zVhM4YGLiBl1l5lbTdLtrE=
 github.com/richardwooding/projectdetect v0.4.0/go.mod h1:+49ozT8n9+Hsu93/nb7wKclou9qLpEtqLeqefrR4bEg=
-github.com/richardwooding/treesitter-symbols v0.3.0 h1:T12RMoI6figMqG3P9szAxd5L59yjXLCNlQkUo0pPpDI=
-github.com/richardwooding/treesitter-symbols v0.3.0/go.mod h1:BeYtMsw4Q6/1/8qxFlhuydtaoUbEpjgOMl5T3o/rcac=
+github.com/richardwooding/treesitter-symbols v0.3.1 h1:yazWZMPMVlUVUTa4p+KXykL7Z/AQlMZOlBXj1oIZZhU=
+github.com/richardwooding/treesitter-symbols v0.3.1/go.mod h1:xEpXx5CGg2dJhY1hEQ4rlHugczdAhiYMo2lB/+RPsBo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=


### PR DESCRIPTION
Updates the tree-sitter stack to **gotreesitter v0.20.6** by bumping the two extracted libraries that carry it:
- `treesitter-symbols` v0.3.0 → **v0.3.1**
- `go-codemetrics` v0.4.0 → **v0.4.1**

…which pulls `gotreesitter` v0.20.5 → **v0.20.6** (indirect). v0.20.6 is a patch release: parser-recovery correctness (recovered trees keep the grammar root / strip cyclic back-edges) + forest-parsing performance work.

## Swift note (the motivation)
v0.20.6 has **no Swift-specific fix** — it mentions Swift only as prior art for the root-shape recovery now extended to Go. Spot-checked: Swift cyclomatic still computes correctly, and Swift **cognitive remains `nil`** — but that's because the analyzer has no cognitive *spec* for Swift (a code gap, tracked by #522), **not** a grammar bug, so the gotreesitter bump can't change it. Worth doing for the parser-recovery/perf gains and to stay current; the Swift cognitive gap needs a separate spec addition.

## Verification
`go build`, `go test ./...`, `go vet`, `go fix` (idempotent) all green. The content extraction baselines (all 16 tree-sitter languages) and the search suites (coupling / complexity / dead-code / …) pass unchanged — the bump is behaviour-preserving. Review gate green (baseline mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)