### PR TITLE
docs: add the anatomy page — one tool, eleven libraries

### DIFF
--- a/docs/anatomy/index.html
+++ b/docs/anatomy/index.html
@@ -1,0 +1,280 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The anatomy of file-search-on — one tool, eleven libraries</title>
+<meta name="description" content="A case study in composition: how eleven small, dependency-light Go libraries — most of them extracted from this very codebase — assemble into file-search-on's walk → extract → index → analyse pipeline.">
+<link rel="canonical" href="https://richardwooding.github.io/file-search-on/anatomy/">
+<meta name="theme-color" content="#0d1117">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Crect width='24' height='24' rx='5' fill='%230d1117'/%3E%3Crect x='5' y='12' width='3.5' height='7' rx='1' fill='%23a371f7'/%3E%3Crect x='10.25' y='8' width='3.5' height='11' rx='1' fill='%23bd93ff'/%3E%3Crect x='15.5' y='4' width='3.5' height='15' rx='1' fill='%23d2b3ff'/%3E%3C/svg%3E">
+<meta property="og:type" content="article">
+<meta property="og:title" content="The anatomy of file-search-on">
+<meta property="og:description" content="How eleven small Go libraries — most extracted from this codebase — compose into one file-search tool.">
+<meta property="og:url" content="https://richardwooding.github.io/file-search-on/anatomy/">
+<script>try{var t=localStorage.getItem("gl-theme");if(t)document.documentElement.setAttribute("data-theme",t)}catch(e){}</script>
+<link rel="stylesheet" href="../gloam.css">
+<style>
+  .ana-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+    gap: 20px; margin-top: 26px; align-items: start; }
+  @media (max-width: 920px) { .ana-grid { grid-template-columns: 1fr; } }
+
+  .layer { border: 1px solid var(--gl-border); border-radius: var(--gl-radius);
+    background: var(--gl-panel); padding: 14px 16px; position: relative; }
+  .layer + .layer { margin-top: 26px; }
+  .layer + .layer::before { content: ""; position: absolute; left: 50%; top: -27px;
+    width: 2px; height: 26px; background: var(--gl-border); }
+  .layer .lname { font-family: var(--gl-mono); font-size: .72rem; text-transform: uppercase;
+    letter-spacing: .08em; color: var(--gl-muted); margin: 0 0 10px; }
+  .layer .lname .n { color: var(--gl-accent-2); }
+  .chips { display: flex; flex-wrap: wrap; gap: 8px; }
+  .lib { font-family: var(--gl-mono); font-size: .84rem; border: 1px solid var(--gl-border);
+    border-radius: 999px; background: var(--gl-panel-2); color: var(--gl-fg);
+    padding: 6px 14px; cursor: pointer; transition: border-color .12s ease, background .12s ease; }
+  .lib:hover { border-color: var(--gl-accent); }
+  .lib[aria-pressed="true"] { background: color-mix(in srgb, var(--gl-accent) 22%, transparent);
+    border-color: var(--gl-accent); color: var(--gl-accent-2); }
+  .lib:focus-visible { outline: 2px solid var(--gl-accent); outline-offset: 2px; }
+  .layer .internal { font-family: var(--gl-mono); font-size: .78rem; color: var(--gl-faint);
+    border: 1px dashed var(--gl-border); border-radius: 999px; padding: 6px 12px; }
+
+  .detail { position: sticky; top: 76px; }
+  .detail h3 { margin-top: 0; font-family: var(--gl-mono); }
+  .detail .tagline { color: var(--gl-muted); margin: 6px 0 14px; }
+  .detail .role { margin: 0 0 14px; }
+  .detail dl { display: grid; grid-template-columns: max-content 1fr; gap: 6px 14px; margin: 0 0 16px; }
+  .detail dt { font-family: var(--gl-mono); font-size: .78rem; color: var(--gl-muted); padding-top: 2px; }
+  .detail dd { margin: 0; font-size: .92rem; overflow-wrap: anywhere; }
+  .detail code { font-size: .84rem; }
+  .badge-x { display: inline-block; font-family: var(--gl-mono); font-size: .72rem;
+    color: var(--gl-green); background: color-mix(in srgb, var(--gl-green) 13%, transparent);
+    border-radius: 6px; padding: 2px 8px; margin-bottom: 12px; }
+</style>
+</head>
+<body class="gl">
+<a class="gl-skip" href="#main">Skip to content</a>
+
+<header class="gl-nav">
+  <div class="gl-wrap">
+    <span class="gl-brand">
+      <svg width="26" height="26" viewBox="0 0 24 24" aria-hidden="true">
+        <rect width="24" height="24" rx="6" fill="var(--gl-panel-2)"/>
+        <rect x="5" y="12" width="3.5" height="7" rx="1" fill="var(--gl-accent)"/>
+        <rect x="10.25" y="8" width="3.5" height="11" rx="1" fill="var(--gl-accent-2)"/>
+        <rect x="15.5" y="4" width="3.5" height="15" rx="1" fill="#d2b3ff"/>
+      </svg>
+      file-search-on <span style="color:var(--gl-muted)">/ anatomy</span>
+    </span>
+    <button class="gl-nav-toggle" aria-label="Toggle navigation" data-gl-nav-toggle="nav" aria-expanded="false">☰</button>
+    <nav id="nav">
+      <a href="../">file-search-on</a>
+      <button class="gl-theme-toggle" data-gl-theme-toggle aria-label="Toggle color theme" aria-pressed="true">
+        <svg class="gl-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+        <svg class="gl-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/></svg>
+      </button>
+      <a class="gl-btn ghost" href="https://github.com/richardwooding/file-search-on">GitHub ★</a>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+  <section class="gl-section">
+    <div class="gl-wrap">
+      <p class="gl-eyebrow">case study · how it's built</p>
+      <h1>One tool. <span class="gl-grad">Eleven libraries.</span></h1>
+      <p class="gl-lede" style="margin-top:14px">file-search-on is deliberately not a monolith.
+        When a capability grows a clean seam — git metadata, BM25 ranking, C2PA validation — it gets
+        extracted into a small, dependency-light library with its own tests, docs, and releases, then
+        consumed back like any third-party module. Seven of the eleven libraries below were born in
+        this codebase. Click any of them to see exactly what it powers.</p>
+
+      <div class="ana-grid">
+        <div id="layers">
+          <div class="layer">
+            <p class="lname"><span class="n">1</span> · walk &amp; identify</p>
+            <div class="chips">
+              <button class="lib" data-lib="projectdetect">projectdetect</button>
+              <button class="lib" data-lib="gitmeta">gitmeta</button>
+              <span class="internal">+ internal walker</span>
+            </div>
+          </div>
+          <div class="layer">
+            <p class="lname"><span class="n">2</span> · extract, format by format</p>
+            <div class="chips">
+              <button class="lib" data-lib="treesitter-symbols">treesitter-symbols</button>
+              <button class="lib" data-lib="codemetrics">codemetrics</button>
+              <button class="lib" data-lib="c2pa">c2pa</button>
+              <span class="internal">+ EXIF · audio · video · archives · email · binaries</span>
+            </div>
+          </div>
+          <div class="layer">
+            <p class="lname"><span class="n">3</span> · index, rank &amp; match</p>
+            <div class="chips">
+              <button class="lib" data-lib="bm25">bm25</button>
+              <button class="lib" data-lib="ollamaembed">ollamaembed</button>
+              <button class="lib" data-lib="fingerprint">fingerprint</button>
+              <button class="lib" data-lib="go-hashset">go-hashset</button>
+            </div>
+          </div>
+          <div class="layer">
+            <p class="lname"><span class="n">4</span> · analyse &amp; report</p>
+            <div class="chips">
+              <button class="lib" data-lib="go-coupling">go-coupling</button>
+              <button class="lib" data-lib="go-sarif">go-sarif</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="gl-card detail" id="detail" aria-live="polite">
+          <h3 id="d-name"></h3>
+          <span class="badge-x" id="d-extracted" hidden>extracted from this codebase</span>
+          <p class="tagline" id="d-tagline"></p>
+          <p class="role" id="d-role"></p>
+          <dl>
+            <dt>powers</dt><dd id="d-powers"></dd>
+            <dt>links</dt><dd id="d-links"></dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="gl-section">
+    <div class="gl-wrap">
+      <p class="gl-eyebrow">the pattern</p>
+      <h2>Extract, harden, consume back.</h2>
+      <p class="gl-lede" style="margin-top:14px">The payoff compounds. Each extraction gets a sharper
+        API and its own fuzzing and CI; file-search-on's surface shrinks; and the pieces start
+        living second lives — <a href="https://github.com/richardwooding/gitmeta">gitmeta</a> now has
+        Rust, Zig, and C# ports, <a href="https://github.com/richardwooding/projectdetect">projectdetect</a>
+        has Rust and Zig ports, and three of the libraries run as live in-browser WASM demos:
+        the <a href="https://richardwooding.github.io/c2pa-inspector/">C2PA inspector</a>,
+        the <a href="https://richardwooding.github.io/codemetrics/playground/">codemetrics playground</a>,
+        and <a href="https://richardwooding.github.io/textlab/">textlab</a>.</p>
+    </div>
+  </section>
+</main>
+
+<footer class="gl-footer">
+  <div class="gl-wrap">
+    <span class="gl-brand" style="font-size:.98rem">file-search-on · MIT · <span data-gl-year></span></span>
+    <nav class="gl-fnav">
+      <a href="../">file-search-on</a>
+      <a href="https://github.com/richardwooding/file-search-on">GitHub</a>
+      <a href="https://richardwooding.github.io/">richardwooding.github.io</a>
+    </nav>
+  </div>
+</footer>
+
+<script>
+(function () {
+  "use strict";
+  var LIBS = {
+    "projectdetect": {
+      tagline: "Detects what kind of project a directory is — 18+ ecosystems, YAML/CEL-extensible, pure Go.",
+      role: "Runs during the walk so every file knows which project (and ecosystem) it belongs to.",
+      powers: "the detect_project, find_projects, and resolve_project_for_path tools",
+      extracted: true,
+      links: [["Code", "https://github.com/richardwooding/projectdetect"], ["Site", "https://richardwooding.github.io/projectdetect/"], ["Rust port", "https://github.com/richardwooding/projectdetect-rs"], ["Zig port", "https://github.com/richardwooding/projectdetect-zig"]]
+    },
+    "gitmeta": {
+      tagline: "Per-file git metadata from one batch scan — constant-time lookups afterwards.",
+      role: "One git scan per repo enriches every file with last-commit time, author, subject, churn, and tracked/ignored state.",
+      powers: "the git-aware attributes and the churn_owners tool",
+      extracted: true,
+      links: [["Code", "https://github.com/richardwooding/gitmeta"], ["Site", "https://richardwooding.github.io/gitmeta/"], ["Rust port", "https://github.com/richardwooding/gitmeta-rs"], ["Zig port", "https://github.com/richardwooding/gitmeta-zig"], ["C# port", "https://github.com/richardwooding/gitmeta-csharp"]]
+    },
+    "treesitter-symbols": {
+      tagline: "Cross-language symbol extraction — definitions, imports, references, call edges — for 17 languages.",
+      role: "Parses source files once and hands file-search-on its symbol tables and call graph.",
+      powers: "source attributes (functions, imports) and the code-graph tools: find_definition, references, who_calls, calls, call_path, code_graph",
+      extracted: false,
+      links: [["Code", "https://github.com/richardwooding/treesitter-symbols"], ["Site", "https://richardwooding.github.io/treesitter-symbols/"]]
+    },
+    "codemetrics": {
+      tagline: "Per-function cyclomatic + cognitive complexity for 17 languages, stdlib-only core.",
+      role: "Scores every function during source extraction so complexity is just another queryable attribute.",
+      powers: "the complexity tool and per-function metrics",
+      extracted: false,
+      links: [["Code", "https://github.com/richardwooding/codemetrics"], ["Site", "https://richardwooding.github.io/codemetrics/"], ["Live playground", "https://richardwooding.github.io/codemetrics/playground/"]]
+    },
+    "c2pa": {
+      tagline: "Pure-Go C2PA / Content Credentials: fast unverified reader + full cryptographic validator. No cgo.",
+      role: "Reads provenance claims from JPEG/PNG at index time; full validation on demand.",
+      powers: "the is_c2pa / c2pa_* attributes",
+      extracted: true,
+      links: [["Code", "https://github.com/richardwooding/c2pa"], ["Site", "https://richardwooding.github.io/c2pa/"], ["Live inspector", "https://richardwooding.github.io/c2pa-inspector/"]]
+    },
+    "bm25": {
+      tagline: "Okapi BM25 keyword ranking + reciprocal-rank fusion. Zero dependencies.",
+      role: "The keyword half of hybrid search; RRF fuses its ranking with the embedding side.",
+      powers: "keyword ranking inside search_semantic's hybrid mode",
+      extracted: true,
+      links: [["Code", "https://github.com/richardwooding/bm25"], ["Site", "https://richardwooding.github.io/bm25/"], ["Live demo (textlab)", "https://richardwooding.github.io/textlab/"]]
+    },
+    "ollamaembed": {
+      tagline: "Zero-dependency Ollama embeddings client, vector math, and a curated model catalog.",
+      role: "The semantic half of hybrid search — turns file content into vectors via a local Ollama.",
+      powers: "search_semantic, list_embedding_models, pull_embedding_model",
+      extracted: true,
+      links: [["Code", "https://github.com/richardwooding/ollamaembed"], ["Site", "https://richardwooding.github.io/ollamaembed/"]]
+    },
+    "fingerprint": {
+      tagline: "SimHash text near-duplicates + perceptual image hashing, in one small package.",
+      role: "Fingerprints text and images at index time so similarity queries are hash comparisons, not re-reads.",
+      powers: "find_near_duplicates, find_duplicate_functions, and image-similarity search",
+      extracted: true,
+      links: [["Code", "https://github.com/richardwooding/fingerprint"], ["Site", "https://richardwooding.github.io/fingerprint/"], ["Live demo (textlab)", "https://richardwooding.github.io/textlab/"]]
+    },
+    "go-hashset": {
+      tagline: "MD5/SHA-1/SHA-256 allow/deny sets — in-memory, or bbolt-backed at NSRL scale.",
+      role: "Loads known-good / known-bad hash lists once; membership checks are then constant-time.",
+      powers: "known-file lookups in CEL (IsKnownGood) and sha256 dedup",
+      extracted: false,
+      links: [["Code", "https://github.com/richardwooding/go-hashset"], ["Site", "https://richardwooding.github.io/go-hashset/"]]
+    },
+    "go-coupling": {
+      tagline: "Package coupling (Ca/Ce/instability) and circular-dependency detection across 9 ecosystems.",
+      role: "Consumes the imports already extracted per file — no second parse — and computes the coupling graph.",
+      powers: "the coupling and circular tools",
+      extracted: false,
+      links: [["Code", "https://github.com/richardwooding/go-coupling"], ["Site", "https://richardwooding.github.io/go-coupling/"]]
+    },
+    "go-sarif": {
+      tagline: "Minimal, zero-dependency SARIF 2.1.0 emitter for Go static-analysis tools.",
+      role: "Turns findings into the document GitHub Code Scanning ingests.",
+      powers: "SARIF output for find_matches and unused_exports",
+      extracted: true,
+      links: [["Code", "https://github.com/richardwooding/go-sarif"], ["Site", "https://richardwooding.github.io/go-sarif/"]]
+    }
+  };
+
+  var buttons = document.querySelectorAll(".lib");
+  function show(id) {
+    var lib = LIBS[id];
+    if (!lib) return;
+    buttons.forEach(function (b) { b.setAttribute("aria-pressed", String(b.getAttribute("data-lib") === id)); });
+    document.getElementById("d-name").textContent = id;
+    document.getElementById("d-extracted").hidden = !lib.extracted;
+    document.getElementById("d-tagline").textContent = lib.tagline;
+    document.getElementById("d-role").textContent = lib.role;
+    document.getElementById("d-powers").textContent = lib.powers;
+    var links = document.getElementById("d-links");
+    links.textContent = "";
+    lib.links.forEach(function (l, i) {
+      if (i) links.appendChild(document.createTextNode(" · "));
+      var a = document.createElement("a");
+      a.href = l[1];
+      a.textContent = l[0] + " ↗";
+      links.appendChild(a);
+    });
+  }
+  buttons.forEach(function (b) {
+    b.addEventListener("click", function () { show(b.getAttribute("data-lib")); });
+  });
+  show("gitmeta");
+})();
+</script>
+<script src="../gloam.js" defer></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,6 +55,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <a href="#cel">CEL</a>
       <a href="#mcp">MCP</a>
       <a href="#install">Install</a>
+      <a href="anatomy/">Anatomy</a>
       <button class="gl-theme-toggle" data-gl-theme-toggle aria-label="Toggle color theme" aria-pressed="true">
         <svg class="gl-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
         <svg class="gl-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/></svg>


### PR DESCRIPTION
## What

A case-study page at [`/anatomy/`](https://richardwooding.github.io/file-search-on/anatomy/): the walk → extract → index → analyse pipeline rendered as four clickable layers, one chip per `richardwooding/*` dependency. Selecting a library shows its tagline, its role in the pipeline, exactly what it powers (real attribute/tool names — `churn_owners`, `search_semantic`, `find_near_duplicates`, `coupling`, …), an "extracted from this codebase" badge where the library's README documents that origin (7 of the 11), and links to code, site, ports, and the live WASM demos (c2pa-inspector, codemetrics playground, textlab).

Also adds an "Anatomy" link to the main page nav. Static HTML + a small inline script, gloam-styled, dark/light aware; no new build steps — `pages.yml` already deploys `docs/**`.

## Accuracy notes

- The 11 libraries are exactly the `richardwooding/*` entries in `go.mod`; each "powers" line was checked against the import sites (`internal/search`, `internal/content`, `internal/celexpr`, `cmd`).
- Extraction badges only where the library's own README states it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)