### PR TITLE
chore(dependabot): group minor and patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,8 @@ updates:
       - dependencies
       - github-actions
     open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Group minor and patch dependency updates into a single PR per ecosystem to cut Dependabot noise; major versions stay as individual PRs for review.

Applies the technique from the SPAN Chronicle article "Taming Dependabot Fatigue: Group Your Minor and Patch Updates".

🤖 Generated with [Claude Code](https://claude.com/claude-code)